### PR TITLE
fix: remove trailing slash from url

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/browser"
 
@@ -100,7 +101,7 @@ func runLogin(cmd *cobra.Command, _ []string) error {
 	// real URL:
 	gatewayURL, ok := urlAliases[args.url]
 	if !ok {
-		gatewayURL = args.url
+		gatewayURL = path.Clean(args.url)
 	}
 
 	var authURL string


### PR DESCRIPTION
cc @wtrocki 

This PR sanitizes the input URL and removes trailing slashes.

See https://golang.org/pkg/path/#Clean