### PR TITLE
feat(kafka): require name confirmation

### DIFF
--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -94,7 +94,7 @@ func runDelete(opts *options) error {
 
 	var confirmDeleteAction bool
 	var promptConfirmAction = &survey.Confirm{
-		Message: "Once a Kafka instance is deleted it cannot be recovered, are you sure you want to proceed?",
+		Message: fmt.Sprintf("Are you sure you want to delete the Kafka instance '%v'?", kafkaName),
 	}
 
 	err = survey.AskOne(promptConfirmAction, &confirmDeleteAction)
@@ -106,7 +106,7 @@ func runDelete(opts *options) error {
 	}
 
 	var promptConfirmName = &survey.Input{
-		Message: "Please confirm the name of the Kafka instance you wish to permanently delete:",
+		Message: "Confirm the name of the instance you want to permanently delete:",
 	}
 
 	var confirmedKafkaName string


### PR DESCRIPTION
Closes #215 

The UI makes the user confirm the _name_ of the Kafka instance when deleting. This PR aligns both interfaces.

It makes more sense to confirm the name as the ID will already have been entered, and is more likely to be pasted from the clipboard, skipping this sanitisation check.

```shell
❯ ./rhoas kafka delete
? Are you sure you want to delete the Kafka instance 'enda-test'? Yes
? Confirm the name of the instance you want to permanently delete: enda-test
Kafka instance 'enda-test' has successfully been deleted
```