### PR TITLE
fix: add ability to force delete

### DIFF
--- a/docs/commands/rhoas_kafka_create.adoc
+++ b/docs/commands/rhoas_kafka_create.adoc
@@ -5,7 +5,9 @@ Create a Kafka instance
 === Synopsis
 
 Create a Kafka instance with custom configuration values, otherwise use
-default values. The created instance is then set in the config as the current Kafka instance.
+default values.
+
+The created instance is set in the config as the current Kafka instance.
 
 Configuration options available: name, cloud provider, region.
 

--- a/docs/commands/rhoas_kafka_delete.adoc
+++ b/docs/commands/rhoas_kafka_delete.adoc
@@ -23,6 +23,7 @@ $ rhoas kafka delete --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 === Options
 
 ....
+  -f, --force       Force delete this Kafka instance, bypassing verification
   -h, --help        help for delete
       --id string   ID of the Kafka instance you want to delete. If not set, the current Kafka instance will be used
 ....

--- a/docs/commands/rhoas_serviceaccount_delete.adoc
+++ b/docs/commands/rhoas_serviceaccount_delete.adoc
@@ -20,6 +20,7 @@ $ rhoas serviceaccount delete --id 173c1ad9-932d-4007-ae0f-4da74f4d2ccd
 === Options
 
 ....
+  -f, --force       Force delete this service account, bypassing verification
   -h, --help        help for delete
       --id string   The unique ID of the service account to delete
 ....

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -20,7 +20,8 @@ import (
 )
 
 type options struct {
-	id string
+	id    string
+	force bool
 
 	Config     config.IConfig
 	Connection func() (connection.Connection, error)
@@ -71,6 +72,7 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.id, "id", "", "ID of the Kafka instance you want to delete. If not set, the current Kafka instance will be used")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation to force delete this Kafka instance")
 
 	return cmd
 }
@@ -106,19 +108,21 @@ func runDelete(opts *options) error {
 
 	logger.Info("Deleting Kafka instance", color.Info(kafkaName), "\n")
 
-	var promptConfirmName = &survey.Input{
-		Message: "Confirm the name of the instance you want to delete:",
-	}
+	if !opts.force {
+		var promptConfirmName = &survey.Input{
+			Message: "Confirm the name of the instance you want to delete:",
+		}
 
-	var confirmedKafkaName string
-	err = survey.AskOne(promptConfirmName, &confirmedKafkaName)
-	if err != nil {
-		return err
-	}
+		var confirmedKafkaName string
+		err = survey.AskOne(promptConfirmName, &confirmedKafkaName)
+		if err != nil {
+			return err
+		}
 
-	if confirmedKafkaName != kafkaName {
-		logger.Info("The name you entered does not match the name of the Kafka instance that you are trying to delete. Please check that it correct and try again.")
-		return nil
+		if confirmedKafkaName != kafkaName {
+			logger.Info("The name you entered does not match the name of the Kafka instance that you are trying to delete. Please check that it correct and try again.")
+			return nil
+		}
 	}
 
 	logger.Debug("Deleting Kafka instance", kafkaName)


### PR DESCRIPTION
This PR makes it possible to forcefully delete service accounts and Kafkas with `--force`