### PR TITLE
docs: update title for mod doc cli guide

### DIFF
--- a/internal/docs/modular_docs.go
+++ b/internal/docs/modular_docs.go
@@ -88,7 +88,7 @@ func CreateAssembly(assembliesDir string, files []string) error {
 	}
 
 	contentTemplate := `[id="cli-command-reference_{context}"]
-= CLI command reference
+= CLI command reference (rhoas)
 
 [role="_abstract"]
 You use the ` + "`rhoas`" + ` CLI to manage your application services from the command line.


### PR DESCRIPTION
### Description
Adding "rhoas" to the title of the CLI command ref guide that is generated for modular docs.

### Type of change
- [ ] Documentation