### PR TITLE
fix(cluster info): rename command info to status

### DIFF
--- a/docs/commands/rhoas_cluster.adoc
+++ b/docs/commands/rhoas_cluster.adoc
@@ -10,8 +10,8 @@ operations related to your application services.
 === Examples
 
 ....
-# view information about your cluster
-$ rhoas cluster info
+# view the status of the cluster
+$ rhoas cluster status
 
 # connect a service to your cluster
 $ rhoas cluster connect
@@ -34,5 +34,5 @@ $ rhoas cluster connect
 * link:rhoas.adoc[rhoas] - RHOAS CLI
 * link:rhoas_cluster_connect.adoc[rhoas cluster connect] - Connect your
 services to a Kubernetes or OpenShift
-* link:rhoas_cluster_info.adoc[rhoas cluster info] - View information
-about the current Kubernetes or OpenShift cluster.
+* link:rhoas_cluster_status.adoc[rhoas cluster status] - View status of
+the current Kubernetes or OpenShift cluster.

--- a/docs/commands/rhoas_cluster_status.adoc
+++ b/docs/commands/rhoas_cluster_status.adoc
@@ -1,0 +1,43 @@
+== rhoas cluster status
+
+View status of the current Kubernetes or OpenShift cluster.
+
+=== Synopsis
+
+View status of the current Kubernetes or OpenShift cluster using your
+kubeconfig file.
+
+The information shown is useful for connecting your service to the
+OpenShift cluster.
+
+For this command to work you must be logged into a Kubernetes or
+OpenShift cluster. The command uses the kubeconfig file to identify the
+cluster context.
+
+....
+rhoas cluster status [flags]
+....
+
+=== Examples
+
+....
+# print status of the current cluster
+$ rhoas cluster status
+....
+
+=== Options
+
+....
+  -h, --help   help for status
+....
+
+=== Options inherited from parent commands
+
+....
+  -d, --debug   Enable debug mode
+....
+
+=== SEE ALSO
+
+* link:rhoas_cluster.adoc[rhoas cluster] - View and perform operations on
+your Kubernetes or OpenShift Cluster

--- a/pkg/cmd/cluster/cluster.go
+++ b/pkg/cmd/cluster/cluster.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/cluster/connect"
-	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/cluster/info"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/cluster/status"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
 	"github.com/spf13/cobra"
 )
@@ -18,8 +18,8 @@ func NewClusterCommand(f *factory.Factory) *cobra.Command {
 			and perform operations related to your application services.
 		`),
 		Example: heredoc.Doc(`
-			# view information about your cluster
-			$ rhoas cluster info
+			# view the status of the cluster
+			$ rhoas cluster status
 
 			# connect a service to your cluster
 			$ rhoas cluster connect
@@ -28,7 +28,7 @@ func NewClusterCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		info.NewInfoCommand(f),
+		status.NewStatusCommand(f),
 		connect.NewConnectCommand(f),
 	)
 

--- a/pkg/cmd/cluster/status/status.go
+++ b/pkg/cmd/cluster/status/status.go
@@ -1,4 +1,4 @@
-package info
+package status
 
 import (
 	"context"
@@ -30,7 +30,7 @@ type Options struct {
 	Logger     func() (logging.Logger, error)
 }
 
-func NewInfoCommand(f *factory.Factory) *cobra.Command {
+func NewStatusCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
 		Config:     f.Config,
 		Connection: f.Connection,
@@ -38,10 +38,10 @@ func NewInfoCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "info",
-		Short: "View information about the current Kubernetes or OpenShift cluster.",
+		Use:   "status",
+		Short: "View status of the current Kubernetes or OpenShift cluster.",
 		Long: heredoc.Doc(`
-			View information about the current Kubernetes or OpenShift cluster using your kubeconfig file.
+			View status of the current Kubernetes or OpenShift cluster using your kubeconfig file.
 
 			The information shown is useful for connecting your service to the OpenShift cluster.
 
@@ -49,18 +49,18 @@ func NewInfoCommand(f *factory.Factory) *cobra.Command {
 			uses the kubeconfig file to identify the cluster context.
 		`),
 		Example: heredoc.Doc(`
-			# print information about the current cluster
-			$ rhoas cluster info
+			# print status of the current cluster
+			$ rhoas cluster status
 		`),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runInfo(opts)
+			return runStatus(opts)
 		},
 	}
 
 	return cmd
 }
 
-func runInfo(opts *Options) error {
+func runStatus(opts *Options) error {
 	connection, err := opts.Connection()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #289 

This PR renames the `rhoas cluster info` command to `rhoas cluster status`

## Verification

1. Run `rhoas cluster status`