### PR TITLE
chore: fix pandoc script

### DIFF
--- a/scripts/pandoc.sh
+++ b/scripts/pandoc.sh
@@ -1,5 +1,11 @@
+if ! command -v pandoc &> /dev/null
+then
+  echo "Please install pandoc [https://pandoc.org]"
+  exit 1
+fi
+
 files=($(find "./docs/commands" -type f -name '*.md'))
-echo "Generating  adoc"
+echo "Generating adoc"
 for item in ${files[*]}
 do
   filename="`basename ${item%.*}`"   
@@ -7,7 +13,12 @@ do
   printf "Working on   %s\n" $filename
   pandoc -s $item -f markdown -t asciidoc -o ${adocFile}
 
-  sed -i '' 's/.md/.adoc/g' ${adocFile}
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i 's/.md/.adoc/g' ${adocFile}
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/.md/.adoc/g' ${adocFile}
+  fi
+
   echo "Generated adoc. Removing markdown"
   rm -f ${item}
 done


### PR DESCRIPTION
The pandoc script did not show if pandoc was not installed, this checks if it is installed first and prints a message.

Also, the sed command only worked for MacOS﻿
