### PR TITLE
fix(kafka delete): confirm name only to delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ openapi/strimzi-admin/generate:
 .PHONY: openapi/strimzi-admin/generate
 
 openapi/kas/pull:
-	wget -O ./openapi/kafka-service.yaml --no-check-certificate https://gitlab.cee.redhat.com/service/managed-services-api/-/raw/master/openapi/managed-services-api.yaml
+	wget -O ./openapi/kafka-service.yaml --no-check-certificate https://gitlab.cee.redhat.com/service/managed-services-api/-/raw/master/openapi/kafka-service.yaml
 .PHONY: openapi/kas/pull
 
 # validate the openapi schema

--- a/mas-mock/package.json
+++ b/mas-mock/package.json
@@ -9,7 +9,7 @@
     "start": "node ./src/index.js",
     "refresh": "../scripts/pullapi.sh",
     "test": "jest",
-    "api": "openapi-editor --file ../openapi/managed-services-api.yaml --port 10000"
+    "api": "openapi-editor --file ../openapi/kafka-service.yaml --port 10000"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/mas-mock/src/index.js
+++ b/mas-mock/src/index.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(express.json());
 
 // define api
-const api = new OpenAPIBackend({ definition: path.join(__dirname, "../../openapi/managed-services-api.yaml") });
+const api = new OpenAPIBackend({ definition: path.join(__dirname, "../../openapi/kafka-service.yaml") });
 
 // register handlers
 api.register(handlers);

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -104,21 +104,10 @@ func runDelete(opts *options) error {
 
 	kafkaName := response.GetName()
 
-	var confirmDeleteAction bool
-	var promptConfirmAction = &survey.Confirm{
-		Message: fmt.Sprintf("Are you sure you want to delete the Kafka instance %v?", color.Info(kafkaName)),
-	}
-
-	err = survey.AskOne(promptConfirmAction, &confirmDeleteAction)
-	if err != nil {
-		return err
-	}
-	if !confirmDeleteAction {
-		return nil
-	}
+	logger.Info("Deleting Kafka instance", color.Info(kafkaName), "\n")
 
 	var promptConfirmName = &survey.Input{
-		Message: "Confirm the name of the instance you want to permanently delete:",
+		Message: "Confirm the name of the instance you want to delete:",
 	}
 
 	var confirmedKafkaName string

--- a/scripts/pullapi.sh
+++ b/scripts/pullapi.sh
@@ -1,10 +1,10 @@
 
 echo "Synchronizing managed-services-api"
 
-wget --no-check-certificate https://gitlab.cee.redhat.com/service/managed-services-api/-/raw/master/openapi/managed-services-api.yaml
-mv managed-services-api.yaml ./openapi/managed-services-api.yaml
+wget --no-check-certificate https://gitlab.cee.redhat.com/service/managed-services-api/-/raw/master/openapi/kafka-service.yaml
+mv kafka-service.yaml ./openapi/kafka-service.yaml
 
 ## Copy api to mock
-cp ./openapi/managed-services-api.yaml ./mas-mock/managed-services-api.yaml
+cp ./openapi/kafka-service.yaml ./mas-mock/kafka-service.yaml
 
 echo "Finished synchronization with managed-services-api"


### PR DESCRIPTION
This PR removes the two-step delete verification as it was overkill and did not align with the same flow as the UI.