### PR TITLE
chore: disable consumergroup commands which are not ready

### DIFF
--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -14,7 +14,6 @@ Create, view, use, and manage your Apache Kafka instances
 === SEE ALSO
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
-* link:rhoas_kafka_consumergroup{relfilesuffix}[rhoas kafka consumergroup]	 - Describe, update, list, and delete consumer groups for the current Kafka instance.
 * link:rhoas_kafka_create{relfilesuffix}[rhoas kafka create]	 - Create an Apache Kafka instance
 * link:rhoas_kafka_delete{relfilesuffix}[rhoas kafka delete]	 - Delete an Apache Kafka instance
 * link:rhoas_kafka_describe{relfilesuffix}[rhoas kafka describe]	 - View configuration details of an Apache Kafka instance

--- a/pkg/cmd/kafka/kafka.go
+++ b/pkg/cmd/kafka/kafka.go
@@ -3,7 +3,6 @@
 package kafka
 
 import (
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic"
 	// "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic"
 	"github.com/spf13/cobra"
@@ -31,7 +30,8 @@ func NewKafkaCommand(f *factory.Factory) *cobra.Command {
 		list.NewListCommand(f),
 		use.NewUseCommand(f),
 		topic.NewTopicCommand(f),
-		consumergroup.NewConsumerGroupCommand(f),
+		// disabled for now as consumer group API is not in production
+		// consumergroup.NewConsumerGroupCommand(f),
 	)
 
 	return cmd


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and a link to the GitHub issue. You can use the closing keywords to link a pull request to an issue: [https://docs.github.com/en/enterprise/2.18/user/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue].

Please add any additional motivation and context as needed. Screenshots are also welcome -->

### Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer