### PR TITLE
fix(kafka topic): display missing columns from topic list

### DIFF
--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -35,6 +35,8 @@ type Options struct {
 type topicRow struct {
 	Name            string `json:"name,omitempty" header:"Name"`
 	PartitionsCount int    `json:"partitions_count,omitempty" header:"Partitions"`
+	RetentionTime   string `json:"retention.ms,omitempty" header:"Retention time"`
+	RetentionSize   string `json:"retention.bytes,omitempty" header:"Retention size"`
 }
 
 // NewListTopicCommand gets a new command for getting kafkas.
@@ -168,9 +170,22 @@ func mapTopicResultsToTableFormat(topics []strimziadminclient.Topic) []topicRow 
 	var rows []topicRow = []topicRow{}
 
 	for _, t := range topics {
+		var RetentionTime, RetentionSize string
+
+		for _, config := range t.GetConfig() {
+			if *config.Key == "retention.ms" {
+				RetentionTime = *config.Value
+			}
+			if *config.Key == "retention.bytes" {
+				RetentionSize = *config.Value
+			}
+		}
+
 		row := topicRow{
 			Name:            t.GetName(),
 			PartitionsCount: len(t.GetPartitions()),
+			RetentionTime:   RetentionTime,
+			RetentionSize:   RetentionSize,
 		}
 		rows = append(rows, row)
 	}


### PR DESCRIPTION
### Description

Add missing columns to the topic list table (retention period and retention size).

![Screenshot from 2021-03-16 16-38-57](https://user-images.githubusercontent.com/23582438/111299607-28944280-8676-11eb-9de5-bc0d90f92c1a.png)

Fixes #459 

### Verification Steps

1. Run `go run ./cmd/rhoas kafka use <instance name>` to select a Kafka instance.
2. After an instance is selected, run `go run ./cmd/rhoas kafka topic list` to view the kafka topics in a tabular list.
3. The Kafka topic list table should have 4 columns - `NAME`, `PARTITIONS`, `RETENTION TIME` and `RETENTION SIZE`.

### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer