### PR TITLE
fix: remove old workaround for migrating config file name

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
 	"github.com/redhat-developer/app-services-cli/pkg/doc"
@@ -96,13 +95,6 @@ func generateDocumentation(rootCommand *cobra.Command) {
 }
 
 func initConfig(f *factory.Factory) {
-	// check if the config file is located in the old default location
-	// if so, move it to the new location
-	err := moveConfigFile(f.Config)
-	if err != nil {
-		fmt.Fprintf(f.IOStreams.ErrOut, "Error migrating config file to new location: %v", err)
-	}
-
 	cfgFile, err := f.Config.Load()
 
 	if cfgFile != nil {
@@ -118,36 +110,4 @@ func initConfig(f *factory.Factory) {
 		fmt.Fprintln(f.IOStreams.ErrOut, err)
 		os.Exit(1)
 	}
-}
-
-// check if the config file is located in the old default location
-// if so, move it to the new location
-func moveConfigFile(cfg config.IConfig) error {
-	cfgPath, err := cfg.Location()
-	if err != nil {
-		return err
-	}
-	rhoasCfgDir, err := config.DefaultDir()
-	if err != nil {
-		return err
-	}
-	userCfgDir, err := os.UserConfigDir()
-	if err != nil {
-		return err
-	}
-	oldFilePath := filepath.Join(userCfgDir, ".rhoascli.json")
-	if os.Getenv("RHOASCONFIG") == oldFilePath {
-		return nil
-	}
-	// create rhoas config directory
-	if _, err = os.Stat(rhoasCfgDir); os.IsNotExist(err) {
-		err = os.MkdirAll(rhoasCfgDir, 0o700)
-		if err != nil {
-			return err
-		}
-	}
-	if _, err = os.Stat(oldFilePath); err == nil {
-		return os.Rename(oldFilePath, cfgPath)
-	}
-	return nil
 }


### PR DESCRIPTION
Creating for discussion rather than merge directly.
Might be to early to remove it, but I counted +5 releases since this was introduced.