### PR TITLE
feat(kafka.list): append port to end of bootstrap URL

### DIFF
--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -88,7 +88,7 @@ func runDescribe(opts *options) error {
 		return fmt.Errorf("Unable to get Kafka instance: %w", apiErr)
 	}
 
-	sdkkafka.TransformResponse(&response)
+	sdkkafka.TransformKafkaRequest(&response)
 
 	switch opts.outputFormat {
 	case "json":

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/kafka"
 	"os"
 	"strconv"
 
@@ -21,7 +22,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/kafka"
+	sdkKafka "github.com/bf2fc6cc711aee1a0c2a/cli/pkg/sdk/kafka"
 )
 
 type options struct {
@@ -87,6 +88,10 @@ func runList(opts *options) error {
 	a = a.Page(strconv.Itoa(opts.page))
 	a = a.Size(strconv.Itoa(opts.limit))
 	response, _, apiErr := a.Execute()
+	// modify the items to add a :443 port to the bootstrap URL
+	kafkaItems := response.GetItems()
+	kafkaItems = sdkKafka.TransformKafkaRequestListItems(kafkaItems)
+	response.SetItems(kafkaItems)
 
 	if apiErr.Error() != "" {
 		return fmt.Errorf("Unable to list Kafka instances: %w", apiErr)

--- a/pkg/sdk/kafka/kafka.go
+++ b/pkg/sdk/kafka/kafka.go
@@ -38,19 +38,31 @@ func ValidateName(name string) error {
 	return errInvalidName
 }
 
-// TransformResponse modifies fields from the KafkaRequest payload object
+// TransformKafkaRequestListItems modifies fields fields from a list of kafka instances
 // The main transformation is appending ":443" to the Bootstrap Server URL
-func TransformResponse(kafkaInstance *managedservices.KafkaRequest) *managedservices.KafkaRequest {
-	bootstrapHost := kafkaInstance.GetBootstrapServerHost()
+func TransformKafkaRequestListItems(items []managedservices.KafkaRequest) []managedservices.KafkaRequest {
+	for i := range items {
+		kafka := items[i]
+		kafka = *TransformKafkaRequest(&kafka)
+		items[i] = kafka
+	}
+
+	return items
+}
+
+// TransformKafkaRequest modifies fields from the KafkaRequest payload object
+// The main transformation is appending ":443" to the Bootstrap Server URL
+func TransformKafkaRequest(kafka *managedservices.KafkaRequest) *managedservices.KafkaRequest {
+	bootstrapHost := kafka.GetBootstrapServerHost()
 
 	if bootstrapHost == "" {
-		return kafkaInstance
+		return kafka
 	}
 
 	if !strings.HasSuffix(bootstrapHost, ":443") {
 		hostURL := fmt.Sprintf("%v:443", bootstrapHost)
-		kafkaInstance.SetBootstrapServerHost(hostURL)
+		kafka.SetBootstrapServerHost(hostURL)
 	}
 
-	return kafkaInstance
+	return kafka
 }

--- a/pkg/sdk/kafka/topics/topics.go
+++ b/pkg/sdk/kafka/topics/topics.go
@@ -67,7 +67,7 @@ func brokerConnect(opts *Options) (broker *kafka.Conn, ctl *kafka.Conn, err erro
 		return nil, nil, fmt.Errorf("Kafka instance is missing a Bootstrap Server Host")
 	}
 
-	sdkkafka.TransformResponse(&kafkaInstance)
+	sdkkafka.TransformKafkaRequest(&kafkaInstance)
 
 	conn, err := dialer.Dial("tcp", kafkaInstance.GetBootstrapServerHost())
 	if err != nil {


### PR DESCRIPTION
This PR appends the SSL port ":443" to the end of every Kafka item.

Output:

```diff
❯ ./rhoas kafka list -o json | jq '.items[1]'
{
+  "bootstrapServerHost": "enda-t--n-kqxg-soef-ajajtaqq-y--og.kafka.devshift.org:443",
-  "bootstrapServerHost": "enda-t--n-kqxg-soef-ajajtaqq-y--og.kafka.devshift.org",
  "cloud_provider": "aws",
  "created_at": "2021-01-14T20:38:57.678731Z",
  "href": "/api/managed-services-api/v1/kafkas/1n4kQxg7SOeF7ajAjtaQQ2Y67og",
  "id": "1n4kQxg7SOeF7ajAjtaQQ2Y67og",
  "kind": "Kafka",
  "multi_az": true,
  "name": "enda-test",
  "owner": "ephelan_kafka_devexp",
  "region": "us-east-1",
  "status": "ready",
  "updated_at": "2021-01-14T20:42:09.848984Z"
}
```

## Tasks

- [x] Added tests