### PR TITLE
[DO NOT MERGE] Add description to created service account

### DIFF
--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -339,7 +339,9 @@ func (c *KubernetesCluster) createServiceAccount(ctx context.Context) (*kasclien
 	t := time.Now()
 
 	api := c.connection.API()
-	serviceAcct := &kasclient.ServiceAccountRequest{Name: fmt.Sprintf("svc-acct-%v", t.String())}
+	svcAcctname := fmt.Sprintf("svc-acct-%v", t.String())
+	description := "service account"
+	serviceAcct := &kasclient.ServiceAccountRequest{Name: svcAcctname, Description: &description}
 	req := api.Kafka().CreateServiceAccount(ctx)
 	req = req.ServiceAccountRequest(*serviceAcct)
 	res, _, apiErr := req.Execute()

--- a/pkg/cmd/insecure/flag.go
+++ b/pkg/cmd/insecure/flag.go
@@ -1,0 +1,26 @@
+// This file contains functions used to implement the '--insecure' command line option.
+
+package insecure
+
+import (
+	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/localizer"
+	"github.com/spf13/pflag"
+)
+
+// AddFlag adds the debug flag to the given set of command line flags.
+func AddFlag(flags *pflag.FlagSet) {
+	flags.BoolVar(
+		&insecure,
+		"insecure",
+		false,
+		localizer.MustLocalizeFromID("login.flag.insecure"),
+	)
+}
+
+// Insecure returns a boolean flag that indicates if the insecure mode is enabled
+func Insecure() *bool {
+	return &insecure
+}
+
+// insecure is a boolean flag that indicates that the debug mode is insecure
+var insecure bool

--- a/pkg/httputil/logging_round_tripper.go
+++ b/pkg/httputil/logging_round_tripper.go
@@ -1,0 +1,21 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type LoggingRoundTripper struct {
+	Proxied http.RoundTripper
+}
+
+func (c LoggingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := c.Proxied.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(*resp)
+
+	return resp, nil
+}


### PR DESCRIPTION
This PR is not to be merged, but allows people to try out the `rhoas cluster connect` command. This functionality needs to be fixed server side.

1. Install binary using `make install`.
2. Run `which rhoas` to ensure that you are using the one in `~/go/bin`.
3. Execute "rhoas" commands.
