### PR TITLE
fix: switch to new mas-sso url

### DIFF
--- a/docs/commands/rhoas_login.adoc
+++ b/docs/commands/rhoas_login.adoc
@@ -33,7 +33,7 @@ $ rhoas login --print-sso-url
       --auth-url string       The URL of the SSO Authentication server. (default "https://sso.redhat.com/auth/realms/redhat-external")
       --client-id string      OpenID client identifier (default "rhoas-cli-prod")
       --insecure              Enables insecure communication with the server. This disables verification of TLS certificates and host names.
-      --mas-auth-url string   The URL of the MAS-SSO Authentication server. (default "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org/auth/realms/mas-sso-staging")
+      --mas-auth-url string   The URL of the MAS-SSO Authentication server. (default "https://keycloak-mas-sso-stage.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/auth/realms/rhoas")
       --print-sso-url         Prints the console login URL, which you can use to log in to RHOAS from a different web browser. This is useful if you need to log in with different credentials than the credentials you used in your default web browser.
       --scope stringArray     Override the default OpenID scope. To specify multiple scopes, use a separate --scope for each scope. (default [openid])
       --skip-mas-login        Skip logging in to MAS-SSO

--- a/pkg/connection/keycloak_connection.go
+++ b/pkg/connection/keycloak_connection.go
@@ -34,7 +34,7 @@ const (
 	// SSO defaults
 	DefaultAuthURL = "https://sso.redhat.com/auth/realms/redhat-external"
 	// MAS SSO defaults
-	DefaultMasAuthURL = "https://keycloak-edge-redhat-rhoam-user-sso.apps.mas-sso-stage.1gzl.s1.devshift.org/auth/realms/mas-sso-staging"
+	DefaultMasAuthURL = "https://keycloak-mas-sso-stage.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/auth/realms/rhoas"
 )
 
 var DefaultScopes = []string{


### PR DESCRIPTION
BREAKING CHANGE: This change will mean that old Kafka instances are inaccessible without overriding the MAS-SSO URL

### Description
Migrates to new Single Sign-on URL.

Hold merging until we get the all clear from @akoserwal 

### Verification Steps
1. Run `rhoas login`
2. Validate that it visits the new URL
3. Use the Command Line Interface to list the topics on a NEW Kafka instance
4. 
### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer