### PR TITLE
fix: return request output format when list is empty

### DIFF
--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -110,7 +110,6 @@ func runList(opts *Options) (err error) {
 		req = req.Topic(opts.topic)
 	}
 	consumerGroupData, httpRes, err := req.Execute()
-
 	if err != nil {
 		if httpRes == nil {
 			return err
@@ -147,7 +146,7 @@ func runList(opts *Options) (err error) {
 		}
 	}
 
-	if consumerGroupData.GetCount() == 0 {
+	if consumerGroupData.GetCount() == 0 && opts.output == "" {
 		logger.Info(localizer.MustLocalize(&localizer.Config{
 			MessageID: "kafka.consumerGroup.list.log.info.noConsumerGroups",
 			TemplateData: map[string]interface{}{

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -121,7 +121,7 @@ func runList(opts *options) error {
 		return err
 	}
 
-	if response.Size == 0 {
+	if response.Size == 0 && opts.outputFormat == "" {
 		logger.Info(localizer.MustLocalizeFromID("kafka.common.log.info.noKafkaInstances"))
 		return nil
 	}

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -140,7 +140,7 @@ func runCmd(opts *Options) error {
 		}
 	}
 
-	if topicData.GetCount() == 0 {
+	if topicData.GetCount() == 0 && opts.output == "" {
 		logger.Info(localizer.MustLocalize(&localizer.Config{
 			MessageID: "kafka.topic.list.log.info.noTopics",
 			TemplateData: map[string]interface{}{

--- a/pkg/cmd/serviceaccount/list/list.go
+++ b/pkg/cmd/serviceaccount/list/list.go
@@ -105,7 +105,7 @@ func runList(opts *Options) (err error) {
 	}
 
 	serviceaccounts := res.GetItems()
-	if len(serviceaccounts) == 0 {
+	if len(serviceaccounts) == 0 && opts.output == "" {
 		logger.Info(localizer.MustLocalizeFromID("serviceAccount.list.log.info.noneFound"))
 		return nil
 	}


### PR DESCRIPTION
Fixes #579

### Verification Steps

Run `rhoas kafka list`, `rhoas kafka topic list`, `rhoas serviceaccount list` and `rhoas kafka consumergroup list`, passing `-o json` and `-o yml` (requires 2 runs).

When there are no items, the JSON or YAML will be returned.

```shell
$ ./rhoas kafka list -o yaml
kind: KafkaRequestList
page: 1
size: 0
total: 0
items: []

$ ./rhoas kafka topic list -o json
{
  "count": 0,
  "items": [],
  "limit": 0,
  "offset": 0
}
```

### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer