### PR TITLE
fix(topic): set default retention to 7 days

### DIFF
--- a/docs/commands/rhoas_kafka_topic_create.adoc
+++ b/docs/commands/rhoas_kafka_topic_create.adoc
@@ -29,7 +29,7 @@ $ rhoas kafka topic create topic-1
 ....
   -o, --output string      Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
       --partitions int32   The number of partitions in the topic (default 1)
-      --retention-ms int   The period of time in milliseconds the broker will retain a partition log before deleting it (default -1)
+      --retention-ms int   The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)
 ....
 
 === Options inherited from parent commands

--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	Partitions = "partitions"
-	Replicas   = "replicas"
+	defaultRetentionPeriodMS = 604800000
 )
 
 type Options struct {
@@ -116,7 +115,7 @@ func NewCreateTopicCommand(f *factory.Factory) *cobra.Command {
 		MessageID: "kafka.topic.common.flag.output.description",
 	}))
 	cmd.Flags().Int32Var(&opts.partitions, "partitions", 1, localizer.MustLocalizeFromID("kafka.topic.common.input.partitions.description"))
-	cmd.Flags().IntVar(&opts.retentionMs, "retention-ms", -1, localizer.MustLocalizeFromID("kafka.topic.common.input.retentionMs.description"))
+	cmd.Flags().IntVar(&opts.retentionMs, "retention-ms", defaultRetentionPeriodMS, localizer.MustLocalizeFromID("kafka.topic.common.input.retentionMs.description"))
 
 	return cmd
 }
@@ -278,7 +277,7 @@ func runInteractivePrompt(opts *Options) (err error) {
 	retentionPrompt := &survey.Input{
 		Message: localizer.MustLocalizeFromID("kafka.topic.common.input.retentionMs.message"),
 		Help:    localizer.MustLocalizeFromID("kafka.topic.common.input.retentionMs.description"),
-		Default: "-1",
+		Default: fmt.Sprintf("%v", defaultRetentionPeriodMS),
 	}
 
 	err = survey.AskOne(retentionPrompt, &opts.retentionMs, survey.WithValidator(topic.ValidateMessageRetentionPeriod))

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -159,7 +159,6 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", localizer.MustLocalize(&localizer.Config{
 		MessageID: "kafka.topic.common.flag.output.description",
 	}))
-	// cmd.Flags().StringVar(&opts.partitionsStr, "partitions", "", localizer.MustLocalizeFromID("kafka.topic.common.flag.partitions.description"))
 	cmd.Flags().StringVar(&opts.retentionMsStr, "retention-ms", "", localizer.MustLocalizeFromID("kafka.topic.common.input.retentionMs.description"))
 
 	return cmd


### PR DESCRIPTION
### Description

This aligns the default value to match that set in the UI.

### Verification Steps

1. Create a topic and do not enter a value for retention-ms
2. The created topic will have a retention period of 604800000 (7 days)

### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer