### PR TITLE
feat: wip: validate kafka name

### DIFF
--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/sdk/kafka"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -44,6 +46,11 @@ func NewCreateCommand() *cobra.Command {
 				return fmt.Errorf("Error loading config: %w", err)
 			}
 			opts.cfg = cfg
+
+			err = kafka.ValidateName(opts.name)
+			if err != nil {
+				return err
+			}
 
 			return runCreate(opts)
 		},

--- a/pkg/sdk/kafka/kafka.go
+++ b/pkg/sdk/kafka/kafka.go
@@ -1,0 +1,36 @@
+package kafka
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/MakeNowJust/heredoc"
+)
+
+var (
+	validNameRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
+	errInvalidName  = errors.New(heredoc.Doc(`
+	Invalid Kafka instance name. Valid names must satisfy the following conditions:
+
+	- must be between 1 and 32 characters
+	- must only consist of lower case, alphanumeric characters and '-'
+	- must start with an alphabetic character
+	- must end with an alphanumeric character
+	`))
+)
+
+// ValidateName validates the proposed name of a Kafka instance
+func ValidateName(name string) error {
+	if len(name) < 1 || len(name) > 32 {
+		return fmt.Errorf("Kafka instance name must be between 1 and 32 characters")
+	}
+
+	matched := validNameRegexp.MatchString(name)
+
+	if matched {
+		return nil
+	}
+
+	return errInvalidName
+}

--- a/pkg/sdk/kafka/kafka_test.go
+++ b/pkg/sdk/kafka/kafka_test.go
@@ -1,0 +1,93 @@
+package kafka
+
+import "testing"
+
+func TestValidateName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Should throw error when exceeds 32 characters",
+			args: args{
+				name: "verylongkafkanamef8d9dkf9dkc11dfs",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be valid when name is exactly 32 characters",
+			args: args{
+				name: "verylongkafkanamef8d9dkf9dkc11dd",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should be invalid when name is exactly 0 characters",
+			args: args{
+				name: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when using hyphens",
+			args: args{
+				name: "my-kafka-instance",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should be invalid when starts with number",
+			args: args{
+				name: "1my-kafka-instance",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when includes uppercase letter",
+			args: args{
+				name: "my-Kafka-instance",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when includes a space",
+			args: args{
+				name: "my-kafka instance",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when includes a '.'",
+			args: args{
+				name: "my-kafka.instance",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when starts with a '-'",
+			args: args{
+				name: "-my-kafka-instance",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be invalid when ends with a '-'",
+			args: args{
+				name: "my-kafka-instance-",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// nolint
+			if err := ValidateName(tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Perform client-side validation of a Kafka name when attempting to create a new instance

## Tasks

- [x] Implement validation
- [x] Unit tests