### PR TITLE
fix: print only single topics

### DIFF
--- a/pkg/sdk/kafka/topics/topics.go
+++ b/pkg/sdk/kafka/topics/topics.go
@@ -170,8 +170,14 @@ func ListKafkaTopics(opts *Options) error {
 		return err
 	}
 
-	for i := range partitions {
-		topicPartition := &partitions[i]
+	uniquePartitions := make(map[string]kafka.Partition)
+
+	for idx := range partitions {
+		uniquePartitions[partitions[idx].Topic] = partitions[idx]
+	}
+
+	for idx := range uniquePartitions {
+		topicPartition := uniquePartitions[idx]
 		replicas := strconv.Itoa(len(topicPartition.Replicas))
 		logger.Infof("Name: %v (Replicas: %v)\n",
 			color.Success(topicPartition.Topic),


### PR DESCRIPTION
Temporary change that will reduce confusion on printed topics.


Verified
```
[wtrocki@graphapi rhmas (uniquetopics)]$ rhoas kafka topics list
Topics:
Name: strimzi-canary (Replicas: 3)
Name: __consumer_offsets (Replicas: 3)
Name: test (Replicas: 1)
```