### PR TITLE
fix: append :443 to BootstrapServerHost

### DIFF
--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmdutil"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/config"
+	sdkkafka "github.com/bf2fc6cc711aee1a0c2a/cli/pkg/sdk/kafka"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -79,6 +80,8 @@ func runDescribe(opts *options) error {
 	if err != nil {
 		return fmt.Errorf("Error getting Kafka instance: %w", err)
 	}
+
+	sdkkafka.TransformResponse(&response)
 
 	switch opts.outputFormat {
 	case "json":

--- a/pkg/sdk/kafka/kafka.go
+++ b/pkg/sdk/kafka/kafka.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
+
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/api/managedservices"
 
 	"github.com/MakeNowJust/heredoc"
 )
@@ -33,4 +36,12 @@ func ValidateName(name string) error {
 	}
 
 	return errInvalidName
+}
+
+// TransformResponse modifies fields from the KafkaRequest payload object
+// The main transformation is appending ":443" to the Bootstrap Server URL
+func TransformResponse(kafkaInstance *managedservices.KafkaRequest) {
+	if !strings.HasSuffix(kafkaInstance.BootstrapServerHost, ":443") {
+		kafkaInstance.BootstrapServerHost = fmt.Sprintf("%v:443", kafkaInstance.BootstrapServerHost)
+	}
 }

--- a/pkg/sdk/kafka/topics/topics.go
+++ b/pkg/sdk/kafka/topics/topics.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/api/managedservices"
@@ -52,14 +51,13 @@ func brokerConnect() (broker *kafka.Conn, ctl *kafka.Conn, err error) {
 		return nil, nil, fmt.Errorf("Could not get Kafka instance: %w", err)
 	}
 
-	var clusterURL string
-	if strings.HasPrefix(kafkaInstance.BootstrapServerHost, "localhost") {
-		clusterURL = kafkaInstance.BootstrapServerHost
-	} else {
-		clusterURL = kafkaInstance.BootstrapServerHost + ":443"
+	if kafkaInstance.BootstrapServerHost == "" {
+		return nil, nil, fmt.Errorf("Kafka instance is missing a Bootstrap Server Host")
 	}
 
-	conn, err := dialer.Dial("tcp", clusterURL)
+	fmt.Println(kafkaInstance.BootstrapServerHost)
+
+	conn, err := dialer.Dial("tcp", kafkaInstance.BootstrapServerHost)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR appends :443 to the Bootstrap Server Host, unless it is already there.