### PR TITLE
Minor adjustments to command ref layout

### DIFF
--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -32,14 +32,15 @@ $ rhoas cluster connect
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -d, --debug::               Enable debug mode
       --devpreview:: string   Enable commands that are available under early developer preview. Use --devpreview=yes
   -h, --help::                Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_cluster{relfilesuffix}[rhoas cluster]	 - View and perform operations on your Kubernetes or OpenShift cluster
 * link:rhoas_completion{relfilesuffix}[rhoas completion]	 - Outputs command completion for the given shell (bash, zsh, or fish)

--- a/docs/commands/rhoas_cluster.adoc
+++ b/docs/commands/rhoas_cluster.adoc
@@ -26,13 +26,14 @@ $ rhoas cluster bind
 
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_cluster_bind{relfilesuffix}[rhoas cluster bind]	 - Connect your RHOAS services to Kubernetes or OpenShift applications

--- a/docs/commands/rhoas_cluster_bind.adoc
+++ b/docs/commands/rhoas_cluster_bind.adoc
@@ -37,7 +37,8 @@ $ rhoas cluster bind --namespace=ns --app-name=myapp
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --app-name:: string       Name of the kubernetes deployment to bind
       --binding-name:: string   Name of the Service binding object to create when using operator
@@ -48,13 +49,14 @@ $ rhoas cluster bind --namespace=ns --app-name=myapp
   -n, --namespace:: string      Custom Kubernetes namespace (if not set current namespace will be used)
   -y, --yes::                   Forcibly create a binding without confirmation.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_cluster{relfilesuffix}[rhoas cluster]	 - View and perform operations on your Kubernetes or OpenShift cluster
 

--- a/docs/commands/rhoas_cluster_connect.adoc
+++ b/docs/commands/rhoas_cluster_connect.adoc
@@ -37,7 +37,8 @@ $ rhoas cluster connect
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --ignore-context::      Ignore currently selected services and ask to select each service separately
       --kubeconfig:: string   Location of the kubeconfig file.
@@ -46,13 +47,14 @@ $ rhoas cluster connect
 
   -y, --yes::                 Forcibly create a binding without confirmation.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_cluster{relfilesuffix}[rhoas cluster]	 - View and perform operations on your Kubernetes or OpenShift cluster
 

--- a/docs/commands/rhoas_cluster_status.adoc
+++ b/docs/commands/rhoas_cluster_status.adoc
@@ -28,17 +28,19 @@ $ rhoas cluster status
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --kubeconfig:: string   Location of the kubeconfig file.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_cluster{relfilesuffix}[rhoas cluster]	 - View and perform operations on your Kubernetes or OpenShift cluster
 

--- a/docs/commands/rhoas_completion.adoc
+++ b/docs/commands/rhoas_completion.adoc
@@ -17,13 +17,14 @@ Run `rhoas completion [bash|zsh|fish] -h` for instructions on installing command
 When you have installed the command completion script, make sure you restart your shell for the changes to take effect.
 
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_completion_bash{relfilesuffix}[rhoas completion bash]	 - Generate command completion script for Bash shell

--- a/docs/commands/rhoas_completion_bash.adoc
+++ b/docs/commands/rhoas_completion_bash.adoc
@@ -25,13 +25,14 @@ Installing on macOS:
 rhoas completion bash
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_completion{relfilesuffix}[rhoas completion]	 - Outputs command completion for the given shell (bash, zsh, or fish)
 

--- a/docs/commands/rhoas_completion_fish.adoc
+++ b/docs/commands/rhoas_completion_fish.adoc
@@ -17,13 +17,14 @@ Run `rhoas command completion -s fish > ~/.config/fish/completion/gh.fish` to in
 rhoas completion fish
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_completion{relfilesuffix}[rhoas completion]	 - Outputs command completion for the given shell (bash, zsh, or fish)
 

--- a/docs/commands/rhoas_completion_zsh.adoc
+++ b/docs/commands/rhoas_completion_zsh.adoc
@@ -19,13 +19,14 @@ Generate command completion script for Zsh shell.
 rhoas completion zsh
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_completion{relfilesuffix}[rhoas completion]	 - Outputs command completion for the given shell (bash, zsh, or fish)
 

