### PR TITLE
fix: panic when no kafkas in organization

### DIFF
--- a/pkg/cmd/cluster/bind/bind.go
+++ b/pkg/cmd/cluster/bind/bind.go
@@ -101,6 +101,9 @@ func runBind(opts *Options) error {
 		if err != nil {
 			return err
 		}
+		if selectedKafka == nil {
+			return nil
+		}
 		opts.selectedKafka = selectedKafka.GetId()
 	} else {
 		opts.selectedKafka = cfg.Services.Kafka.ClusterID

--- a/pkg/cmd/cluster/connect/connect.go
+++ b/pkg/cmd/cluster/connect/connect.go
@@ -53,7 +53,7 @@ func NewConnectCommand(f *factory.Factory) *cobra.Command {
 					},
 				}))
 			}
-			return runBind(opts)
+			return runConnect(opts)
 		},
 	}
 
@@ -66,7 +66,7 @@ func NewConnectCommand(f *factory.Factory) *cobra.Command {
 	return cmd
 }
 
-func runBind(opts *Options) error {
+func runConnect(opts *Options) error {
 	connection, err := opts.Connection(connection.DefaultConfigSkipMasAuth)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func runBind(opts *Options) error {
 
 			return err
 		}
-		opts.selectedKafka = *selectedKafka.Id
+		opts.selectedKafka = selectedKafka.GetId()
 	} else {
 		opts.selectedKafka = cfg.Services.Kafka.ClusterID
 	}

--- a/pkg/cmd/cluster/connect/connect.go
+++ b/pkg/cmd/cluster/connect/connect.go
@@ -92,8 +92,10 @@ func runConnect(opts *Options) error {
 		// nolint
 		selectedKafka, err := kafka.InteractiveSelect(connection, logger)
 		if err != nil {
-
 			return err
+		}
+		if selectedKafka == nil {
+			return nil
 		}
 		opts.selectedKafka = selectedKafka.GetId()
 	} else {


### PR DESCRIPTION
Resolves
https://github.com/redhat-developer/app-services-cli/issues/627

This fixing problem with CLI crashing when there is no Kafka List returned due to list command returning nil.
We need to add check for nil for the commands.