### PR TITLE
ci(goreleaser): reduce the number of release binary options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,9 +2,10 @@ project_name: rhoas
 
 release:
   prerelease: auto
+  draft: true
   name_template: "{{.Version}}"
 
-before:
+before:\
   hooks:
     - go mod download
     - go mod tidy
@@ -25,14 +26,14 @@ builds:
   - <<: *build_defaults
     id: linux
     goos: [linux]
-    goarch: [386, arm, amd64, arm64]
+    goarch: [amd64]
     env:
       - CGO_ENABLED=0
 
   - <<: *build_defaults
     id: windows
     goos: [windows]
-    goarch: [386, amd64]
+    goarch: [amd64]
 
 archives:
   - id: nix


### PR DESCRIPTION
This PR removes support for ARm architectures and 32-bit systems.