--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -5,13 +5,14 @@ ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Create, view, use, and manage your Apache Kafka instances
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_kafka_consumer-group{relfilesuffix}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.

--- a/docs/commands/rhoas_kafka_consumer-group.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group.adoc
@@ -10,13 +10,14 @@ Describe, list, and delete consumer groups for the current Kafka instance.
 
 Use these commands to describe, list, and delete consumer groups for the current Kafka instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 * link:rhoas_kafka_consumer-group_delete{relfilesuffix}[rhoas kafka consumer-group delete]	 - Delete a consumer group

--- a/docs/commands/rhoas_kafka_consumer-group_delete.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_delete.adoc
@@ -24,18 +24,20 @@ $ rhoas kafka consumer-group delete consumer_group_1
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   The unique ID of the consumer group to delete
   -y, --yes::         Skip confirmation to forcibly delete a consumer group
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_consumer-group{relfilesuffix}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
 

--- a/docs/commands/rhoas_kafka_consumer-group_describe.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_describe.adoc
@@ -24,18 +24,20 @@ $ rhoas kafka consumer-group describe consumer_group_1 -o json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string       The unique ID of the consumer group to view
   -o, --output:: string   Format in which to display the consumer group. Choose from: "json", "yml", "yaml"
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_consumer-group{relfilesuffix}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
 

--- a/docs/commands/rhoas_kafka_consumer-group_list.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_list.adoc
@@ -26,19 +26,21 @@ $ rhoas kafka consumer-group list -o json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --limit:: int32     The maximum number of consumer groups to be returned (default 1000)
   -o, --output:: string   Format in which to display the consumer groups. Choose from: "json", "yml", "yaml"
       --topic:: string    Fetch the consumer groups for a specific Kafka topic
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_consumer-group{relfilesuffix}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
 

--- a/docs/commands/rhoas_kafka_create.adoc
+++ b/docs/commands/rhoas_kafka_create.adoc
@@ -32,20 +32,22 @@ $ rhoas kafka create -o yaml
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string     Format in which to display the Kafka instance. Choose from: "json", "yml", "yaml" (default "json")
       --provider:: string   Cloud Provider ID
       --region:: string     Cloud Provider Region ID
       --use::               Set the new Kafka instance to the current instance (default true)
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 

--- a/docs/commands/rhoas_kafka_delete.adoc
+++ b/docs/commands/rhoas_kafka_delete.adoc
@@ -30,18 +30,20 @@ $ rhoas kafka delete --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   Unique ID of the Kafka instance you want to delete. If not set, the current Kafka instance will be used.
   -y, --yes::         Skip confirmation to forcibly delete this Kafka instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 

--- a/docs/commands/rhoas_kafka_describe.adoc
+++ b/docs/commands/rhoas_kafka_describe.adoc
@@ -36,18 +36,20 @@ $ rhoas kafka describe -o yaml
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string       Unique ID of the Kafka instance you want to view. If not set, the current Kafka instance will be used.
   -o, --output:: string   Format in which to display the Kafka instance. Choose from: "json", "yml", "yaml" (default "json")
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 

--- a/docs/commands/rhoas_kafka_list.adoc
+++ b/docs/commands/rhoas_kafka_list.adoc
@@ -21,20 +21,22 @@ The instances are displayed by default in a table, but can also be displayed as 
 rhoas kafka list [flags]
 ....
 
-=== Options
+[discrete]
+== Options
 
       --limit:: int       The maximum number of Kafka instances to be returned (default 100)
   -o, --output:: string   Format in which to display the Kafka instances. Choose from: "json", "yml", "yaml"
       --page:: int        Display the Kafka instances from the specified page number.
       --search:: string   Text search to filter the Kafka instances by name, owner, cloud_provider, region and status
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 

--- a/docs/commands/rhoas_kafka_topic.adoc
+++ b/docs/commands/rhoas_kafka_topic.adoc
@@ -10,13 +10,14 @@ Create, describe, update, list and delete topics
 
 Create, describe, update, list and delete topics for the current Kafka instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 * link:rhoas_kafka_topic_create{relfilesuffix}[rhoas kafka topic create]	 - Create a topic

