### PR TITLE
fix: show 500 message from admin server

### DIFF
--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -190,7 +190,7 @@ func runCmd(opts *Options) error {
 				},
 			}))
 		case 500:
-			return errors.New(localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"))
+			return fmt.Errorf("%v: %w", localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"), topicErr)
 		case 503:
 			return fmt.Errorf("%v: %w", localizer.MustLocalize(&localizer.Config{
 				MessageID: "kafka.topic.common.error.unableToConnectToKafka",

--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -193,7 +193,7 @@ func runCmd(opts *Options) error {
 				},
 			}))
 		case 500:
-			return errors.New(localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"))
+			return fmt.Errorf("%v: %w", localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"), topicErr)
 		case 503:
 			return fmt.Errorf("%v: %w", localizer.MustLocalize(&localizer.Config{
 				MessageID: "kafka.topic.common.error.unableToConnectToKafka",

--- a/pkg/cmd/kafka/topic/describe/describe.go
+++ b/pkg/cmd/kafka/topic/describe/describe.go
@@ -151,7 +151,7 @@ func runCmd(opts *Options) error {
 				},
 			}))
 		case 500:
-			return errors.New(localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"))
+			return fmt.Errorf("%v: %w", localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"), topicErr)
 		case 503:
 			return fmt.Errorf("%v: %w", localizer.MustLocalize(&localizer.Config{
 				MessageID: "kafka.topic.common.error.unableToConnectToKafka",

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -293,7 +293,7 @@ func runCmd(opts *Options) error {
 				},
 			}))
 		case 500:
-			return errors.New(localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"))
+			return fmt.Errorf("%v: %w", localizer.MustLocalizeFromID("kafka.topic.common.error.internalServerError"), topicErr)
 		case 503:
 			return fmt.Errorf("%v: %w", localizer.MustLocalize(&localizer.Config{
 				MessageID: "kafka.topic.common.error.unableToConnectToKafka",


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and a link to the GitHub issue. You can use the closing keywords to link a pull request to an issue: [https://docs.github.com/en/enterprise/2.18/user/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue].

Please add any additional motivation and context as needed. Screenshots are also welcome -->

The admin server 500 message was not being shown in the CLI.

### Verification Steps

N/A

### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer