### PR TITLE
fix(config): check if .config directory exists

### DIFF
--- a/internal/config/util.go
+++ b/internal/config/util.go
@@ -18,10 +18,7 @@ func getUserConfig(name string) (string, error) {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", name), nil
 	case "linux":
-		baseDir := os.Getenv("XDG_CONFIG_HOME")
-		if baseDir == "" {
-			baseDir = filepath.Join(os.Getenv("HOME"), ".config")
-		}
+		baseDir := getLinuxConfigBaseDir()
 		return filepath.Join(baseDir, name), nil
 	default:
 		return "", errors.New(localizer.MustLocalize(&localizer.Config{
@@ -31,4 +28,19 @@ func getUserConfig(name string) (string, error) {
 			},
 		}))
 	}
+}
+
+// Gets the config directory for Linux
+func getLinuxConfigBaseDir() string {
+	baseDir := os.Getenv("XDG_CONFIG_HOME")
+	if baseDir != "" {
+		return baseDir
+	}
+	baseDir = filepath.Join(os.Getenv("HOME"), ".config")
+	// The config directory does not exist on the current environment
+	// use the HOME directory
+	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
+		baseDir = os.Getenv("HOME")
+	}
+	return baseDir
 }


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and a link to the GitHub issue. You can use the closing keywords to link a pull request to an issue: [https://docs.github.com/en/enterprise/2.18/user/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue].

Please add any additional motivation and context as needed. Screenshots are also welcome -->

Fixes #497

### Verification Steps

1. Rename `.config` directory: `mv $HOME/.config $HOME/.config.bk`
2. Remove any old config at `$HOME/.rhoascli.json`
3. Run `rhoas login`
4. Check if the config has been created at `$HOME/.rhoascli.json`
5. If it has, this works! Restore your config.

### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [] Documentation added for the feature~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer