### PR TITLE
fix(serviceaccount reset-credentials): validate serviceaccount ID in prompt

### DIFF
--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -71,6 +71,11 @@ func NewResetCredentialsCommand(f *factory.Factory) *cobra.Command {
 				return flag.InvalidValueError("file-format", opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			}
 
+			validID := validation.ValidateUUID(opts.localizer)(opts.id)
+			if validID != nil {
+				return validID
+			}
+
 			return runResetCredentials(opts)
 		},
 	}
@@ -218,7 +223,7 @@ func runInteractivePrompt(opts *Options) (err error) {
 		Help:    opts.localizer.MustLocalize("serviceAccount.resetCredentials.input.id.help"),
 	}
 
-	err = survey.AskOne(promptID, &opts.id, survey.WithValidator(survey.Required), survey.WithValidator(validation.ValidateID(opts.localizer)))
+	err = survey.AskOne(promptID, &opts.id, survey.WithValidator(survey.Required), survey.WithValidator(validation.ValidateUUID(opts.localizer)))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -15,6 +15,7 @@ import (
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceaccount/credentials"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceaccount/validation"
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
@@ -217,7 +218,7 @@ func runInteractivePrompt(opts *Options) (err error) {
 		Help:    opts.localizer.MustLocalize("serviceAccount.resetCredentials.input.id.help"),
 	}
 
-	err = survey.AskOne(promptID, &opts.id, survey.WithValidator(survey.Required))
+	err = survey.AskOne(promptID, &opts.id, survey.WithValidator(survey.Required), survey.WithValidator(validation.ValidateID(opts.localizer)))
 	if err != nil {
 		return err
 	}

--- a/pkg/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/localize/locales/en/cmd/serviceaccount.en.toml
@@ -87,3 +87,6 @@ one = 'invalid service account description: only alphanumeric characters and "-"
 
 [serviceAccount.common.validation.description.error.lengthError]
 one = 'service account description cannot exceed {{.MaxLen}} characters'
+
+[serviceAccount.common.validation.id.error.invalidID]
+one = '"{{.ID}}" is not a valid UUID'

--- a/pkg/serviceaccount/validation/validation.go
+++ b/pkg/serviceaccount/validation/validation.go
@@ -14,7 +14,7 @@ const (
 	legalNameChars = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
 	maxNameLength  = 50
 	minNameLength  = 1
-	leagalUUID     = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+	legalUUID      = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 	// description validation rules
 	legalDescriptionChars = "^[a-zA-Z0-9.,\\-\\s]*$"
 	maxDescriptionLength  = 255
@@ -67,14 +67,14 @@ func ValidateDescription(val interface{}) error {
 }
 
 // ValidateID validates if ID is a valid UUID
-func ValidateID(localizer localize.Localizer) func(v interface{}) error {
+func ValidateUUID(localizer localize.Localizer) func(v interface{}) error {
 	return func(val interface{}) error {
 		id, ok := val.(string)
 		if !ok {
 			return commonerr.NewCastError(val, "string")
 		}
 
-		matched, _ := regexp.Match(leagalUUID, []byte(id))
+		matched, _ := regexp.Match(legalUUID, []byte(id))
 
 		if matched {
 			return nil

--- a/pkg/serviceaccount/validation/validation.go
+++ b/pkg/serviceaccount/validation/validation.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/redhat-developer/app-services-cli/pkg/common/commonerr"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
 )
 
 const (
@@ -13,6 +14,7 @@ const (
 	legalNameChars = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
 	maxNameLength  = 50
 	minNameLength  = 1
+	leagalUUID     = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 	// description validation rules
 	legalDescriptionChars = "^[a-zA-Z0-9.,\\-\\s]*$"
 	maxDescriptionLength  = 255
@@ -62,4 +64,23 @@ func ValidateDescription(val interface{}) error {
 	}
 
 	return errors.New(`invalid service account description; only alphanumeric characters and "-", ".", "," are accepted`)
+}
+
+// ValidateID validates if ID is a valid UUID
+func ValidateID(localizer localize.Localizer) func(v interface{}) error {
+	return func(val interface{}) error {
+		id, ok := val.(string)
+		if !ok {
+			return commonerr.NewCastError(val, "string")
+		}
+
+		matched, _ := regexp.Match(leagalUUID, []byte(id))
+
+		if matched {
+			return nil
+		}
+
+		return errors.New(localizer.MustLocalize("serviceAccount.common.validation.id.error.invalidID", localize.NewEntry("ID", id)))
+	}
+
 }

--- a/pkg/serviceaccount/validation/validation.go
+++ b/pkg/serviceaccount/validation/validation.go
@@ -66,7 +66,7 @@ func ValidateDescription(val interface{}) error {
 	return errors.New(`invalid service account description; only alphanumeric characters and "-", ".", "," are accepted`)
 }
 
-// ValidateID validates if ID is a valid UUID
+// ValidateUUID validates if ID is a valid UUID
 func ValidateUUID(localizer localize.Localizer) func(v interface{}) error {
 	return func(val interface{}) error {
 		id, ok := val.(string)

--- a/pkg/serviceaccount/validation/validation_test.go
+++ b/pkg/serviceaccount/validation/validation_test.go
@@ -2,6 +2,8 @@ package validation
 
 import (
 	"testing"
+
+	"github.com/redhat-developer/app-services-cli/pkg/localize/goi18n"
 )
 
 func TestValidateName(t *testing.T) {
@@ -64,6 +66,58 @@ func TestValidateName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateName(tt.args.val); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateUUID(t *testing.T) {
+	type args struct {
+		val interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "fails when length is 5",
+			args:    args{"kafka"},
+			wantErr: true,
+		},
+		{
+			name:    "fails for empty string",
+			args:    args{""},
+			wantErr: true,
+		},
+		{
+			name:    "fails for special chars",
+			args:    args{"9e4d1b1f-19d*-47c2-a334-e420c5e5bbce"},
+			wantErr: true,
+		},
+		{
+			name:    "passes for valid UUID",
+			args:    args{"9e4d1b1f-19dd-47c2-a334-e420c5e5bbce"},
+			wantErr: false,
+		},
+		{
+			name:    "passes for numeric UUID",
+			args:    args{"11111111-2222-3333-4444-555555555555"},
+			wantErr: false,
+		},
+		{
+			name:    "fails for ID containing capital letters",
+			args:    args{"9e4d1b1f-19dd-47c2-A334-e420c5e5bbce"},
+			wantErr: true,
+		},
+	}
+
+	localizer, _ := goi18n.New(nil)
+	// nolint:scopelint
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateUUID(localizer)(tt.args.val); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUUID() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Client side validation for service account ID in interactive mode.

Closes #716

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run command to reset credentials for service account in interactive mode.
```
go run ./cmd/rhoas serviceaccount reset-credentials
```
2. Input any random string that is not an UUID, e.g `"kafka"`. It should throw the error:
```
Sorry, your reply was invalid: "kafka" is not a valid UUID
```

![Screenshot from 2021-06-15 18-53-53](https://user-images.githubusercontent.com/23582438/122060333-1d82b700-ce0b-11eb-93c9-ffb167fbde08.png)


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer