### PR TITLE
fix: do not throw error when --force is passed

### DIFF
--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -45,8 +45,13 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		Example: localizer.MustLocalizeFromID("kafka.delete.cmd.example"),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !opts.IO.CanPrompt() {
-				return fmt.Errorf(localizer.MustLocalizeFromID("flag.error.requiredWhenNonInteractive"))
+			if !opts.IO.CanPrompt() && !opts.force {
+				return fmt.Errorf(localizer.MustLocalize(&localizer.Config{
+					MessageID: "flag.error.requiredWhenNonInteractive",
+					TemplateData: map[string]interface{}{
+						"Flag": "force",
+					},
+				}))
 			}
 
 			cfg, err := opts.Config.Load()

--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -66,7 +66,12 @@ func NewDeleteTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if !opts.IO.CanPrompt() && !opts.force {
-				return errors.New(localizer.MustLocalizeFromID("kafka.topic.error.forceFlagRequired"))
+				return fmt.Errorf(localizer.MustLocalize(&localizer.Config{
+					MessageID: "flag.error.requiredWhenNonInteractive",
+					TemplateData: map[string]interface{}{
+						"Flag": "force",
+					},
+				}))
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/serviceaccount/delete/delete.go
+++ b/pkg/cmd/serviceaccount/delete/delete.go
@@ -39,6 +39,15 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		Long:    localizer.MustLocalizeFromID("serviceAccount.delete.cmd.longDescription"),
 		Example: localizer.MustLocalizeFromID("serviceAccount.delete.cmd.example"),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !opts.IO.CanPrompt() && !opts.force {
+				return fmt.Errorf(localizer.MustLocalize(&localizer.Config{
+					MessageID: "flag.error.requiredWhenNonInteractive",
+					TemplateData: map[string]interface{}{
+						"Flag": "force",
+					},
+				}))
+			}
+
 			return runDelete(opts)
 		},
 	}


### PR DESCRIPTION
Fixes #390 

This was throwing a validation error when the CLI was being running in a non-TTY environment. The fix just required an additional check for the force flag.

**Verification**

Run `rhoas kafka delete` with stdin closed and you will get an error to say interactive mode is not available:

```shell
❯ true | (setsid ./rhoas kafka delete) 2>&1 | cat
Error: --force required when not running interactively
```

Run it agin with `--force` and it will work:

```shell
❯ true | (setsid ./rhoas kafka delete -f) 2>&1 | cat
Deleting Kafka instance "ajay-test"
```