### PR TITLE
fix: fix invalid i18n arg

### DIFF
--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -150,7 +150,7 @@ func runCreate(opts *Options) error {
 		return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("serviceAccount.common.error.couldNotSaveCredentialsFile"), err)
 	}
 
-	logger.Info(opts.localizer.MustLocalize("serviceAccount.common.log.info.credentialsSaved", localize.NewEntry("FileName", opts.filename)))
+	logger.Info(opts.localizer.MustLocalize("serviceAccount.common.log.info.credentialsSaved", localize.NewEntry("FilePath", opts.filename)))
 
 	return nil
 }


### PR DESCRIPTION
Invalid argument for the i18n key `serviceAccount.common.log.info.credentialsSaved`

Closes #678 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a service account after logging in.
```
go run ./cmd/rhoas serviceaccount create
```
2. A successful creation should print the file path where credentials are saved.
```
Credentials saved to <path-to-file>
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer