### PR TITLE
fix(kafka admin): validations and show proper error messages

### DIFF
--- a/pkg/connection/keycloak_connection.go
+++ b/pkg/connection/keycloak_connection.go
@@ -187,9 +187,19 @@ func (c *KeycloakConnection) API() *api.API {
 		}
 
 		kafkaStatus := kafkaInstance.GetStatus()
-		if kafkaStatus != "ready" {
-			err = fmt.Errorf(`Kafka instance "%v" is not ready yet`, kafkaInstance.GetName())
 
+		switch kafkaStatus {
+		case "provisioning", "accepted":
+			err = fmt.Errorf(`Kafka instance "%v" is not ready yet`, kafkaInstance.GetName())
+			return nil, nil, err
+		case "failed":
+			err = fmt.Errorf(`Kafka instance "%v" has failed`, kafkaInstance.GetName())
+			return nil, nil, err
+		case "deprovision":
+			err = fmt.Errorf(`Kafka instance "%v" is being deprovisioned`, kafkaInstance.GetName())
+			return nil, nil, err
+		case "deleting":
+			err = fmt.Errorf(`Kafka instance "%v" is being deleted`, kafkaInstance.GetName())
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
* Check if topic exists before allowing user to prompt values for update.
* Show proper status of Kafka instance while performing topic/consumer group operation.

Closes #712 #726

![Screenshot from 2021-06-19 01-09-51](https://user-images.githubusercontent.com/23582438/122609121-1c67b900-d09b-11eb-898b-7c7877b6f9ad.png)

![Screenshot from 2021-06-19 01-04-39](https://user-images.githubusercontent.com/23582438/122608737-600df300-d09a-11eb-8ff7-d3f55d27e649.png)

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Try updating a topic that doesn't exist:
```
./rhoas kafka topic update <non-existent>
> Error: topic "<non-existent>" does not exist in Kafka instance "test-instance"
```
2. Delete a Kafka instance from UI, try listing all the topics in that Kafka instance.
```
./rhoas kafka topic list
> Error: Kafka instance "<random name>" is being deleted
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer