### PR TITLE
fix: make auth url hard-coded

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,10 @@ To work and test CLI locally please follow the mock readme and then login into c
 
 The repo has a local Keycloak instance which replicates the production environment. To start the server run `make mock-api/start`.
 
+You will need to update the `config.AuthURL` variable to `http;//localhost:8080/auth/realms/redhat-external`.
+
 ```shell
-rhoas login --auth-url http://localhost:80
+rhoas login
 ```
 
 ### `make mock-api/start`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Go to [releases](https://github.com/bf2fc6cc711aee1a0c2a/cli/releases) to downlo
 rhoas login --insecure
 ```
 
-This will redirect you to log in to https://qa.sso.redhat.com/realms/redhat-external with your browser. The `--insecure` flag is required as this uses self-signed certs. To log in to a different server use the `--auth-url` flag:
+This will redirect you to log in to https://sso.redhat.com/realms/redhat-external with your browser. The `--insecure` flag is required as this uses self-signed certs.
 
 ```shell
 rhoas login

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -24,13 +24,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	devURL            = "http://localhost:8000"
-	productionURL     = "https://api.openshift.com"
-	stagingURL        = "https://api.stage.openshift.com"
-	integrationURL    = "https://api-integration.6943.hive-integration.openshiftapps.com"
-	productionAuthURL = "https://sso.qa.redhat.com/auth/realms/redhat-external"
-	defaultClientID   = "rhoas-cli"
+var (
+	devURL          = "http://localhost:8000"
+	productionURL   = "https://api.openshift.com"
+	stagingURL      = "https://api.stage.openshift.com"
+	integrationURL  = "https://api-integration.6943.hive-integration.openshiftapps.com"
+	defaultClientID = "rhoas-cli"
 )
 
 const PostLoginPage = `
@@ -84,7 +83,6 @@ func NewLoginCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&args.url, "url", stagingURL, "URL of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging', 'integration', 'development' and their shorthands.")
-	cmd.Flags().StringVar(&args.authURL, "auth-url", productionAuthURL, "URL of the authorization server.")
 	cmd.Flags().BoolVar(&args.insecureSkipTLSVerify, "insecure", false, "Enables insecure communication with the server. This disables verification of TLS certificates and host names.")
 	cmd.Flags().StringVar(&args.clientID, "client-id", defaultClientID, "OpenID client identifier.")
 
@@ -103,12 +101,9 @@ func runLogin(cmd *cobra.Command, _ []string) error {
 		gatewayURL = args.url
 	}
 
-	var authURL string
-	if args.authURL != "" {
-		authURL = args.authURL
-	}
-
 	httpClient := cfg.CreateHTTPClient()
+
+	authURL := config.AuthURL
 
 	parentCtx, cancel := context.WithCancel(context.Background())
 	ctx := oidc.ClientContext(parentCtx, httpClient)
@@ -197,7 +192,6 @@ func runLogin(cmd *cobra.Command, _ []string) error {
 		}
 
 		cfg.SetClientID(args.clientID)
-		cfg.SetAuthURL(authURL)
 		cfg.SetURL(gatewayURL)
 		cfg.SetScopes(oauthCfg.Scopes)
 		cfg.SetInsecure(args.insecureSkipTLSVerify)

--- a/pkg/cmd/logout/logout.go
+++ b/pkg/cmd/logout/logout.go
@@ -22,15 +22,25 @@ func NewLogoutCommand() *cobra.Command {
 }
 
 func runLogout(cmd *cobra.Command, _ []string) error {
-	cfg, _ := config.Load()
+	cfg, err := config.Load()
 
-	err := cfg.Logout()
+	if err != nil {
+		return err
+	}
+
+	err = cfg.Logout()
+
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Successfully logged out.")
-	err = config.Remove()
+
+	cfg.SetAccessToken("")
+	cfg.SetRefreshToken("")
+
+	err = config.Save(cfg)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,12 +18,15 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
+const (
+	AuthURL = "https://sso.redhat.com/auth/realms/redhat-external"
+)
+
 // Config is the type used to track the config of the client
 type Config struct {
 	AccessToken  string           `json:"access_token,omitempty" doc:"Bearer access token."`
 	RefreshToken string           `json:"refresh_token,omitempty" doc:"Offline or refresh token."`
 	Services     ServiceConfigMap `json:"services,omitempty"`
-	AuthURL      string           `json:"auth_url,omitempty"`
 	URL          string           `json:"url,omitempty" doc:"URL of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'."`
 	ClientID     string           `json:"client_id,omitempty" doc:"OpenID client identifier."`
 	Insecure     bool             `json:"insecure,omitempty" doc:"Enables insecure communication with the server. This disables verification of TLS certificates and host names."`
@@ -66,9 +69,6 @@ func (c *Config) SetInsecure(insecure bool) {
 	c.Insecure = insecure
 }
 
-func (c *Config) SetAuthURL(url string) {
-	c.AuthURL = url
-}
 func (c *Config) HasKafka() bool {
 	return c.Services.Kafka != nil
 }
@@ -230,7 +230,7 @@ func (c *Config) TokenRefresh() error {
 
 // Create a new Keycloak client
 func (c *Config) NewClient() gocloak.GoCloak {
-	authURL, _ := url.Parse(c.AuthURL)
+	authURL, _ := url.Parse(AuthURL)
 	authURLBase, _ := url.Parse(authURL.Scheme + "://" + authURL.Host)
 	client := gocloak.NewClient(authURLBase.String())
 	restyClient := *client.RestyClient()

--- a/website/docs/commands/rhoas_login.md
+++ b/website/docs/commands/rhoas_login.md
@@ -17,7 +17,6 @@ rhoas login [flags]
 ### Options
 
 ```
-      --auth-url string    URL of the authorization server. (default "https://sso.qa.redhat.com/auth/realms/redhat-external")
       --client-id string   OpenID client identifier. (default "rhoas-cli")
   -h, --help               help for login
       --insecure           Enables insecure communication with the server. This disables verification of TLS certificates and host names.


### PR DESCRIPTION
This PR removes the configurability of the auth url from the login command.

This is no longer a requirement since we are close to getting a client on the production SSO instance.