### PR TITLE
chore: update paths

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
       binary: bin/rhoas
       main: ./cmd/rhoas
       ldflags:
-        - -s -w -X github.com/bf2fc6cc711aee1a0c2a/cli/internal/build.Version={{.Version}}
+        - -s -w -X github.com/redhat-developer/app-services-cli/internal/build.Version={{.Version}}
     id: macos
     goos: [darwin]
     goarch: [amd64]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for the RHOAS CLI.
 
 ## Guides
 
-See our [Guides](https://github.com/bf2fc6cc711aee1a0c2a/guides/tree/main/rhoas-cli) for installation and usage instructions.
+See our [Guides](https://github.com/redhat-developer/app-services-guides/tree/main/rhoas-cli) for installation and usage instructions.
 
 ## Commands
 


### PR DESCRIPTION
A path was not updated in the GoReleaser file, causing the build version to be "dev" in a 0.21.1.