### PR TITLE
chore: always force latest version of the mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ openapi/ams/generate:
 .PHONY: openapi/ams/generate
 
 mock-api/start: 
-	echo -e "y" | npx @rhoas/api-mock
+	npm install -g @rhoas/api-mock
+	asapi
 .PHONY: mock-api/start
 
 # clean up code and dependencies


### PR DESCRIPTION
Installing mock globally instead of npx

