### PR TITLE
fix: lint error

### DIFF
--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -103,6 +103,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	return cmd
 }
 
+// nolint:funlen
 func runCreate(opts *Options) error {
 	logger, err := opts.Logger()
 	if err != nil {


### PR DESCRIPTION
### Description

Fixed linting error for `cli/pkg/cmd/serviceaccount/create/create.go`

### Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~- [ ] Documentation added for the feature~~
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer