### PR TITLE
Fix localize id for cluster info

### DIFF
--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -146,7 +146,7 @@ func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArgu
 	// print status
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.log.info.statusMessage"))
 
-	c.localizer.MustLocalize("cluster.kubernetes.info",
+	c.localizer.MustLocalize("cluster.kubernetes.statusInfo",
 		localize.NewEntry("InstanceName", color.Info(kafkaInstance.GetName())),
 		localize.NewEntry("Namespace", color.Info(currentNamespace)),
 		localize.NewEntry("ServiceAccountSecretName", color.Info(serviceAccountSecretName)))


### PR DESCRIPTION
<!-- Add a description here or link to therelevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

When executing the cmd `cluster connect` it fails with this error
```
panic: message "cluster.kubernetes.info" not found in language "en"
```
this will just fix it

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run `rhoas cluster connect`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer