### PR TITLE
feat: add support for generating modular docs

### DIFF
--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -1,0 +1,25 @@
+# This workflow will generate modular docs and publish to the modular-docs branch
+
+name: Modular docs publish
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Source
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+      - run: make docs/generate-modular-docs
+        name: Generate modular-docs
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: modular-docs # The branch the action should deploy to.
+          folder: dist # The folder the action should deploy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,11 @@ make docs/generate
 
 #### `make docs/generate`
 
-After running the command, the documentation should be updated with the command using markdown and then transformed to Asciidocs.
+After running the command, the documentation should be generated in AsciiDoc format.
+
+#### `make docs/generate-modular-docs`
+
+After running the command, the `dist` directory will contain the documentation conforming to the modular docs specification.
 
 ## Best practices
 

--- a/Makefile
+++ b/Makefile
@@ -154,3 +154,7 @@ docs/check: docs/generate
 docs/generate:
 	GENERATE_DOCS=true go run ./cmd/rhoas
 .PHONY: docs/generate
+
+docs/generate-modular-docs: docs/generate
+	SRC_DIR=$$(pwd)/docs/commands DEST_DIR=$$(pwd)/dist go run ./cmd/modular-docs
+.PHONY: docs/generate-modular-docs

--- a/cmd/modular-docs/main.go
+++ b/cmd/modular-docs/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/docs"
+	"os"
+)
+
+func main() {
+	err := docs.CreateModularDocs()
+	if err != nil {
+		fmt.Print(err.Error())
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.1.2
 	github.com/openconfig/goyang v0.2.4
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/internal/docs/modular_docs.go
+++ b/internal/docs/modular_docs.go
@@ -1,0 +1,149 @@
+package docs
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+// Create Modular Documentation from the CLI generated docs
+func CreateModularDocs() error {
+	srcDir := os.Getenv("SRC_DIR")
+	if srcDir == "" {
+		return errors.New("SRC_DIR must be set")
+	}
+	files, err := filepath.Glob(fmt.Sprintf("%s/*.adoc", srcDir))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	outDir := os.Getenv("DEST_DIR")
+	if outDir == "" {
+		outDir = "dist"
+	}
+	modulesDir := path.Join(outDir, "modules")
+	err = os.RemoveAll(modulesDir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = os.MkdirAll(modulesDir, 0755)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	moduleFiles, err := CreateModules(modulesDir, files)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	assembliesDir := path.Join(outDir, "assemblies")
+	err = os.RemoveAll(assembliesDir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = os.MkdirAll(assembliesDir, 0755)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = CreateAssembly(assembliesDir, moduleFiles)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func CreateModules(modulesDir string, commandAdocFiles []string) ([]string, error) {
+	answer := make([]string, 0)
+	for _, f := range commandAdocFiles {
+		destName := fmt.Sprintf("ref-cli%s", strings.Replace(strings.ReplaceAll(filepath.Base(f), "_", "-"), "rhoas", "", 1))
+		destPath := path.Join(modulesDir, destName)
+		_, err := copyFile(f, destPath)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		answer = append(answer, destPath)
+	}
+	return answer, nil
+}
+
+func CreateAssembly(assembliesDir string, files []string) error {
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i] < files[j]
+	})
+
+	commandFileNames := make([]string, 0)
+
+	for _, f := range files {
+		relPath, err := filepath.Rel(assembliesDir, f)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		commandFileNames = append(commandFileNames, relPath)
+	}
+
+	contentTemplate := `[id="cli-command-reference_{context}"]
+= CLI command reference
+
+[role="_abstract"]
+You use the ` + "`rhoas`" + ` CLI to manage your application services from the command line.
+
+{{ range .Commands}}
+include::{{.}}[leveloffset=+1]
+{{ end }}
+`
+	type Vars struct {
+		Commands []string
+	}
+
+	vars := Vars{
+		Commands: commandFileNames,
+	}
+
+	filename := "assembly-cli-command-reference.adoc"
+	output, err := os.Create(path.Join(assembliesDir, filename))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = template.Must(template.New("content").Parse(contentTemplate)).Execute(output, vars)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = output.Sync()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
+}


### PR DESCRIPTION
### Description
Add support for converting the docs produced by the Command Line Interface docs generator to the "modular docs" format and pushing them to the `modular-docs` branch on very push to main. This allows other systems to then pick them up as needed.

### Verification Steps
1. Run `make docs/generate-modular-docs`
2. Inspect the output in `dist`
3. On merging the PR, the branch `modular-docs` should be populated with the contents of the dist dir

### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer