### PR TITLE
fix(cmd): typo in command name

### DIFF
--- a/cmd/auth/authorization.go
+++ b/cmd/auth/authorization.go
@@ -8,9 +8,9 @@ import (
 
 func NewAuthorizationCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "autorization",
-		Short: "Manage autorization rules",
-		Long:  "Manage autorization rules",
+		Use:   "authorization",
+		Short: "Manage authorization rules",
+		Long:  "Manage authorization rules",
 		Run:   runAuthz,
 	}
 


### PR DESCRIPTION
Title speaks for itself - there is a spelling mistake in one of the commands: `autorization`