### PR TITLE
fix: increase timeout for watching managed kafka to 60 seconds

### DIFF
--- a/pkg/cluster/mkcManager.go
+++ b/pkg/cluster/mkcManager.go
@@ -146,7 +146,7 @@ func watchForKafkaStatus(c *KubernetesCluster, crName string, namespace string) 
 				}
 			}
 
-		case <-time.After(30 * time.Second):
+		case <-time.After(60 * time.Second):
 			w.Stop()
 			return fmt.Errorf(localizer.MustLocalizeFromID("cluster.kubernetes.watchForKafkaStatus.error.timeout"))
 		}


### PR DESCRIPTION
When performing tests on the sandbox environment  and when our API was under some load we noticed that sometimes it takes very long time to get response.
This can even get worse at the time of summit so I'm extending timeout to 60 seconds

 