### PR TITLE
fix(kafka delete): add async=true to ensure Kafka can be deleted

### DIFF
--- a/openapi/kafka-service.yaml
+++ b/openapi/kafka-service.yaml
@@ -69,6 +69,13 @@ paths:
       summary: Get a kafka request by id
     delete:
       operationId: deleteKafkaById
+      parameters:
+        - in: query
+          name: async
+          description: Perform the action in an asynchronous manner
+          schema:
+            type: boolean
+          required: true
       responses:
         "204":
           content:
@@ -78,6 +85,15 @@ paths:
               example:
               #No Content
           description: Deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                400DeletionExample:
+                  $ref: '#/components/examples/400DeletionExample'
+          description: Validation errors occurred
         "401":
           content:
             application/json:
@@ -1031,6 +1047,14 @@ components:
         name: "my-app-sa"
         description: "service account for my app"
         clientID: "SA-121212"
+    400DeletionExample:
+      value:
+        id: "103"
+        kind: "Error"
+        href: "/api/managed-services-api/v1/errors/103"
+        code: "MGD-SERV-API-103"
+        reason: "Synchronous action is not supported, use async=true parameter"
+        operation_id: "1iWIimqGcrDuL61aUxIZqBTqNRa"
     400CreationExample:
       value:
         id: "103"

--- a/pkg/api/kas/client/.openapi-generator/FILES
+++ b/pkg/api/kas/client/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .travis.yml
 README.md
 api/openapi.yaml

--- a/pkg/api/kas/client/api/openapi.yaml
+++ b/pkg/api/kas/client/api/openapi.yaml
@@ -25,6 +25,14 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Perform the action in an asynchronous manner
+        explode: true
+        in: query
+        name: async
+        required: true
+        schema:
+          type: boolean
+        style: form
       responses:
         "204":
           content:
@@ -32,6 +40,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Deleted
+        "400":
+          content:
+            application/json:
+              examples:
+                "400DeletionExample":
+                  $ref: '#/components/examples/400DeletionExample'
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Validation errors occurred
         "401":
           content:
             application/json:
@@ -802,6 +819,14 @@ components:
         name: my-app-sa
         description: service account for my app
         clientID: SA-121212
+    "400DeletionExample":
+      value:
+        id: "103"
+        kind: Error
+        href: /api/managed-services-api/v1/errors/103
+        code: MGD-SERV-API-103
+        reason: Synchronous action is not supported, use async=true parameter
+        operation_id: 1iWIimqGcrDuL61aUxIZqBTqNRa
     "400CreationExample":
       value:
         id: "103"

--- a/pkg/api/kas/client/api_default.go
+++ b/pkg/api/kas/client/api_default.go
@@ -516,6 +516,12 @@ type ApiDeleteKafkaByIdRequest struct {
 	ctx        _context.Context
 	ApiService DefaultApi
 	id         string
+	async      *bool
+}
+
+func (r ApiDeleteKafkaByIdRequest) Async(async bool) ApiDeleteKafkaByIdRequest {
+	r.async = &async
+	return r
 }
 
 func (r ApiDeleteKafkaByIdRequest) Execute() (Error, *_nethttp.Response, GenericOpenAPIError) {
@@ -563,7 +569,12 @@ func (a *DefaultApiService) DeleteKafkaByIdExecute(r ApiDeleteKafkaByIdRequest) 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	if r.async == nil {
+		executionError.error = "async is required and must be specified"
+		return localVarReturnValue, nil, executionError
+	}
 
+	localVarQueryParams.Add("async", parameterToString(*r.async, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -605,6 +616,16 @@ func (a *DefaultApiService) DeleteKafkaByIdExecute(r ApiDeleteKafkaByIdRequest) 
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v Error

--- a/pkg/api/kas/client/docs/DefaultApi.md
+++ b/pkg/api/kas/client/docs/DefaultApi.md
@@ -150,7 +150,7 @@ Name | Type | Description  | Notes
 
 ## DeleteKafkaById
 
-> Error DeleteKafkaById(ctx, id).Execute()
+> Error DeleteKafkaById(ctx, id).Async(async).Execute()
 
 Delete a kafka request by id
 
@@ -168,10 +168,11 @@ import (
 
 func main() {
     id := "id_example" // string | The id of record
+    async := true // bool | Perform the action in an asynchronous manner
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.DefaultApi.DeleteKafkaById(context.Background(), id).Execute()
+    resp, r, err := api_client.DefaultApi.DeleteKafkaById(context.Background(), id).Async(async).Execute()
     if err.Error() != "" {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteKafkaById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -197,6 +198,7 @@ Other parameters are passed through a pointer to a apiDeleteKafkaByIdRequest str
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
+ **async** | **bool** | Perform the action in an asynchronous manner | 
 
 ### Return type
 

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -133,7 +133,9 @@ func runDelete(opts *options) error {
 	}
 
 	logger.Debug("Deleting Kafka instance", kafkaName)
-	_, _, apiErr = api.Kafka().DeleteKafkaById(context.Background(), opts.id).Execute()
+	a := api.Kafka().DeleteKafkaById(context.Background(), opts.id)
+	a = a.Async(true)
+	_, _, apiErr = a.Execute()
 
 	if apiErr.Error() != "" {
 		return fmt.Errorf("Unable to delete Kafka instance: %w", apiErr)


### PR DESCRIPTION
Fixes https://github.com/bf2fc6cc711aee1a0c2a/cli/issues/313

This issue was caused by the fact that the Control Plane API changed so that `?async=true` is required to delete a Kafka instance. The CLI was still using an older version of the API.