### PR TITLE
feat(kafka topic): add search flag to list subcommand

### DIFF
--- a/docs/commands/rhoas_kafka_topic_list.adoc
+++ b/docs/commands/rhoas_kafka_topic_list.adoc
@@ -28,6 +28,7 @@ $ rhoas kafka topic list -o json
 
 ....
   -o, --output string   Format in which to display the Kafka topics. Choose from: "json", "yml", "yaml"
+      --search string   Text search to filter the Kafka topics by name
 ....
 
 === Options inherited from parent commands

--- a/pkg/kafka/topic/validators.go
+++ b/pkg/kafka/topic/validators.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/redhat-developer/app-services-cli/pkg/common/commonerr"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 )
 
@@ -43,6 +44,23 @@ func ValidateName(val interface{}) error {
 	}
 
 	return fmt.Errorf(`invalid topic name "%v"; only letters (Aa-Zz), numbers, "_", "." and "-" are accepted`, name)
+}
+
+func ValidateSearchInput(val interface{}, localizer localize.Localizer) error {
+
+	search, ok := val.(string)
+	if !ok {
+		return commonerr.NewCastError(val, "string")
+	}
+
+	matched, _ := regexp.Match(legalNameChars, []byte(search))
+
+	if matched {
+		return nil
+	}
+
+	return fmt.Errorf(localizer.MustLocalize("kafka.topic.list.error.illegalSearchValue", localize.NewEntry("Search", search)))
+
 }
 
 // ValidatePartitionsN performs validation on the number of partitions v

--- a/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
@@ -20,3 +20,15 @@ $ rhoas kafka topic list -o json
 
 [kafka.topic.list.log.info.noTopics]
 one = 'Kafka instance "{{.InstanceName}}" has no topics. Run "rhoas kafka topic create <topic-name>" to create one'
+
+[kafka.topic.list.flag.search.description]
+description = 'Description for the --search flag'
+one = 'Text search to filter the Kafka topics by name'
+
+[kafka.topic.list.log.debug.filteringTopicList]
+description = 'Debug message when filtering the list of Kafka topic'
+one = 'Filtering Kafka topics with the query "{{.Search}}"'
+
+[kafka.topic.list.error.illegalSearchValue]
+description = 'Error message when invalid chars are used for search flag'
+one = 'illegal search value "{{.Search}}"; only letters (Aa-Zz), numbers, "_", "." and "-" are accepted'

--- a/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
@@ -19,7 +19,7 @@ $ rhoas kafka topic list -o json
 '''
 
 [kafka.topic.list.log.info.noTopics]
-one = 'Kafka instance "{{.InstanceName}}" has no topics. Run "rhoas kafka topic create <topic-name>" to create one'
+one = 'No topics found in Kafka instance "{{.InstanceName}}"'
 
 [kafka.topic.list.flag.search.description]
 description = 'Description for the --search flag'


### PR DESCRIPTION
Allow user to filter list of kafka topics by passing `--search` flag to `rhoas kafka topic list`

Closes #697 

![Screenshot from 2021-06-10 16-00-37](https://user-images.githubusercontent.com/23582438/121513662-b62ec680-ca08-11eb-905b-f736f6926f13.png)


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. > go run ./cmd/rhoas kafka topic list --search "pic(-1"
2. It should throw the error message `Error: illegal search value "pic(-1"; only letters (Aa-Zz), numbers, "_", "." and "-" are accepted`
3. Run `go run ./cmd/rhoas kafka topic list --search <search input>`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer