### PR TITLE
chore: fix install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,6 +61,10 @@
     DOWNLOAD_TAG="$RELEASE_TAG"
   fi
 
+  if [[ $DOWNLOAD_TAG == v* ]]; then
+    DOWNLOAD_TAG="${DOWNLOAD_TAG:1}"
+  fi
+
 
   ASSET_NAME="${BINARY_NAME}_${DOWNLOAD_TAG}_${OS_TYPE}_amd${OS_LONG_BIT}"
   ASSET_NAME_COMPRESSED="${ASSET_NAME}.tar.gz"


### PR DESCRIPTION
Fixes a bug where the binary could not be extracted as the tag has a `v` prefix, but the asset does not, and the tag is used to dynamically build the asset name.

## Verification

Install latest:

```shell
curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/fix-install-script/scripts/install.sh | bash
```

Install with "v" prefix:

```shell
curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/fix-install-script/scripts/install.sh | bash -s v0.24.4
```

Install without prefix:

```shell
curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/fix-install-script/scripts/install.sh | bash -s 0.24.4
```

