### PR TITLE
fix: use direct link to the operator repository in the status

### DIFF
--- a/locales/cmd/cluster/status/active.en.toml
+++ b/locales/cmd/cluster/status/active.en.toml
@@ -34,5 +34,5 @@ Command requires configuration using kubeconfig for Kubernetes cluster running R
 Operator can be installed using OperatorHub.
 You can find operator by typing "rhoas" in search.
 
-For more information please refer to https://operatorhub.io/how-to-install-an-operator
+For more information please visit Operator Github repository: https://github.com/redhat-developer/app-services-operator
 '''

--- a/locales/cmd/cluster/status/active.en.toml
+++ b/locales/cmd/cluster/status/active.en.toml
@@ -34,5 +34,5 @@ Command requires configuration using kubeconfig for Kubernetes cluster running R
 Operator can be installed using OperatorHub.
 You can find operator by typing "rhoas" in search.
 
-For more information please visit Operator Github repository: https://github.com/redhat-developer/app-services-operator
+For more information please visit Operator GitHub repository: https://github.com/redhat-developer/app-services-operator
 '''


### PR DESCRIPTION
Update link to the operator from the status