### PR TITLE
refactor: standardised error messages

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -49,7 +49,7 @@ func main() {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.4
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Nerzal/gocloak/v7 v7.7.0
-	github.com/antihax/optional v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+)
+
+// Error records a Config file error
+type Error struct {
+	Err    error
+	Reason string
+}
+
+func (e *Error) Error() string {
+	var reason string
+	if e.Reason != "" {
+		reason = ": " + e.Reason
+	}
+	return fmt.Sprintf("ConfigError: %v%v", e.Err.Error(), reason)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func Errorf(format string, a ...interface{}) *Error {
+	err := fmt.Errorf(format, a...)
+	return &Error{err, ""}
+}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -32,17 +31,17 @@ func (c *File) Load() (*Config, error) {
 		return nil, err
 	}
 	if err != nil {
-		return nil, fmt.Errorf("can't check if config file '%s' exists: %w", file, err)
+		return nil, Errorf("unable to check if config file exists: %w", err)
 	}
 	// #nosec G304
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("can't read config file '%s': %w", file, err)
+		return nil, Errorf("unable to read config file: %w", err)
 	}
 	var cfg Config
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
-		return nil, fmt.Errorf("can't parse config file '%s': %w", file, err)
+		return nil, Errorf("unable to parse config: %w", err)
 	}
 	return &cfg, nil
 }
@@ -55,11 +54,11 @@ func (c *File) Save(cfg *Config) error {
 	}
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return fmt.Errorf("can't marshal config: %w", err)
+		return Errorf("unable to marshal config: %w", err)
 	}
 	err = ioutil.WriteFile(file, data, 0600)
 	if err != nil {
-		return fmt.Errorf("can't write file '%s': %w", file, err)
+		return Errorf(err.Error())
 	}
 	return nil
 }

--- a/pkg/auth/token/errors.go
+++ b/pkg/auth/token/errors.go
@@ -1,0 +1,34 @@
+package token
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrTokenExpired defines when a user's token is expired
+	ErrTokenExpired = errors.New("token expired")
+)
+
+// Error records an error with a JWT token
+type Error struct {
+	Err    error
+	Reason string
+}
+
+func (e *Error) Error() string {
+	var reason string
+	if e.Reason != "" {
+		reason = ": " + e.Reason
+	}
+	return fmt.Sprintf("TokenError: %v%v", e.Err, reason)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func Errorf(format string, a ...interface{}) *Error {
+	err := fmt.Errorf(format, a...)
+	return &Error{err, ""}
+}

--- a/pkg/auth/token/token.go
+++ b/pkg/auth/token/token.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -56,7 +55,7 @@ func Parse(textToken string) (token *jwt.Token, err error) {
 	parser := new(jwt.Parser)
 	token, _, err = parser.ParseUnverified(textToken, jwt.MapClaims{})
 	if err != nil {
-		err = fmt.Errorf("can't parse token: %w", err)
+		err = Errorf(err.Error())
 		return
 	}
 	return token, nil
@@ -65,7 +64,7 @@ func Parse(textToken string) (token *jwt.Token, err error) {
 func MapClaims(token *jwt.Token) (jwt.MapClaims, error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		err := fmt.Errorf("expected map claims bug got %T", claims)
+		err := Errorf("expected map claims but got %T", claims)
 		return nil, err
 	}
 
@@ -83,7 +82,7 @@ func GetExpiry(token *jwt.Token, now time.Time) (expires bool,
 	if ok {
 		exp, ok = claim.(float64)
 		if !ok {
-			err = fmt.Errorf("expected floating point 'exp' but got %T", claim)
+			err = Errorf("expected floating point 'exp' but got %T", claim)
 			return
 		}
 	}

--- a/pkg/cmd/cluster/connect/connect.go
+++ b/pkg/cmd/cluster/connect/connect.go
@@ -1,8 +1,6 @@
 package connect
 
 import (
-	"fmt"
-
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/connection"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/sdk/cluster"
@@ -64,7 +62,7 @@ Using --forceSelect will ignore current command context make interactive prompt 
 func runBind(opts *Options) error {
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	cluster.ConnectToCluster(connection, opts.Config, opts.secretName, opts.kubeconfigLocation, opts.forceSelect)

--- a/pkg/cmd/cluster/info/info.go
+++ b/pkg/cmd/cluster/info/info.go
@@ -47,8 +47,8 @@ func runInfo() error {
 
 	if !fileExists(kubeconfig) {
 		return fmt.Errorf(`
-		Command uses oc or kubectl login context file. 
-		Please make sure that you have configured access to your cluster and selected the right namespace`)
+Command uses oc or kubectl login context file. 
+Please make sure that you have configured access to your cluster and selected the right namespace`)
 	}
 
 	kubeClientconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -70,12 +70,12 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 func runCreate(opts *Options) error {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return fmt.Errorf("Error loading config: %w", err)
+		return err
 	}
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
@@ -89,10 +89,8 @@ func runCreate(opts *Options) error {
 	response, _, apiErr := a.Execute()
 
 	if apiErr.Error() != "" {
-		return fmt.Errorf("Error while requesting new Kafka instance: %w", apiErr)
+		return fmt.Errorf("Unable to create Kafka instance: %w", apiErr)
 	}
-
-	fmt.Fprintf(os.Stderr, "Created new Kafka instance:\n")
 
 	switch opts.outputFormat {
 	case "json":
@@ -109,7 +107,7 @@ func runCreate(opts *Options) error {
 
 	cfg.Services.Kafka = kafkaCfg
 	if err := opts.Config.Save(cfg); err != nil {
-		return fmt.Errorf("Unable to automatically use Kafka instance: %w", err)
+		return fmt.Errorf("Unable to use Kafka instance: %w", err)
 	}
 
 	return nil

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -40,7 +40,7 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := opts.Config.Load()
 			if err != nil {
-				return fmt.Errorf("Error loading config: %w", err)
+				return err
 			}
 
 			if opts.id != "" {
@@ -66,12 +66,12 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 func runDelete(opts *options) error {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return fmt.Errorf("Error loading config: %w", err)
+		return err
 	}
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
@@ -110,7 +110,7 @@ func runDelete(opts *options) error {
 	_, _, apiErr := client.DefaultApi.DeleteKafkaById(context.Background(), kafkaID).Execute()
 
 	if apiErr.Error() != "" {
-		return fmt.Errorf("Error deleting Kafka instance: %w", apiErr)
+		return fmt.Errorf("Unable to delete Kafka instance: %w", apiErr)
 	}
 
 	fmt.Fprint(os.Stderr, "\nKafka instance has successfully been deleted.\n")
@@ -122,11 +122,11 @@ func runDelete(opts *options) error {
 	}
 
 	// the Kafka that was deleted is set as the user's current cluster
-	// since it was deleted it should be removed from the confgi
+	// since it was deleted it should be removed from the config
 	cfg.Services.Kafka = nil
 	err = opts.Config.Save(cfg)
 	if err != nil {
-		return fmt.Errorf("Could not save config: %w", err)
+		return err
 	}
 
 	return nil

--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -52,7 +52,7 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 
 			cfg, err := opts.Config.Load()
 			if err != nil {
-				return fmt.Errorf("Error loading config: %w", err)
+				return err
 			}
 
 			var kafkaConfig *config.KafkaConfig
@@ -75,7 +75,7 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 func runDescribe(opts *options) error {
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
@@ -83,7 +83,7 @@ func runDescribe(opts *options) error {
 	response, _, apiErr := client.DefaultApi.GetKafkaById(context.Background(), opts.id).Execute()
 
 	if apiErr.Error() != "" {
-		return fmt.Errorf("Error getting Kafka instance: %w", apiErr)
+		return fmt.Errorf("Unable to get Kafka instance: %w", apiErr)
 	}
 
 	sdkkafka.TransformResponse(&response)

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -61,7 +61,7 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 func runList(opts *options) error {
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
@@ -72,7 +72,7 @@ func runList(opts *options) error {
 	response, _, apiErr := a.Execute()
 
 	if apiErr.Error() != "" {
-		return fmt.Errorf("Error retrieving Kafka instances: %w", apiErr)
+		return fmt.Errorf("Unable to list Kafka instances: %w", apiErr)
 	}
 
 	if response.Size == 0 {

--- a/pkg/cmd/kafka/status/status.go
+++ b/pkg/cmd/kafka/status/status.go
@@ -35,7 +35,7 @@ func NewStatusCommand(f *factory.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := opts.Config.Load()
 			if err != nil {
-				return fmt.Errorf("Error loading config: %w", err)
+				return err
 			}
 
 			if opts.id != "" {
@@ -61,14 +61,14 @@ func NewStatusCommand(f *factory.Factory) *cobra.Command {
 func runStatus(opts *Options) error {
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
 
 	res, _, apiErr := client.DefaultApi.GetKafkaById(context.Background(), opts.id).Execute()
 	if apiErr.Error() != "" {
-		return fmt.Errorf("Error retrieving Kafka instance: %w", apiErr)
+		return fmt.Errorf("Unable to get Kafka instance: %w", apiErr)
 	}
 
 	type kafkaStatus struct {

--- a/pkg/cmd/kafka/topics/create/create.go
+++ b/pkg/cmd/kafka/topics/create/create.go
@@ -70,11 +70,11 @@ func createTopic(opts *Options) error {
 	}
 	err := topics.ValidateCredentials(topicOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating credentials for topic: %w", err)
+		return fmt.Errorf("Unable to create credentials for topic: %w", err)
 	}
 	err = topics.CreateKafkaTopic(topicConfigs, topicOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating topic: %w", err)
+		return fmt.Errorf("Unable to create topic: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Topic %v created\n", opts.topicName)

--- a/pkg/cmd/kafka/topics/delete/delete.go
+++ b/pkg/cmd/kafka/topics/delete/delete.go
@@ -53,11 +53,11 @@ func deleteTopic(opts *Options) error {
 	fmt.Fprintf(os.Stderr, "Deleting topic %v\n", opts.topicName)
 	err := topics.ValidateCredentials(topicOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating credentials for topic: %w", err)
+		return fmt.Errorf("Unable to create credentials for topic: %w", err)
 	}
 	err = topics.DeleteKafkaTopic(opts.topicName, topicOpts)
 	if err != nil {
-		return fmt.Errorf("Error deleting topic: %w", err)
+		return fmt.Errorf("Unable to delete topic: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Topic %v deleted\n", opts.topicName)

--- a/pkg/cmd/kafka/topics/list/list.go
+++ b/pkg/cmd/kafka/topics/list/list.go
@@ -49,7 +49,7 @@ func listTopic(opts *Options) error {
 
 	err := topics.ValidateCredentials(topicOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating credentials for list: %w", err)
+		return fmt.Errorf("Unable to create credentials: %w", err)
 	}
 	fmt.Fprintln(os.Stderr, "Topics:")
 	err = topics.ListKafkaTopics(topicOpts)

--- a/pkg/cmd/kafka/use/use.go
+++ b/pkg/cmd/kafka/use/use.go
@@ -50,12 +50,12 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 func runUse(opts *options) error {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return fmt.Errorf("Error loading config: %w", err)
+		return err
 	}
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	client := connection.NewMASClient()
@@ -72,7 +72,7 @@ func runUse(opts *options) error {
 
 	cfg.Services.Kafka = &kafkaConfig
 	if err := opts.Config.Save(cfg); err != nil {
-		return fmt.Errorf("Unable to update config: %w", err)
+		return fmt.Errorf("Unable to use Kafka instance: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Using Kafka instance \"%v\"\n", *res.Id)

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -215,7 +215,7 @@ func runLogin(opts *Options) error {
 
 		cfg, err := opts.Config.Load()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Could not load config: %v\n", err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -228,7 +228,7 @@ func runLogin(opts *Options) error {
 		cfg.RefreshToken = oauth2Token.RefreshToken
 
 		if err = opts.Config.Save(cfg); err != nil {
-			fmt.Fprintf(os.Stderr, "Could not save config: %v\n", err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -262,7 +262,7 @@ func runLogin(opts *Options) error {
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error starting server: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to start server: %v\n", err)
 		}
 	}()
 	<-parentCtx.Done()

--- a/pkg/cmd/logout/logout.go
+++ b/pkg/cmd/logout/logout.go
@@ -40,12 +40,12 @@ func NewLogoutCommand(f *factory.Factory) *cobra.Command {
 func runLogout(opts *Options) error {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return fmt.Errorf("Error loading config: %w", err)
+		return err
 	}
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Could not create connection: %w", err)
+		return err
 	}
 
 	err = connection.Logout(context.TODO())
@@ -61,7 +61,7 @@ func runLogout(opts *Options) error {
 
 	err = opts.Config.Save(cfg)
 	if err != nil {
-		return fmt.Errorf("Could not save config file: %w", err)
+		return err
 	}
 
 	return nil

--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -115,7 +115,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 func runCreate(opts *Options) error {
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 
 	fmt.Fprintf(os.Stderr, "Creating service account with the following permissions: %v\n", opts.scopes)
@@ -169,7 +169,7 @@ func runCreate(opts *Options) error {
 
 	err = ioutil.WriteFile(fileName, dataToWrite, 0600)
 	if err != nil {
-		return fmt.Errorf("Could not save file: %w", err)
+		return err
 	}
 
 	fmt.Fprintf(os.Stderr, "Successfully saved credentials to %v\n", fileName)

--- a/pkg/connection/builder.go
+++ b/pkg/connection/builder.go
@@ -99,15 +99,11 @@ func (b *Builder) Build() (connection *Connection, err error) {
 // the connection, and an error if something fails when trying to create it.
 func (b *Builder) BuildContext(ctx context.Context) (connection *Connection, err error) {
 	if b.clientID == "" {
-		return nil, fmt.Errorf(
-			"Missing client ID",
-		)
+		return nil, AuthErrorf("Missing client ID")
 	}
 
 	if b.accessToken == "" && b.refreshToken == "" {
-		return nil, fmt.Errorf(
-			"You are not logged in",
-		)
+		return nil, notLoggedInError()
 	}
 
 	tkn := token.Token{
@@ -120,7 +116,7 @@ func (b *Builder) BuildContext(ctx context.Context) (connection *Connection, err
 		return nil, err
 	}
 	if !tokenIsValid {
-		return nil, fmt.Errorf("Invalid token. Please log in again")
+		return nil, sessionExpiredError()
 	}
 
 	scopes := b.scopes
@@ -140,13 +136,13 @@ func (b *Builder) BuildContext(ctx context.Context) (connection *Connection, err
 	}
 	apiURL, err := url.Parse(rawAPIURL)
 	if err != nil {
-		err = fmt.Errorf("can't parse API URL '%s': %w", rawAPIURL, err)
+		err = AuthErrorf("unable to parse API URL '%s': %w", rawAPIURL, err)
 		return
 	}
 
 	authURL, err := url.Parse(b.authURL)
 	if err != nil {
-		err = fmt.Errorf("can't parse Auth URL '%s': %w", DefaultAuthURL, err)
+		err = AuthErrorf("unable to parse Auth URL '%s': %w", DefaultAuthURL, err)
 		return
 	}
 

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -48,7 +48,7 @@ type IConnection interface {
 func (c *Connection) RefreshTokens(ctx context.Context) (accessToken string, refreshToken string, err error) {
 	refreshedTk, err := c.authClient.RefreshToken(ctx, c.Token.RefreshToken, c.clientID, "", "redhat-external")
 	if err != nil {
-		return "", "", err
+		return "", "", &AuthError{err, ""}
 	}
 
 	if refreshedTk.AccessToken != c.Token.AccessToken {
@@ -64,7 +64,7 @@ func (c *Connection) RefreshTokens(ctx context.Context) (accessToken string, ref
 func (c *Connection) Logout(ctx context.Context) error {
 	err := c.authClient.Logout(ctx, c.clientID, "", "redhat-external", c.Token.RefreshToken)
 	if err != nil {
-		return err
+		return &AuthError{err, ""}
 	}
 
 	c.Token.AccessToken = ""

--- a/pkg/connection/errors.go
+++ b/pkg/connection/errors.go
@@ -1,0 +1,44 @@
+package connection
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNotLoggedIn defines when a user is not authenticated
+	ErrNotLoggedIn = errors.New("Not logged in. Run `rhoas login` to authenticate")
+	// ErrSessionExpired defines when a user's session has expired
+	ErrSessionExpired = errors.New("Session expired. Run `rhoas login` to authenticate")
+)
+
+// AuthError defines an Authentication error
+type AuthError struct {
+	Err    error
+	Reason string
+}
+
+func (e *AuthError) Error() string {
+	var reason string
+	if e.Reason != "" {
+		reason = ": " + e.Reason
+	}
+	return fmt.Sprintf("AuthError: %v%v", e.Err, reason)
+}
+
+func (e *AuthError) Unwrap() error {
+	return e.Err
+}
+
+func AuthErrorf(format string, a ...interface{}) *AuthError {
+	err := fmt.Errorf(format, a...)
+	return &AuthError{err, ""}
+}
+
+func notLoggedInError() *AuthError {
+	return &AuthError{ErrNotLoggedIn, ""}
+}
+
+func sessionExpiredError() *AuthError {
+	return &AuthError{ErrSessionExpired, ""}
+}

--- a/pkg/sdk/cluster/cluster.go
+++ b/pkg/sdk/cluster/cluster.go
@@ -250,7 +250,7 @@ func useKafka(cliconfig *config.Config, connection pkgConnection.IConnection) *c
 	response, _, apiErr := client.DefaultApi.ListKafkas(context.Background()).Execute()
 
 	if apiErr.Error() != "" {
-		fmt.Fprintf(os.Stderr, "Error retrieving Kafka clusters: %v\n", apiErr)
+		fmt.Fprintf(os.Stderr, "Unable to get Kafka clusters: %v\n", apiErr)
 		os.Exit(1)
 	}
 

--- a/pkg/sdk/kafka/topics/topics.go
+++ b/pkg/sdk/kafka/topics/topics.go
@@ -28,7 +28,7 @@ type Options struct {
 func brokerConnect(opts *Options) (broker *kafka.Conn, ctl *kafka.Conn, err error) {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not load config: %w", err)
+		return nil, nil, err
 	}
 
 	if cfg.Services.Kafka == nil || cfg.Services.Kafka.ClusterID == "" {
@@ -52,7 +52,7 @@ func brokerConnect(opts *Options) (broker *kafka.Conn, ctl *kafka.Conn, err erro
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not create connection: %w", err)
+		return nil, nil, err
 	}
 
 	managedservices := connection.NewMASClient()
@@ -88,7 +88,7 @@ func brokerConnect(opts *Options) (broker *kafka.Conn, ctl *kafka.Conn, err erro
 func ValidateCredentials(opts *Options) error {
 	cfg, err := opts.Config.Load()
 	if err != nil {
-		return fmt.Errorf("Could not load config: %w", err)
+		return err
 	}
 
 	if cfg.ServiceAuth.ClientID != "" && cfg.ServiceAuth.ClientSecret != "" {
@@ -97,7 +97,7 @@ func ValidateCredentials(opts *Options) error {
 
 	connection, err := opts.Connection()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %w", err)
+		return err
 	}
 	client := connection.NewMASClient()
 	fmt.Fprint(os.Stderr, "\nNo Service credentials. \nCreating service account for CLI\n")


### PR DESCRIPTION
This PR adds three custom error types:

AuthError - use when there is an authentication error
TokenError - use when there is an issue with a JWT 
ConfigError - use when there is an error while accessing the config