### PR TITLE
chore: expose binding name

### DIFF
--- a/docs/commands/rhoas_cluster_bind.adoc
+++ b/docs/commands/rhoas_cluster_bind.adoc
@@ -37,13 +37,14 @@ $ rhoas cluster bind --namespace=ns --app-name=myapp
 === Options
 
 ....
-      --app-name string     Name of the kubernetes deployment to bind
-      --force-operator      Use ServiceBindingOperator only and fail if Operator is not installed
-      --force-sdk           Use Service Binding SDK and skip ServiceBindingOperator even if installed on the cluster
-      --ignore-context      Ignore currently selected services and ask to select each service separately
-      --kubeconfig string   Location of the kubeconfig file.
-  -n, --namespace string    Custom Kubernetes namespace (if not set current namespace will be used)
-  -y, --yes                 Forcibly create a binding without confirmation.
+      --app-name string       Name of the kubernetes deployment to bind
+      --binding-name string   Name of the Service binding object to create when using operator
+      --force-operator        Use ServiceBindingOperator only and fail if Operator is not installed
+      --force-sdk             Use Service Binding SDK and skip ServiceBindingOperator even if installed on the cluster
+      --ignore-context        Ignore currently selected services and ask to select each service separately
+      --kubeconfig string     Location of the kubeconfig file.
+  -n, --namespace string      Custom Kubernetes namespace (if not set current namespace will be used)
+  -y, --yes                   Forcibly create a binding without confirmation.
 ....
 
 === Options inherited from parent commands

--- a/pkg/cmd/cluster/bind/bind.go
+++ b/pkg/cmd/cluster/bind/bind.go
@@ -62,6 +62,7 @@ func NewBindCommand(f *factory.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.kubeconfigLocation, "kubeconfig", "", "", opts.localizer.MustLocalize("cluster.common.flag.kubeconfig.description"))
 	cmd.Flags().StringVarP(&opts.appName, "app-name", "", "", opts.localizer.MustLocalize("cluster.bind.flag.appName"))
+	cmd.Flags().StringVarP(&opts.bindingName, "binding-name", "", "", opts.localizer.MustLocalize("cluster.bind.flag.bindName"))
 	cmd.Flags().BoolVarP(&opts.forceCreationWithoutAsk, "yes", "y", false, opts.localizer.MustLocalize("cluster.common.flag.yes.description"))
 	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", opts.localizer.MustLocalize("cluster.common.flag.namespace.description"))
 	cmd.Flags().BoolVarP(&opts.ignoreContext, "ignore-context", "", false, opts.localizer.MustLocalize("cluster.common.flag.ignoreContext.description"))

--- a/pkg/localize/locales/en/cmd/cluster_bind.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster_bind.en.toml
@@ -29,6 +29,9 @@ $ rhoas cluster bind --namespace=ns --app-name=myapp
 [cluster.bind.flag.appName]
 one = '''Name of the kubernetes deployment to bind'''
 
+[cluster.bind.flag.bindName]
+one = '''Name of the Service binding object to create when using operator'''
+
 [cluster.bind.flag.forceOperator.description]
 one = '''Use ServiceBindingOperator only and fail if Operator is not installed'''
 

--- a/pkg/localize/locales/en/cmd/cluster_bind.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster_bind.en.toml
@@ -30,7 +30,7 @@ $ rhoas cluster bind --namespace=ns --app-name=myapp
 one = '''Name of the kubernetes deployment to bind'''
 
 [cluster.bind.flag.bindName]
-one = '''Name of the Service binding object to create when using operator'''
+one = 'Name of the Service binding object to create when using operator'
 
 [cluster.bind.flag.forceOperator.description]
 one = '''Use ServiceBindingOperator only and fail if Operator is not installed'''


### PR DESCRIPTION
1. Expose binding name to support multiple bindings


> NOTE: The only flag that we do not expose now is `bindAsFiles` 

This is because we do not have any documentation for environment variables binding and using it will not work without any doc.