### PR TITLE
fix(kafka create): run interactive if no name provided and fix typos

### DIFF
--- a/pkg/auth/login/login.go
+++ b/pkg/auth/login/login.go
@@ -232,7 +232,7 @@ func (a *AuthorizationCodeGrant) openBrowser(authCodeURL string, redirectURL *ur
 func (a *AuthorizationCodeGrant) startServer(ctx context.Context, server *http.Server) {
 	go func() {
 		if err := server.ListenAndServe(); err == nil {
-			a.Logger.Error(a.Localizer.MustLocalize("login.log.error.unableToStartServer"), localize.NewEntry("Error", err))
+			a.Logger.Error(a.Localizer.MustLocalize("login.log.error.unableToStartServer", localize.NewEntry("Error", err)))
 		}
 	}()
 	<-ctx.Done()

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -187,7 +187,7 @@ func checkForConsumerGroups(count int, opts *Options, kafkaName string) (hasCoun
 		if opts.topic == "" {
 			logger.Info(opts.localizer.MustLocalize("kafka.consumerGroup.list.log.info.noConsumerGroups", kafkaNameTmplPair))
 		} else {
-			logger.Info(opts.localizer.MustLocalize("kafka.consumerGroup.list.log.info.noConsumerGroupsForTopic"), kafkaNameTmplPair, localize.NewEntry("TopicName", opts.topic))
+			logger.Info(opts.localizer.MustLocalize("kafka.consumerGroup.list.log.info.noConsumerGroupsForTopic", kafkaNameTmplPair, localize.NewEntry("TopicName", opts.topic)))
 		}
 
 		return false, nil

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -92,6 +92,9 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 			if !opts.IO.CanPrompt() && opts.name == "" {
 				return errors.New(opts.localizer.MustLocalize("kafka.create.argument.name.error.requiredWhenNonInteractive"))
 			} else if opts.name == "" {
+				if opts.provider != "" || opts.region != "" {
+					return errors.New(opts.localizer.MustLocalize("kafka.create.flags.notAllowedWhenInteractive"))
+				}
 				opts.interactive = true
 			}
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -91,7 +91,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 
 			if !opts.IO.CanPrompt() && opts.name == "" {
 				return errors.New(opts.localizer.MustLocalize("kafka.create.argument.name.error.requiredWhenNonInteractive"))
-			} else if opts.name == "" && opts.provider == "" && opts.region == "" {
+			} else if opts.name == "" {
 				opts.interactive = true
 			}
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -93,7 +93,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return errors.New(opts.localizer.MustLocalize("kafka.create.argument.name.error.requiredWhenNonInteractive"))
 			} else if opts.name == "" {
 				if opts.provider != "" || opts.region != "" {
-					return errors.New(opts.localizer.MustLocalize("kafka.create.flags.notAllowedWhenInteractive"))
+					return errors.New(opts.localizer.MustLocalize("kafka.create.argument.name.error.requiredWhenNonInteractive"))
 				}
 				opts.interactive = true
 			}

--- a/pkg/localize/locales/en/cmd/kafka_create.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_create.en.toml
@@ -69,6 +69,9 @@ one = "Geographical region where the Kafka instance will be deployed"
 [kafka.create.argument.name.error.requiredWhenNonInteractive]
 one = 'name is required. Run "rhoas kafka create <name>"'
 
+[kafka.create.flags.notAllowedWhenInteractive]
+one = 'region and provider flags not allowed for interactive Kafka instance creation'
+
 [kafka.create.debug.autoUseSetMessage]
 one = 'Auto-use Kafka is set, updating the current Kafka instance'
 

--- a/pkg/localize/locales/en/cmd/kafka_create.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_create.en.toml
@@ -69,9 +69,6 @@ one = "Geographical region where the Kafka instance will be deployed"
 [kafka.create.argument.name.error.requiredWhenNonInteractive]
 one = 'name is required. Run "rhoas kafka create <name>"'
 
-[kafka.create.flags.notAllowedWhenInteractive]
-one = 'region and provider flags not allowed for interactive Kafka instance creation'
-
 [kafka.create.debug.autoUseSetMessage]
 one = 'Auto-use Kafka is set, updating the current Kafka instance'
 


### PR DESCRIPTION
- Open interactive mode when `rhoas kafka create` is run with flags but no name.
- Fix faulty error message while filtering consumergroups by topic.

Closes #703, #704

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run `rhoas kafka create --provider aws`, it should open the interactive mode.
2. Run `rhoas kafka consumergroup list --topic <topic-name>` where the topic has no associated consumergroup, it should display the message `Kafka instance "<instance name>" has no consumer groups for topic "<topic-name>"`

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer