### PR TITLE
ci(build): run `go build` when `go.mod` file changes

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -1,14 +1,16 @@
-name: Go
+name: Go Build
 
 on:
   push:
     branches: [main]
     paths:
       - '**.go'
+      - 'go.mod'
   pull_request:
     branches: [main]
     paths:
       - '**.go'
+      - 'go.mod'
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that the https://github.com/redhat-developer/app-services-cli/runs/2945125536 is failing because #758 bumped the SDK version which contained breaking changes. The pull request `build` workflow only runs when a `*.go` file has changed but it should also run when `go.mod` changes to catch breaking changes.