### PR TITLE
fix: remove kafka credentials format

### DIFF
--- a/docs/commands/rhoas_serviceaccount_create.adoc
+++ b/docs/commands/rhoas_serviceaccount_create.adoc
@@ -22,11 +22,9 @@ rhoas serviceaccount create [flags]
 === Examples
 
 ....
+$ rhoas serviceaccount create
 $ rhoas serviceaccount create --output kafka
-$ rhoas serviceaccount create --output=env
-$ rhoas serviceaccount create -o=properties
 $ rhoas serviceaccount create -o env --force
-$ rhoas serviceaccount create -o json
 ....
 
 === Options

--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -74,13 +74,16 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				if opts.output == "" {
 					return fmt.Errorf("--output is a required flag")
 				}
+			}
+
+			if opts.output != "" {
 				// check that a valid --output flag value is used
 				validOutput := flagutil.IsValidInput(opts.output, flagutil.CredentialsOutputFormats...)
 				if !validOutput {
 					return fmt.Errorf("Invalid value for --output. Valid values: %q", flagutil.CredentialsOutputFormats)
 				}
-			}
 
+			}
 			return runCreate(opts)
 		},
 	}

--- a/pkg/cmdutil/flags/flags.go
+++ b/pkg/cmdutil/flags/flags.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	AllowedListFormats       = []string{"plain", "json", "yml", "yaml"}
-	CredentialsOutputFormats = []string{"env", "json", "properties", "kafka", "kube"}
+	CredentialsOutputFormats = []string{"env", "json", "properties", "kube"}
 )
 
 // MustGetDefinedString attempts to get a non-empty string flag from the provided flag set or panic

--- a/pkg/serviceaccount/credentials/credentials.go
+++ b/pkg/serviceaccount/credentials/credentials.go
@@ -57,8 +57,8 @@ func AbsolutePath(outputFormat string, customLocation string) (filePath string) 
 		switch outputFormat {
 		case "env":
 			filePath = ".env"
-		case "properties", "kafka":
-			filePath = "kafka.properties"
+		case "properties":
+			filePath = "credentials.properties"
 		case "json":
 			filePath = "credentials.json"
 		case "kube":


### PR DESCRIPTION
There is no "kafka" output format and this would only serve to confuse users.

Fixes #243 