### PR TITLE
feat(kafka topic update): add cleanup policy flag

### DIFF
--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -24,6 +24,7 @@ $ rhoas kafka topic update topic-1 --retention-ms -1
 === Options
 
 ....
+      --cleanup-policy string    Determines whether log messages are deleted, compacted, or both
   -o, --output string            Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
       --retention-bytes string   The maximum total size of a partition log segments before old log segments are deleted to free up space
       --retention-ms string      The period of time in milliseconds the broker will retain a partition log before deleting it

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 
@@ -222,7 +223,7 @@ func runCmd(opts *Options) error {
 	// track if any values have changed
 	var needsUpdate bool
 
-	_, httpRes, err := api.GetTopic(context.Background(), opts.topicName).Execute()
+	topic, httpRes, err := api.GetTopic(context.Background(), opts.topicName).Execute()
 
 	topicNameTmplPair := localize.NewEntry("TopicName", opts.topicName)
 	kafkaNameTmplPair := localize.NewEntry("InstanceName", kafkaInstance.GetName())
@@ -252,7 +253,7 @@ func runCmd(opts *Options) error {
 		configEntryMap[topicutil.RetentionSizeKey] = &opts.retentionBytesStr
 	}
 
-	if opts.cleanupPolicy != "" {
+	if opts.cleanupPolicy != "" && strings.Compare(opts.cleanupPolicy, topicutil.GetConfigValue(topic.GetConfig(), topicutil.CleanupPolicy)) != 0 {
 		needsUpdate = true
 		configEntryMap[topicutil.CleanupPolicy] = &opts.cleanupPolicy
 	}

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -43,6 +43,7 @@ type Options struct {
 	kafkaID           string
 	outputFormat      string
 	interactive       bool
+	cleanupPolicy     string
 
 	IO         *iostreams.IOStreams
 	Config     config.IConfig
@@ -80,7 +81,7 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 
 			if !opts.IO.CanPrompt() && opts.retentionMsStr == "" && opts.partitionsStr == "" && opts.retentionBytesStr == "" {
 				return errors.New(opts.localizer.MustLocalize("argument.error.requiredWhenNonInteractive", localize.NewEntry("Argument", "name")))
-			} else if opts.retentionMsStr == "" && opts.partitionsStr == "" && opts.retentionBytesStr == "" {
+			} else if opts.retentionMsStr == "" && opts.partitionsStr == "" && opts.retentionBytesStr == "" && opts.cleanupPolicy == "" {
 				opts.interactive = true
 			}
 
@@ -94,7 +95,7 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 					return err
 				}
 
-				if opts.retentionMsStr == "" && opts.partitionsStr == "" && opts.retentionBytesStr == "" {
+				if opts.retentionMsStr == "" && opts.partitionsStr == "" && opts.retentionBytesStr == "" && opts.cleanupPolicy == "" {
 					logger.Info(opts.localizer.MustLocalize("kafka.topic.update.log.info.nothingToUpdate"))
 					return nil
 				}
@@ -102,6 +103,15 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 				if err = validator.ValidateName(opts.topicName); err != nil {
 					return err
 				}
+
+				// check that a valid --cleanup-policy flag value is used
+				if opts.cleanupPolicy != "" {
+					validPolicy := flagutil.IsValidInput(opts.cleanupPolicy, topicutil.ValidCleanupPolicies...)
+					if !validPolicy {
+						return flag.InvalidValueError("cleanup-policy", opts.cleanupPolicy, topicutil.ValidCleanupPolicies...)
+					}
+				}
+
 			}
 
 			if err = flag.ValidateOutput(opts.outputFormat); err != nil {
@@ -161,8 +171,11 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
 	cmd.Flags().StringVar(&opts.retentionMsStr, "retention-ms", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
 	cmd.Flags().StringVar(&opts.retentionBytesStr, "retention-bytes", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
+	cmd.Flags().StringVar(&opts.cleanupPolicy, "cleanup-policy", "", opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
+
+	flagutil.EnableStaticFlagCompletion(cmd, "cleanup-policy", topicutil.ValidCleanupPolicies)
 
 	return cmd
 }
@@ -239,6 +252,11 @@ func runCmd(opts *Options) error {
 		configEntryMap[topicutil.RetentionSizeKey] = &opts.retentionBytesStr
 	}
 
+	if opts.cleanupPolicy != "" {
+		needsUpdate = true
+		configEntryMap[topicutil.CleanupPolicy] = &opts.cleanupPolicy
+	}
+
 	if !needsUpdate {
 		logger.Info(opts.localizer.MustLocalize("kafka.topic.update.log.info.nothingToUpdate"))
 		return nil
@@ -303,7 +321,7 @@ func runInteractivePrompt(opts *Options) (err error) {
 	}
 
 	// check if topic exists
-	_, httpRes, err := api.GetTopic(context.Background(), opts.topicName).
+	topic, httpRes, err := api.GetTopic(context.Background(), opts.topicName).
 		Execute()
 
 	topicNameTmplPair := localize.NewEntry("TopicName", opts.topicName)
@@ -344,6 +362,18 @@ func runInteractivePrompt(opts *Options) (err error) {
 	}
 
 	err = survey.AskOne(retentionBytesPrompt, &opts.retentionBytesStr, survey.WithValidator(validator.ValidateMessageRetentionSize))
+	if err != nil {
+		return err
+	}
+
+	cleanupPolicyPrompt := &survey.Select{
+		Message: opts.localizer.MustLocalize("kafka.topic.update.input.cleanupPolicy.message"),
+		Help:    opts.localizer.MustLocalize("kafka.topic.update.input.cleanupPolicy.help"),
+		Options: topicutil.ValidCleanupPolicies,
+		Default: topicutil.GetConfigValue(topic.GetConfig(), topicutil.CleanupPolicy),
+	}
+
+	err = survey.AskOne(cleanupPolicyPrompt, &opts.cleanupPolicy)
 	if err != nil {
 		return err
 	}

--- a/pkg/kafka/topic/util.go
+++ b/pkg/kafka/topic/util.go
@@ -12,7 +12,7 @@ var RetentionSizeKey string = "retention.bytes"
 var PartitionsKey string = "partitions"
 var CleanupPolicy string = "cleanup.policy"
 
-var ValidCleanupPolicies = []string{"delete", "compact", "compact, delete"}
+var ValidCleanupPolicies = []string{"delete", "compact", "compact,delete"}
 
 // CreateConfigEntries converts a key value map of config entries to an array of config entries
 func CreateConfigEntries(entryMap map[string]*string) *[]kafkainstanceclient.ConfigEntry {
@@ -62,4 +62,15 @@ func ConvertRetentionBytesToInt(retentionBytesStr string) (int, error) {
 	}
 
 	return retentionMsInt, nil
+}
+
+func GetConfigValue(configEntries []kafkainstanceclient.ConfigEntry, keyName string) (val string) {
+	for _, config := range configEntries {
+
+		if *config.Key == keyName {
+			val = config.GetValue()
+		}
+	}
+
+	return val
 }

--- a/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
@@ -42,3 +42,11 @@ one = 'Retention Size (bytes) [optional]:'
 [kafka.topic.update.input.retentionBytes.help]
 description = 'Help for the Retention size input'
 one = 'The maximum total size of a partition log segments before old log segments are deleted to free up space. Leave blank to skip updating this value.'
+
+[kafka.topic.update.input.cleanupPolicy.message]
+description = 'Message for the Cleanup policy input'
+one = 'Cleanup Policy [optional]:'
+
+[kafka.topic.update.input.cleanupPolicy.help]
+description = 'Help for the Cleanup policy input'
+one = 'Determines whether log messages are deleted, compacted, or both. Leave blank to skip updating this value.'


### PR DESCRIPTION
User should be able to update cleanup policy of a Kafka topic.

Closes #772 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Update a Kafka topic while passing the `--cleanup-policy` flag.
2. Update a Kafka topic in interactive mode

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer