### PR TITLE
ci: automate CLI versioning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
   - main: ./cmd/rhoas/main.go
     id: rhoas_cli
     binary: rhoas
+    ldflags:
+      - -s -w -X github.com/bf2fc6cc711aee1a0c2a/cli/pkg/version.CLI_VERSION={{.Version}}
     goos:
       - linux
       - windows

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,4 @@
 package version
 
-/**
- * Version for the cli used in various places.
- */
-const CLI_VERSION = "0.6.0" // nolint
+// CLI_VERSION is the version for the cli used in various places
+var CLI_VERSION = "development" // nolint


### PR DESCRIPTION
This PR leverages build flags to ensure the release version listed with `rhoas --version` matches the release version on GitHub

## Verification

You can verify this locally by running the following:

1. `git tag 0.0.0-test154`
2. `goreleaser build`
3. Run the subsequent binary to check the version, example:

```shell
❯ ./dist/rhoas_cli_linux_amd64/rhoas --version
rhoas version 0.0.0=test154
```