### PR TITLE
fix: fix not working insecure login

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
+	"golang.org/x/oauth2"
 
 	"github.com/redhat-developer/app-services-cli/pkg/auth/login"
 	"github.com/redhat-developer/app-services-cli/pkg/auth/token"
@@ -18,7 +19,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/debug"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/httputil"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 
@@ -149,12 +149,8 @@ func runLogin(opts *Options) (err error) {
 
 	if opts.offlineToken == "" {
 		tr := createTransport(opts.insecureSkipTLSVerify)
-		httpClient := &http.Client{
-			Transport: httputil.LoggingRoundTripper{
-				Proxied: tr,
-				Logger:  logger,
-			},
-		}
+		httpClient := oauth2.NewClient(context.Background(), nil)
+		httpClient.Transport = tr
 
 		loginExec := &login.AuthorizationCodeGrant{
 			HTTPClient: httpClient,


### PR DESCRIPTION
Use oauth2.HTTPClient to perform login
As the go-oidc provider can obtain the custom transport layer
from the context

<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps

Run login against a custom auth URL:
```shell
./rhoas login --auth-url "https://keycloakexternal.apps.akoserwa.ipt.integrations.rhmw.io/auth/realms/redhat-external" --insecure
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer