### PR TITLE
feat(kafka describe): add arguments to print a single field

### DIFF
--- a/docs/commands/rhoas_kafka_describe.adoc
+++ b/docs/commands/rhoas_kafka_describe.adoc
@@ -10,8 +10,8 @@ Pass the –id flag to specify which instance you would like to view. If
 the –id flag is not passed then the selected Kafka instance will be
 used, if available. The result can be output either as JSON or YAML.
 
-Pass one of ``name'', ``id'', ``bootstrap-server-host'' or ``status'' as
-an argument to request that single field instead of printing the full
+Pass one of ``name'', ``id'', ``bootstrap-url'' or ``status'' as an
+argument to request that single field instead of printing the full
 instance object.
 
 ....
@@ -31,7 +31,7 @@ $ rhoas kafka describe --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 $ rhoas kafka describe -o yaml
 
 # retrieve the bootstrap server url
-$ rhoas kafka describe bootstrap-server-host
+$ rhoas kafka describe bootstrap-url
 ....
 
 === Options

--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -38,7 +38,7 @@ type options struct {
 // possible values for the field argument
 const (
 	idFieldCmd           = "id"
-	bootstrapURLFieldCmd = "bootstrap-server-host"
+	bootstrapURLFieldCmd = "bootstrap-url"
 	statusFieldCmd       = "status"
 	nameFieldCmd         = "name"
 )
@@ -66,7 +66,7 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 			Pass one of "%v", "%v", "%v" or "%v" as an argument to request 
 			that single field instead of printing the full instance object.
 		`, nameFieldCmd, idFieldCmd, bootstrapURLFieldCmd, statusFieldCmd),
-		Example: heredoc.Doc(`
+		Example: heredoc.Docf(`
 			# view the current Kafka instance instance
 			$ rhoas kafka describe
 
@@ -77,8 +77,8 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 			$ rhoas kafka describe -o yaml
 
 			# retrieve the bootstrap server url
-			$ rhoas kafka describe bootstrap-server-host
-			`,
+			$ rhoas kafka describe %v
+			`, bootstrapURLFieldCmd,
 		),
 		Args:      cobra.RangeArgs(0, 1),
 		ValidArgs: []string{idFieldCmd, bootstrapURLFieldCmd, statusFieldCmd, nameFieldCmd},


### PR DESCRIPTION
This PR adds a usability improvement by adding a set of valid arguments to `rhoas kafka describe`, enabling the user to fetch a single field instead of printing the entire Kafka instance object.

Four fields have been added as valid arguments. They are:

- id
- name
- status
- bootstrap-server-host

I did not see the need to add every field as a valid argument. These are the fields most likely to be used.

Before this change, users would have to combine `rhoas` with other tools such as jq to get a single field. Example:

```shell
$ BOOTSTRAP_URL=$(rhoas kafka describe | jq .bootstrapServerHost -r)
$ echo $BOOTSTRAP_URL
enda-kafka--nziwakrvbza--vmaatwmlt--da.kafka.devshift.org:443
```

Now the same can be achieved with:

```shell
$ BOOTSTRAP_URL=$(rhoas kafka describe bootstrap-server-host)
$ echo $BOOTSTRAP_URL
enda-kafka--nziwakrvbza--vmaatwmlt--da.kafka.devshift.org:443
```

Fixes #172 

## Tasks

- [x] Add feature 
- [x] Generate docs