### PR TITLE
ci(windows): add MSI installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,39 @@ jobs:
         id: download_exe
         shell: bash
         run: |
-          curl -s "${GITHUB_REF#refs/tags}" -i 'windows_amd64.zip'
+          hub release download "${GITHUB_REF#refs/tags/}" -i '*windows_amd64*.zip'
+          printf "::set-output name=zip::%s\n" *.zip
+          unzip -o *.zip && rm -v *.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install go-msi
+        run: choco install -y "go-msi"
+      - name: Prepare PATH
+        shell: bash
+        run: |
+          echo "$WIX\\bin" >> $GITHUB_PATH
+          echo "C:\\Program Files\\go-msi" >> $GITHUB_PATH
+      - name: Build MSI
+        id: buildmsi
+        shell: bash
+        run: |
+          mkdir -p build
+          msi="$(basename "${{ steps.download_exe.outputs.zip }}" ".zip").msi"
+          printf "::set-output name=msi::%s\n" "$msi"
+          go-msi make --msi "$PWD/$msi" --out "$PWD/build" --version "${GITHUB_REF#refs/tags/}"
+      - name: Obtain signing cert
+        id: obtain_cert
+        env:
+          DESKTOP_CERT_TOKEN: ${{ secrets.DESKTOP_CERT_TOKEN }}
+        run: .\script\setup-windows-certificate.ps1
+      - name: Sign MSI
+        env:
+          GITHUB_CERT_PASSWORD: ${{ secrets.GITHUB_CERT_PASSWORD }}
+        run: |
+          .\script\sign.ps1 -Certificate "${{ steps.obtain_cert.outputs.cert-file }}" `
+            -Executable "${{ steps.buildmsi.outputs.msi }}"
+      - name: Upload MSI
+        shell: bash
+        run: hub release edit "${GITHUB_REF#refs/tags/}" -m "" --draft=false -a "${{ steps.buildmsi.outputs.msi }}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Inspired by https://github.com/cli/cli/blob/trunk/.github/workflows/releases.yml#L111

I am not sure if this will work, do not have a Windows device to test it locally with Act.