--- a/docs/commands/rhoas_kafka_topic_create.adoc
+++ b/docs/commands/rhoas_kafka_topic_create.adoc
@@ -27,7 +27,8 @@ $ rhoas kafka topic create topic-1
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --cleanup-policy:: string   Determines whether log messages are deleted, compacted, or both (default "delete")
   -o, --output:: string           Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
@@ -35,13 +36,14 @@ $ rhoas kafka topic create topic-1
       --retention-bytes:: int     The maximum total size of a partition log segments before old log segments are deleted to free up space (default -1)
       --retention-ms:: int        The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_topic{relfilesuffix}[rhoas kafka topic]	 - Create, describe, update, list and delete topics
 

--- a/docs/commands/rhoas_kafka_topic_delete.adoc
+++ b/docs/commands/rhoas_kafka_topic_delete.adoc
@@ -24,17 +24,19 @@ $ rhoas kafka topic delete topic-1
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -y, --yes::   Skip confirmation to forcibly delete a topic
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_topic{relfilesuffix}[rhoas kafka topic]	 - Create, describe, update, list and delete topics
 

--- a/docs/commands/rhoas_kafka_topic_describe.adoc
+++ b/docs/commands/rhoas_kafka_topic_describe.adoc
@@ -24,17 +24,19 @@ $ rhoas kafka topic describe topic-1
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string   Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_topic{relfilesuffix}[rhoas kafka topic]	 - Create, describe, update, list and delete topics
 

--- a/docs/commands/rhoas_kafka_topic_list.adoc
+++ b/docs/commands/rhoas_kafka_topic_list.adoc
@@ -27,18 +27,20 @@ $ rhoas kafka topic list -o json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string   Format in which to display the Kafka topics. Choose from: "json", "yml", "yaml"
       --search:: string   Text search to filter the Kafka topics by name
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_topic{relfilesuffix}[rhoas kafka topic]	 - Create, describe, update, list and delete topics
 

--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -24,20 +24,22 @@ $ rhoas kafka topic update topic-1 --retention-ms -1
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --cleanup-policy:: string    Determines whether log messages are deleted, compacted, or both
   -o, --output:: string            Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
       --retention-bytes:: string   The maximum total size of a partition log segments before old log segments are deleted to free up space
       --retention-ms:: string      The period of time in milliseconds the broker will retain a partition log before deleting it
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka_topic{relfilesuffix}[rhoas kafka topic]	 - Create, describe, update, list and delete topics
 

--- a/docs/commands/rhoas_kafka_use.adoc
+++ b/docs/commands/rhoas_kafka_use.adoc
@@ -28,17 +28,19 @@ $ rhoas kafka use --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg,
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   Unique ID of the Kafka instance you want to set as the current instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 

--- a/docs/commands/rhoas_login.adoc
+++ b/docs/commands/rhoas_login.adoc
@@ -36,7 +36,8 @@ $ rhoas login --token <your-token>
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --api-gateway:: string    URL of the API gateway. (default "https://api.openshift.com")
       --auth-url:: string       The URL of the SSO Authentication server. (default "https://sso.redhat.com/auth/realms/redhat-external")
@@ -47,13 +48,14 @@ $ rhoas login --token <your-token>
       --scope:: stringArray     Override the default OpenID scope. To specify multiple scopes, use a separate --scope for each scope. (default [openid])
   -t, --token:: string          Allows you to log in using an offline token, which can be obtained at https://cloud.redhat.com/openshift/token.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 

--- a/docs/commands/rhoas_logout.adoc
+++ b/docs/commands/rhoas_logout.adoc
@@ -14,13 +14,14 @@ Log out from RHOAS. To manage your services again, log in using "rhoas login".
 rhoas logout [flags]
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 

--- a/docs/commands/rhoas_service-account.adoc
+++ b/docs/commands/rhoas_service-account.adoc
@@ -10,13 +10,14 @@ Create, list, describe, delete and update service accounts
 
 Use these commands to create, list, describe, delete and update service accounts. You can also reset the credentials for a service account.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_service-account_create{relfilesuffix}[rhoas service-account create]	 - Create a service account

