### PR TITLE
docs(kafka topic): remove rferences to replication factor

### DIFF
--- a/docs/commands/rhoas_kafka_topic_create.adoc
+++ b/docs/commands/rhoas_kafka_topic_create.adoc
@@ -9,7 +9,7 @@ Create a topic
 Create a topic in the current Apache Kafka instance.
 
 This command lets you create a topic, set a desired number of 
-partitions, replicas and retention period or else use the default values.
+partitions, retention size and retention period or else use the default values.
 
 
 ....

--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -16,7 +16,7 @@ rhoas kafka topic update [flags]
 === Examples
 
 ....
-# update the number of replicas for a topic
+# update the message retention period for a topic
 $ rhoas kafka topic update topic-1 --retention-ms -1
 
 ....

--- a/pkg/kafka/topic/validators.go
+++ b/pkg/kafka/topic/validators.go
@@ -13,11 +13,10 @@ import (
 )
 
 const (
-	legalNameChars       = "^[a-zA-Z0-9\\_\\-]+$"
-	maxNameLength        = 249
-	minReplicationFactor = 1
-	minPartitions        = 1
-	maxPartitions        = 100
+	legalNameChars = "^[a-zA-Z0-9\\_\\-]+$"
+	maxNameLength  = 249
+	minPartitions  = 1
+	maxPartitions  = 100
 )
 
 // ValidateName validates the name of the topic
@@ -57,20 +56,6 @@ func ValidatePartitionsN(v interface{}) error {
 
 	if partitions > maxPartitions {
 		return fmt.Errorf("invalid partition count %v, maximum value is %v", partitions, maxPartitions)
-	}
-
-	return nil
-}
-
-// ValidationReplicationFactorN performs validation on the number of replicas v
-func ValidateReplicationFactorN(v interface{}) error {
-	replicas, ok := v.(int32)
-	if !ok {
-		return commonerr.NewCastError(v, "int32")
-	}
-
-	if replicas < minReplicationFactor {
-		return fmt.Errorf("invalid replication factor %v, minimum value is %v", replicas, minReplicationFactor)
 	}
 
 	return nil

--- a/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
@@ -8,9 +8,6 @@ one = 'Format in which to display the Kafka topics. Choose from: "json", "yml", 
 description = 'help for the Partitions input'
 one = 'The number of partitions in the topic'
 
-[kafka.topic.common.flag.replicas.description]
-one = 'The replication factor for the topic'
-
 [kafka.topic.common.input.retentionMs.description]
 description = 'Description for the Retention period input'
 one = 'The period of time in milliseconds the broker will retain a partition log before deleting it'

--- a/pkg/localize/locales/en/cmd/kafka_topic_create.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_create.en.toml
@@ -9,7 +9,7 @@ one = '''
 Create a topic in the current Apache Kafka instance.
 
 This command lets you create a topic, set a desired number of 
-partitions, replicas and retention period or else use the default values.
+partitions, retention size and retention period or else use the default values.
 '''
 
 [kafka.topic.create.cmd.example]

--- a/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
@@ -11,7 +11,7 @@ Update a topic in the current Apache Kafka instance.
 
 [kafka.topic.update.cmd.example]
 one = '''
-# update the number of replicas for a topic
+# update the message retention period for a topic
 $ rhoas kafka topic update topic-1 --retention-ms -1
 '''
 


### PR DESCRIPTION
Remove references to replication factor in docs of `kafka topic` commands.

Closes #665 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer