### PR TITLE
Check for conventional commits

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -1,0 +1,14 @@
+name: Validate
+on: [pull_request]
+
+jobs:
+  validate_comments:
+    name: 'Validate Conventional Commits'
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2


### PR DESCRIPTION
This PR adds a GitHub Action which checks that the commit message follows convetional commits.