### PR TITLE
fix: replace mitchellh/go-homedir with os.UserHomeDir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nicksnyder/go-i18n/v2 v2.1.2
 	github.com/openconfig/goyang v0.2.4
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/localizer"
-	"github.com/mitchellh/go-homedir"
 )
 
 // NewFile creates a new config type
@@ -87,7 +86,7 @@ func (c *File) Location() (path string, err error) {
 	if rhoasConfig := os.Getenv("RHOASCLI_CONFIG"); rhoasConfig != "" {
 		path = rhoasConfig
 	} else {
-		home, err := homedir.Dir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -24,8 +24,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/connection"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
@@ -58,7 +56,7 @@ func NewKubernetesClusterConnection(connection connection.Connection, config con
 	}
 
 	if kubeconfig == "" {
-		home, _ := homedir.Dir()
+		home, _ := os.UserHomeDir()
 		kubeconfig = filepath.Join(home, ".kube", "config")
 	}
 


### PR DESCRIPTION
Use `os.UserHomeDir` to get the current user's home directory.

fixes #396 