### PR TITLE
feat(completion): dynamic completion for suitable flags

### DIFF
--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
@@ -80,6 +81,10 @@ func NewListConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 1000, opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.limit"))
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.output.description"))
 	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.topic.description"))
+
+	_ = cmd.RegisterFlagCompletionFunc("topic", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
+	})
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -109,6 +109,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.common.flag.output.description"))
 	cmd.Flags().BoolVar(&opts.autoUse, "use", true, opts.localizer.MustLocalize("kafka.create.flag.autoUse.description"))
 
+	_ = cmd.RegisterFlagCompletionFunc(flags.FlagProvider, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.FetchCloudProviders(f)
+	})
+
 	flagutil.EnableOutputFlagCompletion(cmd)
 
 	return cmd

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -142,14 +142,12 @@ func FetchCloudProviders(f *factory.Factory) (validProviders []string, directive
 	validProviders = []string{}
 	directive = cobra.ShellCompDirectiveNoSpace
 
-	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
+	conn, err := f.Connection(connection.DefaultConfigSkipMasAuth)
 	if err != nil {
 		return validProviders, directive
 	}
 
-	api := conn.API()
-
-	cloudProviderResponse, _, err := api.Kafka().GetCloudProviders(context.Background()).Execute()
+	cloudProviderResponse, _, err := conn.API().Kafka().GetCloudProviders(context.Background()).Execute()
 	if err != nil {
 		return validProviders, directive
 	}


### PR DESCRIPTION
Add dynamic flag completion for `--topic` of `rhoas kafka consumergroup list` and `--provider` for `rhoas kafka create`.

Addresses #591 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Press tab twice after `rhoas kafka consumergroup list --topic`, it should auto-fill according to topics in the instance.
2. Press tab twice after `rhoas kafka create <instance name> --provider`, it should suggest the available providers.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer