### PR TITLE
fix(connection): only refresh tokens when needed

### DIFF
--- a/pkg/auth/token/token.go
+++ b/pkg/auth/token/token.go
@@ -17,12 +17,7 @@ func (c *Token) IsValid() (tokenIsValid bool, err error) {
 	if c.AccessToken != "" {
 		var expires bool
 		var left time.Duration
-		var accessToken *jwt.Token
-		accessToken, err = Parse(c.AccessToken)
-		if err != nil {
-			return
-		}
-		expires, left, err = GetExpiry(accessToken, now)
+		expires, left, err = GetExpiry(c.AccessToken, now)
 		if err != nil {
 			return
 		}
@@ -34,12 +29,7 @@ func (c *Token) IsValid() (tokenIsValid bool, err error) {
 	if c.RefreshToken != "" {
 		var expires bool
 		var left time.Duration
-		var refreshToken *jwt.Token
-		refreshToken, err = Parse(c.RefreshToken)
-		if err != nil {
-			return
-		}
-		expires, left, err = GetExpiry(refreshToken, now)
+		expires, left, err = GetExpiry(c.RefreshToken, now)
 		if err != nil {
 			return
 		}
@@ -71,8 +61,14 @@ func MapClaims(token *jwt.Token) (jwt.MapClaims, error) {
 	return claims, nil
 }
 
-func GetExpiry(token *jwt.Token, now time.Time) (expires bool,
+func GetExpiry(tokenStr string, now time.Time) (expires bool,
 	left time.Duration, err error) {
+
+	token, err := Parse(tokenStr)
+	if err != nil {
+		return false, 0, err
+	}
+
 	claims, err := MapClaims(token)
 	if err != nil {
 		return false, 0, err


### PR DESCRIPTION
Resolves #273 

When token is still valid:

```sh
❯ ./rhoas kafka describe -d
Refreshing access tokens
Token is already valid. Expires in 13m49.851566316s
Adding bearer token to request
{
  "bootstrapServerHost": "enda-test--nqm---fmupr-iyldbkjomzl-wv.kafka.devshift.org:443",
  "cloud_provider": "aws",
  "created_at": "2021-01-22T15:48:53.507929Z",
  "href": "/api/managed-services-api/v1/kafkas/1nQm940fmupR4iYlDbkJOmZl4Wv",
  "id": "1nQm940fmupR4iYlDbkJOmZl4Wv",
  "kind": "Kafka",
  "multi_az": true,
  "name": "enda-test",
  "owner": "ephelan_kafka_devexp",
  "region": "us-east-1",
  "status": "provisioning",
  "updated_at": "2021-01-22T15:49:19.979335Z"
}
```