### PR TITLE
fix(config): create-config-directory-recursive

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -143,7 +143,7 @@ func moveConfigFile(cfg config.IConfig) error {
 	}
 	// create rhoas config directory
 	if _, err = os.Stat(rhoasCfgDir); os.IsNotExist(err) {
-		err = os.Mkdir(rhoasCfgDir, 0700)
+		err = os.MkdirAll(rhoasCfgDir, 0700)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the config directory does not exist already then an error is thrown as it is not recursively created while migrating the config from the old location.

### Verification Steps

Backup your config directory: `mv ~/.config ~/.config.bk`

Run a `rhoas` command.

Before this change this would happen:

```shell
❯ ./rhoas whoami
Error migrating config file to new location: mkdir /home/ephelan/.config/rhoas: no such file or directorymkdir /home/ephelan/.config/rhoas: no such file or directory
❯ ./rhoas whoami
Error migrating config file to new location: mkdir /home/ephelan/.config/rhoas: no such file or directorymkdir /home/ephelan/.config/rhoas: no such file or directory
❯ cat ~/.config/rhoas/config.json

After:
```shell
❯ ./rhoas whoami
Error: not logged in. Run "rhoas login" to authenticate
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer