### PR TITLE
docs(service-registry): missing link in rhoas.adoc

### DIFF
--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -45,7 +45,6 @@ $ rhoas cluster connect
 * link:rhoas_login{relfilesuffix}[rhoas login]	 - Log in to RHOAS
 * link:rhoas_logout{relfilesuffix}[rhoas logout]	 - Log out from RHOAS
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
-* link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [96m[Preview] [0mService Registry commands
 * link:rhoas_status{relfilesuffix}[rhoas status]	 - View the status of all currently used services
 * link:rhoas_whoami{relfilesuffix}[rhoas whoami]	 - Print current username
 


### PR DESCRIPTION
Build was failing due to outdated doc after merging #776 

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer