### PR TITLE
feat(kafka topic create): add cleanup policy flag

### DIFF
--- a/docs/commands/rhoas_kafka_topic_create.adoc
+++ b/docs/commands/rhoas_kafka_topic_create.adoc
@@ -27,10 +27,11 @@ $ rhoas kafka topic create topic-1
 === Options
 
 ....
-  -o, --output string         Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
-      --partitions int32      The number of partitions in the topic (default 1)
-      --retention-bytes int   The maximum total size of a partition log segments before old log segments are deleted to free up space (default -1)
-      --retention-ms int      The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)
+      --cleanup-policy string   Determines whether log messages are deleted, compacted, or both (default "delete")
+  -o, --output string           Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
+      --partitions int32        The number of partitions in the topic (default 1)
+      --retention-bytes int     The maximum total size of a partition log segments before old log segments are deleted to free up space (default -1)
+      --retention-ms int        The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)
 ....
 
 === Options inherited from parent commands

--- a/pkg/kafka/topic/util.go
+++ b/pkg/kafka/topic/util.go
@@ -9,6 +9,10 @@ import (
 
 var RetentionMsKey string = "retention.ms"
 var RetentionSizeKey string = "retention.bytes"
+var PartitionsKey string = "partitions"
+var CleanupPolicy string = "cleanup.policy"
+
+var ValidCleanupPolicies = []string{"delete", "compact", "compact, delete"}
 
 // CreateConfigEntries converts a key value map of config entries to an array of config entries
 func CreateConfigEntries(entryMap map[string]*string) *[]kafkainstanceclient.ConfigEntry {

--- a/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
@@ -16,6 +16,10 @@ one = 'The period of time in milliseconds the broker will retain a partition log
 description = 'Description for the Retention size input'
 one = 'The maximum total size of a partition log segments before old log segments are deleted to free up space'
 
+[kafka.topic.common.input.cleanupPolicy.description]
+description = 'Description for the Cleanup policy input'
+one = 'Determines whether log messages are deleted, compacted, or both'
+
 [kafka.topic.common.error.noKafkaSelected]
 one = 'no Kafka instance is currently selected, run "rhoas kafka use" to set the current instance'
 

--- a/pkg/localize/locales/en/cmd/kafka_topic_create.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_create.en.toml
@@ -38,3 +38,7 @@ one = 'Retention Size (bytes):'
 [kafka.topic.create.input.partitions.message]
 description = 'Message for the Partitions input'
 one = 'Number of Partitions:'
+
+[kafka.topic.create.input.cleanupPolicy.message]
+description = 'Message for the Cleanup Policy input'
+one = 'Cleanup Policy:'


### PR DESCRIPTION
User should be able to specify `cleanup policy` while creating a Kafka topic.

Closes #769 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a kafka topic while passing the `--cleanup-policy` flag.
2. Create a Kafka topic in interactive mode, it should prompt options for `cleanup-policy`.

![Screenshot from 2021-06-30 22-38-41](https://user-images.githubusercontent.com/23582438/124004153-5e76f000-d9f5-11eb-9024-189e9a9faacc.png)

![Screenshot from 2021-06-30 22-40-11](https://user-images.githubusercontent.com/23582438/124004178-646cd100-d9f5-11eb-923b-4ad58ac190d7.png)


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer