### PR TITLE
feat: standardise colors for printing to console

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmdutil"
 	"os"
+
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmdutil"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/build"
 

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/fatih/color"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/kafka"
@@ -125,7 +124,7 @@ func (c *Kubernetes) Connect(ctx context.Context, secretName string, forceSelect
 	}
 
 	// print status
-	c.logger.Infof(statusMsg, color.HiGreenString(kafkaInstance.GetName()), color.HiGreenString(currentNamespace), color.HiGreenString(secretName))
+	c.logger.Infof(statusMsg, color.Info(kafkaInstance.GetName()), color.Info(currentNamespace), color.Info(secretName))
 
 	var shouldContinue bool
 	confirm := &survey.Confirm{
@@ -253,7 +252,7 @@ func (c *Kubernetes) createSecret(ctx context.Context, serviceAcct *serviceapicl
 
 	_, err = c.clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err == nil {
-		return fmt.Errorf("Secret '%v' already exists. Please choose a different name with --secret-name", secretName)
+		return fmt.Errorf("Secret %v already exists. Please choose a different name with --secret-name", color.Info(secretName))
 	}
 
 	createdSecret, err := c.clientset.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
@@ -261,7 +260,7 @@ func (c *Kubernetes) createSecret(ctx context.Context, serviceAcct *serviceapicl
 		return fmt.Errorf("Could not create secret: %w", err)
 	}
 
-	c.logger.Infof("Secret '%v' created", createdSecret.Name)
+	c.logger.Infof("Secret %v created", color.Info(createdSecret.Name))
 
 	return nil
 }

--- a/pkg/cmd/cluster/status/status.go
+++ b/pkg/cmd/cluster/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
@@ -10,8 +11,6 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/connection"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
-
-	"github.com/fatih/color"
 
 	"github.com/spf13/cobra"
 
@@ -84,9 +83,9 @@ func runStatus(opts *Options) error {
 	}
 
 	if isCRDInstalled {
-		operatorStatus = color.HiGreenString("Installed")
+		operatorStatus = color.Success("Installed")
 	} else {
-		operatorStatus = color.HiRedString("Not installed")
+		operatorStatus = color.Error("Not installed")
 	}
 
 	currentNamespace, err := clusterConn.CurrentNamespace()
@@ -94,7 +93,7 @@ func runStatus(opts *Options) error {
 		return err
 	}
 
-	logger.Info(fmt.Sprintf(statusMsg, color.HiGreenString(currentNamespace), operatorStatus))
+	logger.Info(fmt.Sprintf(statusMsg, color.Info(currentNamespace), operatorStatus))
 
 	return nil
 }

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 
 	"github.com/MakeNowJust/heredoc"
@@ -99,7 +100,7 @@ func runDelete(opts *options) error {
 
 	var confirmDeleteAction bool
 	var promptConfirmAction = &survey.Confirm{
-		Message: fmt.Sprintf("Are you sure you want to delete the Kafka instance '%v'?", kafkaName),
+		Message: fmt.Sprintf("Are you sure you want to delete the Kafka instance %v?", color.Info(kafkaName)),
 	}
 
 	err = survey.AskOne(promptConfirmAction, &confirmDeleteAction)
@@ -132,7 +133,7 @@ func runDelete(opts *options) error {
 		return fmt.Errorf("Unable to delete Kafka instance: %w", apiErr)
 	}
 
-	logger.Infof("Kafka instance '%v' has successfully been deleted", kafkaName)
+	logger.Infof("Kafka instance %v has successfully been deleted", color.Info(kafkaName))
 
 	currentKafka := cfg.Services.Kafka
 	// this is not the current cluster, our work here is done

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/auth/token"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/browser"
@@ -141,7 +142,7 @@ func runLogin(opts *Options) error {
 		return err
 	}
 	if gatewayURL.Scheme != "http" && gatewayURL.Scheme != "https" {
-		return fmt.Errorf("Scheme missing from URL '%v'. Please add either 'https' or 'https'.", unparsedGatewayURL)
+		return fmt.Errorf("Scheme missing from URL %v. Please add either 'https' or 'https'.", color.Info(unparsedGatewayURL))
 	}
 
 	tr := createTransport(opts.insecureSkipTLSVerify)
@@ -265,7 +266,8 @@ func runLogin(opts *Options) error {
 		if !ok {
 			logger.Info("You are now logged in")
 		} else {
-			logger.Infof("You are now logged in as %v", userName)
+			rawUsername := fmt.Sprintf("%v", userName)
+			logger.Infof("You are now logged in as %v", color.Info(rawUsername))
 		}
 
 		cancel()

--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -132,7 +133,7 @@ func runCreate(opts *Options) error {
 	// indicating that the user should explicitly request overwriting of the file
 	_, err = os.Stat(opts.filename)
 	if err == nil && !opts.overwrite {
-		return fmt.Errorf("file '%v' already exists. Use --overwrite to overwrite the file, or --file-location flag to choose a custom location", opts.filename)
+		return fmt.Errorf("file %v already exists. Use --overwrite to overwrite the file, or --file-location flag to choose a custom location", color.Info(opts.filename))
 	}
 
 	// create the service account
@@ -147,7 +148,7 @@ func runCreate(opts *Options) error {
 		return fmt.Errorf("Could not create service account: %w", apiErr)
 	}
 
-	logger.Infof("Service account '%v' created", serviceacct.GetName())
+	logger.Infof("Service account %v created", color.Info(serviceacct.GetName()))
 
 	creds := &credentials.Credentials{
 		ClientID:     serviceacct.GetClientID(),

--- a/pkg/cmd/serviceaccount/delete/delete.go
+++ b/pkg/cmd/serviceaccount/delete/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/connection"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 	"github.com/spf13/cobra"
@@ -58,7 +59,7 @@ func runDelete(opts *Options) (err error) {
 
 	var confirmDelete bool
 	promptConfirmDelete := &survey.Confirm{
-		Message: fmt.Sprintf("Are you sure you want to delete the service account with ID '%v'?", opts.id),
+		Message: fmt.Sprintf("Are you sure you want to delete the service account with ID %v?", color.Info(opts.id)),
 	}
 
 	err = survey.AskOne(promptConfirmDelete, &confirmDelete)

--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -116,14 +117,14 @@ func runResetCredentials(opts *Options) (err error) {
 		// If the credentials file already exists, and the --overwrite flag is not set then return an error
 		// indicating that the user should explicitly request overwriting of the file
 		if _, err = os.Stat(opts.filename); err == nil && !opts.overwrite {
-			return fmt.Errorf("file '%v' already exists. Use --overwrite to overwrite the file, or --file-location to choose a custom location", opts.filename)
+			return fmt.Errorf("file %v already exists. Use --overwrite to overwrite the file, or --file-location to choose a custom location", color.Info(opts.filename))
 		}
 	}
 
 	// prompt the user to confirm their wish to proceed with this action
 	var confirmReset bool
 	promptConfirmDelete := &survey.Confirm{
-		Message: fmt.Sprintf("Are you sure you want to reset the credentials for the service account with ID '%v'?", opts.id),
+		Message: fmt.Sprintf("Are you sure you want to reset the credentials for the service account with ID %v?", color.Info(opts.id)),
 	}
 
 	if err = survey.AskOne(promptConfirmDelete, &confirmReset); err != nil {

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -1,0 +1,26 @@
+// Color package is for printing a uniform set of colors for the CLI
+package color
+
+import (
+	"github.com/fatih/color"
+)
+
+// CodeSnippet returns a colored string for code and command snippets
+func CodeSnippet(format string) string {
+	return color.HiMagentaString(format)
+}
+
+// Info returns a colored string for information messages
+func Info(format string) string {
+	return color.HiCyanString(format)
+}
+
+// Success returns a colored string for success messages
+func Success(format string) string {
+	return color.HiGreenString(format)
+}
+
+// Error returns a colored string for error messages
+func Error(format string) string {
+	return color.HiRedString(format)
+}

--- a/pkg/connection/errors.go
+++ b/pkg/connection/errors.go
@@ -1,15 +1,17 @@
 package connection
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 )
 
 var (
+	loginCmd = color.CodeSnippet("rhoas login")
 	// ErrNotLoggedIn defines when a user is not authenticated
-	ErrNotLoggedIn = errors.New("Not logged in. Run `rhoas login` to authenticate")
+	ErrNotLoggedIn = fmt.Errorf("Not logged in. Run %v to authenticate", loginCmd)
 	// ErrSessionExpired defines when a user's session has expired
-	ErrSessionExpired = errors.New("Session expired. Run `rhoas login` to authenticate")
+	ErrSessionExpired = fmt.Errorf("Session expired. Run %v to authenticate", loginCmd)
 )
 
 // AuthError defines an Authentication error

--- a/pkg/sdk/kafka/topics/topics.go
+++ b/pkg/sdk/kafka/topics/topics.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/connection"
 	pkgKafka "github.com/bf2fc6cc711aee1a0c2a/cli/pkg/kafka"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	serviceapi "github.com/bf2fc6cc711aee1a0c2a/cli/pkg/api/serviceapi/client"
-	"github.com/fatih/color"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
 )
@@ -174,8 +174,8 @@ func ListKafkaTopics(opts *Options) error {
 		topicPartition := &partitions[i]
 		replicas := strconv.Itoa(len(topicPartition.Replicas))
 		logger.Infof("Name: %v (Replicas: %v)\n",
-			color.HiGreenString(topicPartition.Topic),
-			color.HiRedString(replicas))
+			color.Success(topicPartition.Topic),
+			color.Info(replicas))
 	}
 
 	return nil

--- a/pkg/serviceaccount/credentials/credentials.go
+++ b/pkg/serviceaccount/credentials/credentials.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/color"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -143,7 +144,7 @@ func ChooseFileLocation(outputFormat string, filePath string, overwrite bool) (s
 		}
 
 		overwriteFilePrompt := &survey.Confirm{
-			Message: fmt.Sprintf("The file '%v' already exists. Do you want to overwrite it?", filePath),
+			Message: fmt.Sprintf("file %v already exists. Do you want to overwrite it?", color.Info(filePath)),
 		}
 
 		err = survey.AskOne(overwriteFilePrompt, &overwrite)


### PR DESCRIPTION
Closes #290 

This PR adds purpose-oriented functions to highlight a string in a color.

`CodeSnippet` - prints the string in high contrast magenta. Useful for highlighting code or commands.

![image](https://user-images.githubusercontent.com/11743717/105848607-20ede100-5fd7-11eb-9541-d109e622230b.png)

`Info` - general purpose information highlighting in high-contract cyan.

![image](https://user-images.githubusercontent.com/11743717/105848695-4975db00-5fd7-11eb-81d0-1cc283263606.png)


`Success` - (green) used to highlight a success message

![image](https://user-images.githubusercontent.com/11743717/105848344-bf2d7700-5fd6-11eb-8100-4132a39784b3.png)

`Error` - (red) used to highlight an error

![image](https://user-images.githubusercontent.com/11743717/105848557-09165d00-5fd7-11eb-8bc6-d92beedcedb9.png)
