### PR TITLE
feat(serviceaccount): add owner column to table

### DIFF
--- a/pkg/cmd/serviceaccount/list/list.go
+++ b/pkg/cmd/serviceaccount/list/list.go
@@ -32,9 +32,11 @@ type Options struct {
 // svcAcctRow contains the properties used to
 // populate the list of service accounts into a table row
 type svcAcctRow struct {
-	ID       string `json:"id" header:"ID"`
-	Name     string `json:"name" header:"Name"`
-	ClientID string `json:"clientID" header:"Client ID"`
+	ID        string `json:"id" header:"ID"`
+	Name      string `json:"name" header:"Name"`
+	ClientID  string `json:"clientID" header:"Client ID"`
+	Owner     string `json:"owner" header:"Owner"`
+	CreatedAt string `json:"createdAt" header:"Created At"`
 }
 
 // NewListCommand creates a new command to list service accounts
@@ -129,9 +131,11 @@ func mapResponseItemsToRows(svcAccts []kasclient.ServiceAccountListItem) []svcAc
 
 	for _, sa := range svcAccts {
 		row := svcAcctRow{
-			ID:       sa.GetId(),
-			Name:     sa.GetName(),
-			ClientID: sa.GetClientID(),
+			ID:        sa.GetId(),
+			Name:      sa.GetName(),
+			ClientID:  sa.GetClientID(),
+			Owner:     sa.GetOwner(),
+			CreatedAt: sa.GetCreatedAt().String(),
 		}
 
 		rows = append(rows, row)


### PR DESCRIPTION
Closes #575 

```
❯ ./rhoas serviceaccount list
  ID (26)                                NAME                   CLIENT ID                                        OWNER                   CREATED AT                     
 -------------------------------------- ---------------------- ------------------------------------------------ ----------------------- ------------------------------- 
  e488c0a5-de2e-414a-99fd-d39366ba7a0c   owner12-inventory     srvc-acct-081e8cac-023c-476f-a027-47b20206c5bd   mmclaugh_kafka_devexp   2021-04-14 15:38:21 +0000 UTC  
  eb1f01f3-2c82-49e6-bc7d-0536802f562a   owner-operator-guiy    srvc-acct-0e5c87b2-f748-4833-989a-100d6f10bd0e   cmolloy_kafka_devexp    0001-01-01 00:00:00 +0000 UTC  
  e8355e28-b0de-4a5b-848e-9eef05c0fa78   owner-offsec          srvc-acct-1de4a8e6-e36b-4587-830a-75a877ac9856   sisharma_kafka_devexp   2021-04-14 15:48:19 +0000 UTC
```