--- a/docs/commands/rhoas_service-account_create.adoc
+++ b/docs/commands/rhoas_service-account_create.adoc
@@ -41,7 +41,8 @@ $ rhoas service-account create --file-location=./service-acct-credentials.json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --description:: string     Description for the service account. Only alphanumeric characters and '-', '.', ',' are accepted.
       --file-format:: string     Format in which to save the service account credentials. Choose from: "env", "json", "properties"
@@ -49,13 +50,14 @@ $ rhoas service-account create --file-location=./service-acct-credentials.json
       --name:: string            Name of the service account.
       --overwrite::              Forcibly overwrite a credentials file if it already exists.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
 

--- a/docs/commands/rhoas_service-account_delete.adoc
+++ b/docs/commands/rhoas_service-account_delete.adoc
@@ -27,18 +27,20 @@ $ rhoas service-account delete --id 173c1ad9-932d-4007-ae0f-4da74f4d2ccd
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   The unique ID of the service account to delete
   -y, --yes::         Skip confirmation to forcibly delete this service account.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
 

--- a/docs/commands/rhoas_service-account_describe.adoc
+++ b/docs/commands/rhoas_service-account_describe.adoc
@@ -28,18 +28,20 @@ $ rhoas service-account describe --id=8a06e685-f827-44bc-b0a7-250bc8abe52e --out
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string       The unique ID of the service account to view
   -o, --output:: string   Format in which to display the service account. Choose from: "json", "yml", "yaml" (default "json")
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
 

--- a/docs/commands/rhoas_service-account_list.adoc
+++ b/docs/commands/rhoas_service-account_list.adoc
@@ -32,17 +32,19 @@ $ rhoas kafka list -o json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string   Format in which to display the service accounts. Choose from: "json", "yml", "yaml"
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
 

--- a/docs/commands/rhoas_service-account_reset-credentials.adoc
+++ b/docs/commands/rhoas_service-account_reset-credentials.adoc
@@ -36,7 +36,8 @@ $ rhoas service-account reset-credentials --id 173c1ad9-932d-4007-ae0f-4da74f4d2
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --file-format:: string     Format in which to save the service account credentials. Choose from: "env", "json", "properties"
       --file-location:: string   Sets a custom file location to save the credentials.
@@ -44,13 +45,14 @@ $ rhoas service-account reset-credentials --id 173c1ad9-932d-4007-ae0f-4da74f4d2
       --overwrite::              Forcibly overwrite a credentials file if it already exists.
   -y, --yes::                    Skip confirmation to forcibly reset service account credentials
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
 

--- a/docs/commands/rhoas_status.adoc
+++ b/docs/commands/rhoas_status.adoc
@@ -33,17 +33,19 @@ $ rhoas status -o json
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string   Format in which to display the status of your services. Choose from: "json", "yml", "yaml"
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 

--- a/docs/commands/rhoas_whoami.adoc
+++ b/docs/commands/rhoas_whoami.adoc
@@ -26,13 +26,14 @@ $ rhoas whoami
 
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 

--- a/pkg/doc/modular_adoc_docs.go
+++ b/pkg/doc/modular_adoc_docs.go
@@ -137,7 +137,8 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
-		buf.WriteString("=== Options\n\n")
+		buf.WriteString("[discrete]\n")
+		buf.WriteString("== Options\n\n")
 		buf.WriteString(FlagUsages(flags))
 		buf.WriteString("\n")
 	}
@@ -145,7 +146,8 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	parentFlags := cmd.InheritedFlags()
 	parentFlags.SetOutput(buf)
 	if parentFlags.HasAvailableFlags() {
-		buf.WriteString("=== Options inherited from parent commands\n\n")
+		buf.WriteString("[discrete]\n")
+		buf.WriteString("== Options inherited from parent commands\n\n")
 		buf.WriteString(FlagUsages(parentFlags))
 		buf.WriteString("\n")
 	}
@@ -189,7 +191,7 @@ func GenAsciidocCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	}
 	if hasSeeAlso(cmd) {
 		buf.WriteString("[discrete]\n")
-		buf.WriteString("== See Also\n\n")
+		buf.WriteString("== See also\n\n")
 		if cmd.HasParent() {
 			parent := cmd.Parent()
 			pname := parent.CommandPath()


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue>
For the CLI command ref: change "See Also" to sentence case, adjust heading levels, and add "[discrete]" markup to each section.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer