### PR TITLE
feat(topic): Show 'Unlimited' when value is -1

### DIFF
--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -36,7 +36,7 @@ type Options struct {
 type topicRow struct {
 	Name            string `json:"name,omitempty" header:"Name"`
 	PartitionsCount int    `json:"partitions_count,omitempty" header:"Partitions"`
-	RetentionTime   string `json:"retention.ms,omitempty" header:"Retention time"`
+	RetentionTime   string `json:"retention.ms,omitempty" header:"Retention time (ms)"`
 	RetentionSize   string `json:"retention.bytes,omitempty" header:"Retention size"`
 }
 

--- a/pkg/kafka/topic/util.go
+++ b/pkg/kafka/topic/util.go
@@ -8,7 +8,8 @@ import (
 	strimziadminclient "github.com/redhat-developer/app-services-cli/pkg/api/strimzi-admin/client"
 )
 
-var retentionMsKey string = "retention.ms"
+var RetentionMsKey string = "retention.ms"
+var RetentionSizeKey string = "retention.bytes"
 
 // CreateConfig creates a list of topic ConfigEntries
 func CreateConfig(retentionMs int) *[]strimziadminclient.ConfigEntry {
@@ -23,7 +24,7 @@ func CreateRetentionConfigEntry(retentionMs int) *strimziadminclient.ConfigEntry
 	retentionPeriodF := strconv.FormatInt(int64(retentionMs), 10)
 
 	return &strimziadminclient.ConfigEntry{
-		Key:   &retentionMsKey,
+		Key:   &RetentionMsKey,
 		Value: &retentionPeriodF,
 	}
 }


### PR DESCRIPTION
### Description

Resolves #488 

The -1 value for retention size and retention period means "Unlimited". This adds "Unlimited" to the table alongside the true value of -1.

### Verification Steps

Run `rhoas kafka topic list`:

```
❯ rhoas kafka topic list
  NAME             PARTITIONS   RETENTION TIME   RETENTION SIZE  
 ---------------- ------------ ---------------- ---------------- 
  strimzi-canary            3   604800000        -1 (Unlimited)  
  topic-1                   1   -1 (Unlimited)   -1 (Unlimited)  
  topic-2                   1   1000000          -1 (Unlimited)
```
