### PR TITLE
fix: Add  bindAsFiles by default and enforce proper name for right mo…

### DIFF
--- a/locales/cluster/kubernetes/active.en.toml
+++ b/locales/cluster/kubernetes/active.en.toml
@@ -60,7 +60,7 @@ by creating Service Binding (requires ServiceBindingOperator):
 apiVersion: binding.operators.coreos.com/v1alpha1
 kind: ServiceBinding
 metadata:
-  name: {{.Name}}-binding
+  name: kafka-config
   namespace: {{.Namespace}}
 spec:
   application:
@@ -68,7 +68,8 @@ spec:
     name: name-of-your-application
     resource: deployments
     version: v1
-
+    
+  bindAsFiles: true
   services:
   - group: {{.Group}}
     version: {{.Version}}


### PR DESCRIPTION
…unt path

We need to enforce name so binding will appear in /bindings/kafka-config/ rather than location generated by the user