### PR TITLE
docs: fix the link to guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for the RHOAS CLI.
 
 ## Guides
 
-See our [Guides](https://github.com/bf2fc6cc711aee1a0c2a/guides/tree/cli-guides/rhoas-cli) for installation and usage instructions.
+See our [Guides](https://github.com/bf2fc6cc711aee1a0c2a/guides/tree/main/rhoas-cli) for installation and usage instructions.
 
 ## Commands
 


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and a link to the GitHub issue. You can use the closing keywords to link a pull request to an issue: [https://docs.github.com/en/enterprise/2.18/user/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue].

Please add any additional motivation and context as needed. Screenshots are also welcome -->

I think the link should point to the main branch of the guides repo

### Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer