### PR TITLE
refactor: use stderr for error logs

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -2,9 +2,9 @@
 package flags
 
 import (
+	"os"
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 )
 
@@ -12,7 +12,8 @@ import (
 func MustGetDefinedString(flagName string, flags *pflag.FlagSet) string {
 	flagVal := MustGetString(flagName, flags)
 	if flagVal == "" {
-		glog.Fatal(undefinedValueMessage(flagName))
+		fmt.Fprintln(os.Stderr, undefinedValueMessage(flagName))
+		os.Exit(1)
 	}
 	return flagVal
 }
@@ -21,7 +22,8 @@ func MustGetDefinedString(flagName string, flags *pflag.FlagSet) string {
 func MustGetString(flagName string, flags *pflag.FlagSet) string {
 	flagVal, err := flags.GetString(flagName)
 	if err != nil {
-		glog.Fatalf(notFoundMessage(flagName, err))
+		fmt.Fprintln(os.Stderr, notFoundMessage(flagName, err))
+		os.Exit(1)
 	}
 	return flagVal
 }
@@ -38,7 +40,8 @@ func GetString(flagName string, flags *pflag.FlagSet) string {
 func MustGetBool(flagName string, flags *pflag.FlagSet) bool {
 	flagVal, err := flags.GetBool(flagName)
 	if err != nil {
-		glog.Fatalf(notFoundMessage(flagName, err))
+		fmt.Fprintln(os.Stderr, notFoundMessage(flagName, err))
+		os.Exit(1)
 	}
 	return flagVal
 }

--- a/cmd/kafka/create.go
+++ b/cmd/kafka/create.go
@@ -1,13 +1,13 @@
 package kafka
 
 import (
+	"os"
 	"context"
 	"encoding/json"
 	"fmt"
 
 	mas "github.com/bf2fc6cc711aee1a0c2a/cli/client/mas"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/cmd/flags"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -40,12 +40,14 @@ func runCreate(cmd *cobra.Command, _ []string) {
 	response, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasPost(context.Background(), true, kafkaRequest)
 
 	if err != nil {
-		glog.Fatalf("Error while requesting new Kafka cluster: %v", err)
+		fmt.Fprintf(os.Stderr, "Error while requesting new Kafka cluster: %v", err)
+		return
 	}
 	if status.StatusCode == 202 {
 		jsonResponse, _ := json.MarshalIndent(response, "", "  ")
-		fmt.Print("Created Cluster \n ", string(jsonResponse))
+		fmt.Fprintf(os.Stderr, "Created new Kakfa cluster \"%v\"\n", response.Name)
+		fmt.Print(string(jsonResponse))
 	} else {
-		fmt.Print("Creation failed", response, status)
+		fmt.Fprintf(os.Stderr, "Failed to create Kafka cluster \"%v\"", name)
 	}
 }

--- a/cmd/kafka/credentials.go
+++ b/cmd/kafka/credentials.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"os"
 	"fmt"
 	"io/ioutil"
 
@@ -66,8 +67,8 @@ func runCredentials(cmd *cobra.Command, _ []string) {
 	dataToWrite := []byte(propertyFormat)
 	err := ioutil.WriteFile(fileName, dataToWrite, 0644)
 	if err != nil {
-		fmt.Println("Error when saving file:", err)
+		fmt.Fprintln(os.Stderr, "Error when saving file:", err)
 	} else {
-		fmt.Println("Successfully saved credentials to", fileName)
+		fmt.Fprintln(os.Stderr, "Successfully saved credentials to", fileName)
 	}
 }

--- a/cmd/kafka/delete.go
+++ b/cmd/kafka/delete.go
@@ -1,10 +1,10 @@
 package kafka
 
 import (
+	"os"
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +28,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		id = args[0]
 	} else {
 		// TODO: Get ID of current cluster
-		glog.Fatalf("No Kafka cluster selected")
+		fmt.Fprintln(os.Stderr, "No Kafka cluster selected")
 	}
 
 	client := BuildMasClient()
@@ -36,11 +36,11 @@ func runDelete(cmd *cobra.Command, args []string) {
 	response, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasIdDelete(context.Background(), id)
 
 	if err != nil {
-		glog.Fatalf("Error while deleting Kafka cluster: %v", err)
+		fmt.Fprintf(os.Stderr, "Error while deleting Kafka cluster: %v", err)
 	}
 	if status.StatusCode == 204 {
-		fmt.Print("Deleted Kafka cluster with ID ", id)
+		fmt.Fprint(os.Stderr, "Deleted Kafka cluster with ID ", id)
 	} else {
-		fmt.Print("Deletion failed", response, status)
+		fmt.Fprintln(os.Stderr, "Deletion failed", response, status)
 	}
 }

--- a/cmd/kafka/get.go
+++ b/cmd/kafka/get.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"os"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,7 +30,7 @@ func runGet(cmd *cobra.Command, args []string) {
 		id = args[0]
 	} else {
 		// TODO: Get ID of current cluster
-		fmt.Println("No Kafka cluster selected")
+		fmt.Fprintln(os.Stderr, "No Kafka cluster selected")
 		return
 	}
 
@@ -38,7 +39,7 @@ func runGet(cmd *cobra.Command, args []string) {
 	response, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasIdGet(context.Background(), id)
 
 	if err != nil {
-		fmt.Printf("Error retrieving Kafka clusters: %v", err)
+		fmt.Fprintf(os.Stderr, "Error retrieving Kafka clusters: %v", err)
 		return
 	}
 
@@ -48,6 +49,6 @@ func runGet(cmd *cobra.Command, args []string) {
 		json.Unmarshal(jsonResponse, &kafkaCluster)
 		fmt.Print(string(jsonResponse))
 	} else {
-		fmt.Print("Get failed", response, status)
+		fmt.Fprintln(os.Stderr, "Get failed", response, status)
 	}
 }

--- a/cmd/kafka/list.go
+++ b/cmd/kafka/list.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"os"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -45,7 +46,7 @@ func runList(cmd *cobra.Command, _ []string) {
 	response, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasGet(context.Background(), &options)
 
 	if err != nil {
-		fmt.Printf("Error retrieving Kafka clusters: %v", err)
+		fmt.Fprintf(os.Stderr, "Error retrieving Kafka clusters: %v", err)
 		return
 	}
 
@@ -54,7 +55,7 @@ func runList(cmd *cobra.Command, _ []string) {
 
 		var kafkaList kafka.ClusterList
 		if err = json.Unmarshal(jsonResponse, &kafkaList); err != nil {
-			fmt.Printf("Could not format Kakfa cluster to table: %v", err)
+			fmt.Fprintf(os.Stderr, "Could not format Kakfa cluster to table: %v", err)
 			outputFormat = "json"
 		}
 

--- a/cmd/kafka/massdk.go
+++ b/cmd/kafka/massdk.go
@@ -17,7 +17,7 @@ func BuildMasClient() *mas.APIClient {
 	cfg, err := config.Load()
 
 	if err != nil {
-		fmt.Println("Error loading configuration")
+		fmt.Fprintln(os.Stderr, "Error loading configuration")
 		os.Exit(1)
 	}
 
@@ -28,14 +28,14 @@ func BuildMasClient() *mas.APIClient {
 	}
 
 	if token == "" {
-		fmt.Println("You must be loggen in. To do so use the `rhmas login` command")
+		fmt.Fprintln(os.Stderr, "You must be logged in. To do so use the `rhmas login` command")
 		os.Exit(1)
 	}
 
 	tokenIsValid, _ := cfg.CheckTokenValidity()
 
 	if !tokenIsValid {
-		fmt.Println("Token has expired. Login again using `rhmas login` command")
+		fmt.Fprintln(os.Stderr, "Token has expired. Login again using `rhmas login` command")
 		os.Exit(1)
 	}
 

--- a/cmd/kafka/status.go
+++ b/cmd/kafka/status.go
@@ -1,13 +1,12 @@
 package kafka
 
 import (
+	"os"
+	"encoding/json"
 	"context"
 	"fmt"
 
-	"encoding/json"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/config"
-	"github.com/golang/glog"
-
 	"github.com/spf13/cobra"
 )
 
@@ -24,13 +23,13 @@ func NewStatusCommand() *cobra.Command {
 func runStatus(cmd *cobra.Command, args []string) {
 	cfg, err := config.Load()
 	if err != nil {
-		glog.Fatal(err)
+		fmt.Fprint(os.Stderr, err)
 	}
 
 	id := cfg.Services.Kafka.ClusterID
 
 	if id == "" {
-		fmt.Println("No Kafka cluster is being used. To use a cluster run `rhmas kafka use {clusterId}`")
+		fmt.Fprint(os.Stderr, "No Kafka cluster is being used. To use a cluster run `rhmas kafka use {clusterId}`")
 		return
 	}
 
@@ -38,17 +37,17 @@ func runStatus(cmd *cobra.Command, args []string) {
 
 	res, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasIdGet(context.Background(), id)
 	if err != nil {
-		fmt.Printf("Error retrieving Kafka cluster \"%v\": %v", id, err)
+		fmt.Fprintf(os.Stderr, "Error retrieving Kafka cluster \"%v\": %v", id, err)
 		return
 	}
 
 	if status.StatusCode != 200 {
-		fmt.Printf("Unable to retrieve selected Kafka cluster \"%v\": %v", id, err)
+		fmt.Fprintf(os.Stderr, "Unable to retrieve selected Kafka cluster \"%v\": %v", id, err)
 		return
 	}
 
 	jsonCluster, _ := json.MarshalIndent(res, "", "  ")
 
-	fmt.Printf("Using Kafka cluster \"%v\":\n", res.Id)
+	fmt.Fprintf(os.Stderr, "Using Kafka cluster \"%v\":\n", res.Id)
 	fmt.Print(string(jsonCluster))
 }

--- a/cmd/kafka/topics/create.go
+++ b/cmd/kafka/topics/create.go
@@ -1,6 +1,7 @@
 package topics
 
 import (
+	"os"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ func NewCreateTopicCommand() *cobra.Command {
 }
 
 func createTopic(cmd *cobra.Command, _ []string) {
-	fmt.Println("Creating topic " + topicName + " ...")
+	fmt.Fprintln(os.Stderr, "Creating topic " + topicName + " ...")
 	doRemoteOperation()
-	fmt.Println("Topic " + topicName + " created")
+	fmt.Fprintln(os.Stderr, "Topic " + topicName + " created")
 }

--- a/cmd/kafka/topics/delete.go
+++ b/cmd/kafka/topics/delete.go
@@ -1,6 +1,7 @@
 package topics
 
 import (
+	"os"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -21,7 +22,7 @@ func NewDeleteTopicCommand() *cobra.Command {
 }
 
 func deleteTopic(cmd *cobra.Command, _ []string) {
-	fmt.Println("Deleting topic " + topicName + " ...")
+	fmt.Fprintln(os.Stderr, "Deleting topic " + topicName + " ...")
 	doRemoteOperation()
-	fmt.Println("Topic " + topicName + " deleted")
+	fmt.Fprintln(os.Stderr, "Topic " + topicName + " deleted")
 }

--- a/cmd/kafka/topics/list.go
+++ b/cmd/kafka/topics/list.go
@@ -1,6 +1,7 @@
 package topics
 
 import (
+	"os"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -24,7 +25,7 @@ func NewListTopicCommand() *cobra.Command {
 }
 
 func listTopic(cmd *cobra.Command, _ []string) {
-	fmt.Println("Listing topics ...")
+	fmt.Fprintln(os.Stderr, "Listing topics ...")
 	doRemoteOperation()
 	fmt.Println(`
 3 topics:

--- a/cmd/kafka/topics/update.go
+++ b/cmd/kafka/topics/update.go
@@ -1,6 +1,7 @@
 package topics
 
 import (
+	"os"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ func NewUpdateTopicCommand() *cobra.Command {
 }
 
 func updateTopic(cmd *cobra.Command, _ []string) {
-	fmt.Println("Updating topic " + topicName + " (" + config + ") ...")
+	fmt.Fprintln(os.Stderr, "Updating topic " + topicName + " (" + config + ") ...")
 	doRemoteOperation()
-	fmt.Println("Topic " + topicName + " updated")
+	fmt.Fprintln(os.Stderr, "Topic " + topicName + " updated")
 }

--- a/cmd/tools/documentation.go
+++ b/cmd/tools/documentation.go
@@ -1,12 +1,12 @@
 package tools
 
 import (
+	"os"
 	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -35,6 +35,7 @@ func DocumentationGenerator(rootCommand *cobra.Command) {
 
 	err := doc.GenMarkdownTreeCustom(rootCommand, "./docs/commands", filePrepender, linkHandler)
 	if err != nil {
-		glog.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/operator/controllers/managedkafka_controller.go
+++ b/operator/controllers/managedkafka_controller.go
@@ -55,7 +55,7 @@ func (r *ManagedKafkaReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	response, status, err := client.DefaultApi.ApiManagedServicesApiV1KafkasPost(context.Background(), false, kafkaRequest)
 
 	if err != nil {
-		glog.Fatalf("Error while requesting new Kafka cluster: %v", err)
+		fmt.Fprintf(os.Stderr, "Error while requesting new Kafka cluster: %v", err)
 	}
 	if status.StatusCode == 200 {
 		jsonResponse, _ := json.MarshalIndent(response, "", "  ")


### PR DESCRIPTION
This PR removes usage of the `glog` package everywhere. `glog` is an external package, the same behaviour is perfectly replicable in the standards `logs` library.

Why use `fmt` over `logs`? The main reason is because `logs` creates timestamp information for every log entry made. This is not something I see as desirable in a CLI, since the logs are read by a human in real-time from the terminal. You will see that this is how `ocm-cli` and GitHub CLI make logs also.

The logging has been standardised into the following categories:

- `stderr` - diagnostic output (errors, informational logs to help the *user* understand what is happening)
- `stdout` - conventional output (output such as a JSON response, which can be understood between systems)