### PR TITLE
fix(serviceaccount): fix invalid i18n message

### DIFF
--- a/pkg/cmd/flag/flag.go
+++ b/pkg/cmd/flag/flag.go
@@ -18,6 +18,7 @@ func (e *Error) Unwrap() error {
 	return e.Err
 }
 
+// InvalidValueError returns an error when an invalid flag value is provided
 func InvalidValueError(flag string, val interface{}, validOptions ...string) *Error {
 	var chooseFromStr string
 	if len(validOptions) > 0 {

--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/localizer"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/flag"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 	"github.com/spf13/cobra"
 )
@@ -73,13 +74,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 			// check that a valid --file-format flag value is used
 			validOutput := flagutil.IsValidInput(opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			if !validOutput && opts.fileFormat != "" {
-				return fmt.Errorf(localizer.MustLocalize(&localizer.Config{
-					MessageID: "flag.error.invalidValue",
-					TemplateData: map[string]interface{}{
-						"Flag":  "file-format",
-						"Value": opts.fileFormat,
-					},
-				}))
+				return flag.InvalidValueError("file-format", opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			}
 
 			return runCreate(opts)

--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/config"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/internal/localizer"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/factory"
+	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/cmd/flag"
 	"github.com/bf2fc6cc711aee1a0c2a/cli/pkg/logging"
 	"github.com/spf13/cobra"
 )
@@ -72,13 +73,7 @@ func NewResetCredentialsCommand(f *factory.Factory) *cobra.Command {
 
 			validOutput := flagutil.IsValidInput(opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			if !validOutput && opts.fileFormat != "" {
-				return fmt.Errorf(localizer.MustLocalize(&localizer.Config{
-					MessageID: "flag.error.invalidValue",
-					TemplateData: map[string]interface{}{
-						"Flag":  "file-format",
-						"Value": opts.fileFormat,
-					},
-				}))
+				return flag.InvalidValueError("file-format", opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			}
 
 			return runResetCredentials(opts)


### PR DESCRIPTION
### Description

fixes #462 

### Verification Steps
1. Run `rhoas serviceaccount create --file-format sdfk`

You should get the following error: `Error: invalid value "sdfk" for --file-format, valid options are: "env", "json", "properties", "kubernetes-secret"`

2. Run `rhoas serviceaccount reset-credentials --file-format sdfk`

You should get the following error: `Error: invalid value "sdfk" for --file-format, valid options are: "env", "json", "properties", "kubernetes-secret"`

### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~- [ ] Documentation added for the feature~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer