### PR TITLE
fix: pointer error when bootstrap host is empty

### DIFF
--- a/pkg/sdk/kafka/kafka.go
+++ b/pkg/sdk/kafka/kafka.go
@@ -40,11 +40,17 @@ func ValidateName(name string) error {
 
 // TransformResponse modifies fields from the KafkaRequest payload object
 // The main transformation is appending ":443" to the Bootstrap Server URL
-func TransformResponse(kafkaInstance *managedservices.KafkaRequest) {
+func TransformResponse(kafkaInstance *managedservices.KafkaRequest) *managedservices.KafkaRequest {
 	bootstrapHost := kafkaInstance.GetBootstrapServerHost()
+
+	if bootstrapHost == "" {
+		return kafkaInstance
+	}
 
 	if !strings.HasSuffix(bootstrapHost, ":443") {
 		hostURL := fmt.Sprintf("%v:443", bootstrapHost)
 		kafkaInstance.SetBootstrapServerHost(hostURL)
 	}
+
+	return kafkaInstance
 }


### PR DESCRIPTION
This PR fixes a nil-pointer error which occurred when the `bootstrapServerHost` field was not yet populated.