### PR TITLE
feat: print kafka instances to table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,15 @@ require (
 	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 // indirect
 	github.com/c9s/gomon v1.3.0 // indirect
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.5.1
+	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/landoop/tableprinter v0.0.0-20200805134727-ea32388e35c1
 	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/deckarep/gosx-notifier v0.0.0-20180201035817-e127226297fb/go.mod h1:w
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -188,6 +190,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 h1:M8exrBzuhWcU6aoHJlHWPe4qFjVKzkMGRal78f5jRRU=
+github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23/go.mod h1:kBSna6b0/RzsOcOZf515vAXwSsXYusl2U7SA0XP09yI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -198,6 +202,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/landoop/tableprinter v0.0.0-20200805134727-ea32388e35c1 h1:xUwSaTDYl+Ib5OoFxWJnqYFG9N31++qfeNXzTZ1cc8o=
+github.com/landoop/tableprinter v0.0.0-20200805134727-ea32388e35c1/go.mod h1:f0X1c0za3TbET/rl5ThtCSel0+G3/yZ8iuU9BxnyVK0=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -214,6 +220,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=

--- a/pkg/kafka/structs.go
+++ b/pkg/kafka/structs.go
@@ -1,0 +1,25 @@
+package kafka
+
+// Instance of a Kafka cluster
+type Instance struct {
+	ID                  string `json:"id" header:"ID"`
+	Name                string `json:"name" header:"Name"`
+	Owner               string `json:"owner" header:"Owner"`
+	Kind                string `json:"kind"`
+	Href                string `json:"href"`
+	Status              string `json:"status" header:"Status"`
+	CloudProvider       string `json:"cloud_provider" header:"Cloud Provider"`
+	Region              string `json:"region" header:"Region"`
+	BootstrapServerHost string `json:"bootstrapServerHost"`
+	CreatedAt           string `json:"created_at"`
+	UpdatedAt           string `json:"updated_at"`
+}
+
+// List of Kafka instances
+type List struct {
+	Kind  string     `json:"kind"`
+	Page  int        `json:"page"`
+	Size  int        `size:"size"`
+	Total int        `total:"total"`
+	Items []Instance `items:"items"`
+}

--- a/pkg/kafka/util.go
+++ b/pkg/kafka/util.go
@@ -1,0 +1,12 @@
+package kafka
+
+import (
+	"os"
+	"github.com/landoop/tableprinter"
+)
+
+// PrintInstances prints the instances in a formatted table
+func PrintInstances(kafkaInstances []Instance) {
+	printer := tableprinter.New(os.Stdout)
+	printer.Print(kafkaInstances)
+}

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -77,31 +77,18 @@ rhmas streams create --name=test --multi-az="true" --provider=aws --region=eu-we
 Get details 
 
 ```
-rhmas streams get kafka-id --format=json
+rhmas streams get kafka-id
 ```
 
 **Arguments**:
--f --format: format of the data (json/yaml/table)
+--format: Format to display the Kafka instances. Choose from "json" or "table" (default "table")
 
 **Returns:**
 
-```json
-{
-  "value": {
-    "id": "1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
-    "kind": "kafka",
-    "href": "/api/managed-services-api/v1/kafkas/1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
-    "status": "complete",
-    "cloud_provider": "aws",
-    "multi_az": "false",
-    "region": "eu-west-1",
-    "owner": "api_kafka_service",
-    "name": "serviceapi",
-    "bootstrapServerHost": "serviceapi-1isy6rq3jki8q0otmjqfd3ocfrg.apps.ms-bttg0jn170hp.x5u8.s1.devshift.org",
-    "created_at": "2020-10-05T12:51:24.053142Z",
-    "updated_at": "2020-10-05T12:56:36.362208Z"
-  }
-}
+```shell
+  ID                            NAME         OWNER               STATUS     CLOUD PROVIDER   REGION     
+ ----------------------------- ------------ ------------------- ---------- ---------------- ----------- 
+  1iSY6RQ3JKI8Q0OTmjQFd3ocFRg   serviceapi   api_kafka_service   complete   aws              eu-west-1
 ```
 
 #### List Streams instances 
@@ -114,7 +101,17 @@ rhmas streams list
 
 **Arguments**:
   page: index (default "1")
+  format: Format to display the Kafka instances. Choose from "json" or "table" (default "table")
   size: Number of kafka requests per page (default "100")
+
+**Returns:**
+
+```shell
+  ID                            NAME          OWNER               STATUS     CLOUD PROVIDER   REGION     
+ ----------------------------- ------------- ------------------- ---------- ---------------- ----------- 
+  1iSY6RQ3JKI8Q0OTmjQFd3ocFRg   serviceapi    api_kafka_service   complete   aws              eu-west-1  
+  v5Sg6faQ3JKGas4hFd3og45fd31   serviceapi2   api_kafka_service   complete   aws              eu-west-1
+```
 
 #### Switch to use managed kafka
 


### PR DESCRIPTION
## Description

This PR prints Kafka instances to a table format by default. A `format` flag is available to switch formatting (the only option available is `json`).

This new feature is available to the `rhmas kafka {get,list}` commands.

## Usage

Print to table:

```shell
$ rhmas kafka list
  ID                            NAME          OWNER               STATUS     CLOUD PROVIDER   REGION     
 ----------------------------- ------------- ------------------- ---------- ---------------- ----------- 
  1iSY6RQ3JKI8Q0OTmjQFd3ocFRg   serviceapi    api_kafka_service   complete   aws              eu-west-1  
  v5Sg6faQ3JKGas4hFd3og45fd31   serviceapi2   api_kafka_service   complete   aws              eu-west-1
```

Print as JSON:

```shell
$ rhmas kafka list --format json
[
  {
    "id": "1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
    "name": "serviceapi",
    "owner": "api_kafka_service",
    "kind": "kafka",
    "href": "/api/managed-services-api/v1/kafkas/1iSY6RQ3JKI8Q0OTmjQFd3ocFRg",
    "status": "complete",
    "cloud_provider": "aws",
    "region": "eu-west-1",
    "bootstrapServerHost": "serviceapi-1isy6rq3jki8q0otmjqfd3ocfrg.apps.ms-bttg0jn170hp.x5u8.s1.devshift.org",
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z"
  },
  {
    "id": "v5Sg6faQ3JKGas4hFd3og45fd31",
    "name": "serviceapi2",
    "owner": "api_kafka_service",
    "kind": "kafka",
    "href": "/api/managed-services-api/v1/kafkas/v5Sg6faQ3JKGas4hFd3og45fd31",
    "status": "complete",
    "cloud_provider": "aws",
    "region": "eu-west-1",
    "bootstrapServerHost": "serviceapi-v5Sg6faQ3JKGas4hFd3og45fd31.apps.ms-dfasf3gsds.23ds.s1.devshift.org",
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z"
  }
]
```

## Notes

No decision has been made yet on how to format the table for the `rhmas get {id}` command. I have added the same for both here for now.