### PR TITLE
fix(kafka consumergroup list): fix reference to the wrong i18n ID

### DIFF
--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -124,9 +124,9 @@ func runList(opts *Options) (err error) {
 
 		switch httpRes.StatusCode {
 		case 401:
-			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.list.common.error.unauthorized", operationTmplPair))
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.unauthorized", operationTmplPair))
 		case 403:
-			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.list.common.error.forbidden", operationTmplPair))
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.forbidden", operationTmplPair))
 		case 500:
 			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.internalServerError"))
 		case 503:


### PR DESCRIPTION
Closes #773 

### Verification Steps

Run `rhoas kafka consumergroup list` on an instance you do not own. You should get a nice message like this:

```
Error: you are unauthorized to list these topics
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer