### PR TITLE
Config command support

### DIFF
--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -10,12 +10,16 @@ RHOAS CLI
 
 Manage your application services directly from the command line.
 
+<<<<<<< HEAD
 ....
 rhoas <command> <subcommand> [flags]
 ....
 
 [discrete]
 == Examples
+=======
+=== Examples
+>>>>>>> 05c29d3... docs: update and generate documentation for config command
 
 ....
 # authenticate securely through your web browser
@@ -35,19 +39,28 @@ $ rhoas cluster connect
 [discrete]
 == Options
 
+<<<<<<< HEAD
   -d, --debug::               Enable debug mode
       --devpreview:: string   Enable commands that are available under early developer preview. Use --devpreview=yes
   -h, --help::                Show help for a command
+=======
+....
+  -d, --debug   Enable debug mode
+  -h, --help    Show help for a command
+....
+>>>>>>> 05c29d3... docs: update and generate documentation for config command
 
 [discrete]
 == See also
 
 * link:rhoas_cluster{relfilesuffix}[rhoas cluster]	 - View and perform operations on your Kubernetes or OpenShift cluster
 * link:rhoas_completion{relfilesuffix}[rhoas completion]	 - Outputs command completion for the given shell (bash, zsh, or fish)
+* link:rhoas_config{relfilesuffix}[rhoas config]	 - Change specific configuration for the options
 * link:rhoas_kafka{relfilesuffix}[rhoas kafka]	 - Create, view, use, and manage your Apache Kafka instances
 * link:rhoas_login{relfilesuffix}[rhoas login]	 - Log in to RHOAS
 * link:rhoas_logout{relfilesuffix}[rhoas logout]	 - Log out from RHOAS
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
+* link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 * link:rhoas_status{relfilesuffix}[rhoas status]	 - View the status of all currently used services
 * link:rhoas_whoami{relfilesuffix}[rhoas whoami]	 - Print current username
 

--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -44,6 +44,7 @@ $ rhoas cluster connect
 * link:rhoas_login{relfilesuffix}[rhoas login]	 - Log in to RHOAS
 * link:rhoas_logout{relfilesuffix}[rhoas logout]	 - Log out from RHOAS
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
+* link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 * link:rhoas_status{relfilesuffix}[rhoas status]	 - View the status of all currently used services
 * link:rhoas_whoami{relfilesuffix}[rhoas whoami]	 - Print current username
 

--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -44,7 +44,6 @@ $ rhoas cluster connect
 * link:rhoas_login{relfilesuffix}[rhoas login]	 - Log in to RHOAS
 * link:rhoas_logout{relfilesuffix}[rhoas logout]	 - Log out from RHOAS
 * link:rhoas_service-account{relfilesuffix}[rhoas service-account]	 - Create, list, describe, delete and update service accounts
-* link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 * link:rhoas_status{relfilesuffix}[rhoas status]	 - View the status of all currently used services
 * link:rhoas_whoami{relfilesuffix}[rhoas whoami]	 - Print current username
 

--- a/docs/commands/rhoas.adoc
+++ b/docs/commands/rhoas.adoc
@@ -10,16 +10,8 @@ RHOAS CLI
 
 Manage your application services directly from the command line.
 
-<<<<<<< HEAD
-....
-rhoas <command> <subcommand> [flags]
-....
-
 [discrete]
 == Examples
-=======
-=== Examples
->>>>>>> 05c29d3... docs: update and generate documentation for config command
 
 ....
 # authenticate securely through your web browser
@@ -39,16 +31,8 @@ $ rhoas cluster connect
 [discrete]
 == Options
 
-<<<<<<< HEAD
-  -d, --debug::               Enable debug mode
-      --devpreview:: string   Enable commands that are available under early developer preview. Use --devpreview=yes
-  -h, --help::                Show help for a command
-=======
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
->>>>>>> 05c29d3... docs: update and generate documentation for config command
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
 [discrete]
 == See also

--- a/docs/commands/rhoas_config.adoc
+++ b/docs/commands/rhoas_config.adoc
@@ -16,7 +16,7 @@ Change configuration of the cli by executing one of the available subcommands
 
 ....
 # change dev preview configuration
-$ rhoas config devpreview true
+$ rhoas config dev-preview true
 
 ....
 
@@ -30,5 +30,5 @@ $ rhoas config devpreview true
 == See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
-* link:rhoas_config_devPreview{relfilesuffix}[rhoas config devPreview]	 - Sets development preview features in config
+* link:rhoas_config_dev-preview{relfilesuffix}[rhoas config dev-preview]	 - Sets development preview features in config
 

--- a/docs/commands/rhoas_config.adoc
+++ b/docs/commands/rhoas_config.adoc
@@ -20,13 +20,14 @@ $ rhoas config devpreview true
 
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_config_devPreview{relfilesuffix}[rhoas config devPreview]	 - Sets development preview features in config

--- a/docs/commands/rhoas_config.adoc
+++ b/docs/commands/rhoas_config.adoc
@@ -1,15 +1,18 @@
-== rhoas config
+= rhoas config
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Change specific configuration for the options
 
-=== Synopsis
+[discrete]
+== Synopsis
 
 Change configuration of the cli by executing one of the available subcommands
 
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 # change dev preview configuration
@@ -19,12 +22,11 @@ $ rhoas config devpreview true
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_config_devPreview{relfilesuffix}[rhoas config devPreview]	 - Sets development preview features in config

--- a/docs/commands/rhoas_config.adoc
+++ b/docs/commands/rhoas_config.adoc
@@ -1,0 +1,31 @@
+== rhoas config
+
+ifdef::env-github,env-browser[:relfilesuffix: .adoc]
+
+Change specific configuration for the options
+
+=== Synopsis
+
+Change configuration of the cli by executing one of the available subcommands
+
+
+=== Examples
+
+....
+# change dev preview configuration
+$ rhoas config devpreview true
+
+....
+
+=== Options inherited from parent commands
+
+....
+  -d, --debug   Enable debug mode
+  -h, --help    Show help for a command
+....
+
+=== SEE ALSO
+
+* link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
+* link:rhoas_config_devPreview{relfilesuffix}[rhoas config devPreview]	 - Sets development preview features in config
+

--- a/docs/commands/rhoas_config_dev-preview.adoc
+++ b/docs/commands/rhoas_config_dev-preview.adoc
@@ -1,4 +1,4 @@
-= rhoas config devPreview
+= rhoas config dev-preview
 
 [role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
@@ -13,7 +13,7 @@ Those commands usually work against alpha versions of the API and might often ha
 
 
 ....
-rhoas config devPreview [flags]
+rhoas config dev-preview [flags]
 ....
 
 [discrete]
@@ -21,7 +21,7 @@ rhoas config devPreview [flags]
 
 ....
 # change dev preview configuration
-$ rhoas config devpreview true
+$ rhoas config dev-preview true
 
 ....
 

--- a/docs/commands/rhoas_config_devPreview.adoc
+++ b/docs/commands/rhoas_config_devPreview.adoc
@@ -1,0 +1,35 @@
+== rhoas config devPreview
+
+ifdef::env-github,env-browser[:relfilesuffix: .adoc]
+
+Sets development preview features in config
+
+=== Synopsis
+
+Dev preview is used to enable commands in the CLI that are not available for general use. 
+Those commands usually work against alpha versions of the API and might often have breaking changes.
+
+
+....
+rhoas config devPreview [flags]
+....
+
+=== Examples
+
+....
+# change dev preview configuration
+$ rhoas config devpreview true
+
+....
+
+=== Options inherited from parent commands
+
+....
+  -d, --debug   Enable debug mode
+  -h, --help    Show help for a command
+....
+
+=== SEE ALSO
+
+* link:rhoas_config{relfilesuffix}[rhoas config]	 - Change specific configuration for the options
+

--- a/docs/commands/rhoas_config_devPreview.adoc
+++ b/docs/commands/rhoas_config_devPreview.adoc
@@ -1,10 +1,12 @@
-== rhoas config devPreview
+= rhoas config devPreview
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Sets development preview features in config
 
-=== Synopsis
+[discrete]
+== Synopsis
 
 Dev preview is used to enable commands in the CLI that are not available for general use. 
 Those commands usually work against alpha versions of the API and might often have breaking changes.
@@ -14,7 +16,8 @@ Those commands usually work against alpha versions of the API and might often ha
 rhoas config devPreview [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 # change dev preview configuration
@@ -24,12 +27,11 @@ $ rhoas config devpreview true
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_config{relfilesuffix}[rhoas config]	 - Change specific configuration for the options
 

--- a/docs/commands/rhoas_config_devPreview.adoc
+++ b/docs/commands/rhoas_config_devPreview.adoc
@@ -25,13 +25,14 @@ $ rhoas config devpreview true
 
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_config{relfilesuffix}[rhoas config]	 - Change specific configuration for the options
 

--- a/docs/commands/rhoas_service-registry.adoc
+++ b/docs/commands/rhoas_service-registry.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry
+= rhoas service-registry
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 [Preview] Service Registry commands
 
-=== Synopsis
+[discrete]
+== Synopsis
 
  
 Manage your Service Registry instances directly from the command line.
@@ -12,7 +14,8 @@ Manage your Service Registry instances directly from the command line.
 Create new Service Registry instances and interact with them by adding schema and API artifacts and downloading them to your computer.
 
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 ## Create Service Registry
@@ -25,12 +28,11 @@ rhoas service-registry list
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_service-registry_create{relfilesuffix}[rhoas service-registry create]	 - Create a Service Registry instance

--- a/docs/commands/rhoas_service-registry.adoc
+++ b/docs/commands/rhoas_service-registry.adoc
@@ -26,13 +26,14 @@ rhoas service-registry list
 
 ....
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas{relfilesuffix}[rhoas]	 - RHOAS CLI
 * link:rhoas_service-registry_create{relfilesuffix}[rhoas service-registry create]	 - Create a Service Registry instance

--- a/docs/commands/rhoas_service-registry_create.adoc
+++ b/docs/commands/rhoas_service-registry_create.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry create
+= rhoas service-registry create
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Create a Service Registry instance
 
-=== Synopsis
+[discrete]
+== Synopsis
 
 Create a Service Registry instance to store and manage your schema and API artifacts. 
 
@@ -13,7 +15,8 @@ Create a Service Registry instance to store and manage your schema and API artif
 rhoas service-registry create [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 ## Create Service Registry
@@ -23,19 +26,16 @@ rhoas service-registry create myregistry
 
 === Options
 
-....
-  -o, --output string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
-      --use             Set the new Service Registry instance to the current instance (default true)
-....
+  -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
+      --use::             Set the new Service Registry instance to the current instance (default true)
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_create.adoc
+++ b/docs/commands/rhoas_service-registry_create.adoc
@@ -24,18 +24,20 @@ rhoas service-registry create myregistry
 
 ....
 
-=== Options
+[discrete]
+== Options
 
   -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
       --use::             Set the new Service Registry instance to the current instance (default true)
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_delete.adoc
+++ b/docs/commands/rhoas_service-registry_delete.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry delete
+= rhoas service-registry delete
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Delete a Service Registry instance
 
-=== Synopsis
+[discrete]
+== Synopsis
 
  
 Delete a Service Registry instance along with all of its schema and API artifacts.
@@ -14,7 +16,8 @@ Delete a Service Registry instance along with all of its schema and API artifact
 rhoas service-registry delete [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 rhoas service-registry delete <id>
@@ -23,19 +26,16 @@ rhoas service-registry delete <id>
 
 === Options
 
-....
-      --id string   Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
-  -y, --yes         Skip confirmation to forcibly delete this Service Registry instance.
-....
+      --id:: string   Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
+  -y, --yes::         Skip confirmation to forcibly delete this Service Registry instance.
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_delete.adoc
+++ b/docs/commands/rhoas_service-registry_delete.adoc
@@ -24,18 +24,20 @@ rhoas service-registry delete <id>
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
   -y, --yes::         Skip confirmation to forcibly delete this Service Registry instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_describe.adoc
+++ b/docs/commands/rhoas_service-registry_describe.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry describe
+= rhoas service-registry describe
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Describe a Service Registry instance
 
-=== Synopsis
+[discrete]
+== Synopsis
 
  
 Describe a Service Registry instance. Fetch all required fields including the registry URL. 
@@ -14,7 +16,8 @@ Describe a Service Registry instance. Fetch all required fields including the re
 rhoas service-registry describe [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 rhoas service-registry describe <id>
@@ -23,19 +26,16 @@ rhoas service-registry describe <id>
 
 === Options
 
-....
-      --id string       Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
-  -o, --output string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
-....
+      --id:: string       Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
+  -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_describe.adoc
+++ b/docs/commands/rhoas_service-registry_describe.adoc
@@ -24,18 +24,20 @@ rhoas service-registry describe <id>
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string       Unique ID of the Service Registry instance you want to delete. If not set, the current Service Registry instance is used.
   -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml". (default "json")
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_list.adoc
+++ b/docs/commands/rhoas_service-registry_list.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry list
+= rhoas service-registry list
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 List Service Registry instances
 
-=== Synopsis
+[discrete]
+== Synopsis
 
  
 List all Service Registry instances for your account with the ability to paginate over the results.
@@ -14,7 +16,8 @@ List all Service Registry instances for your account with the ability to paginat
 rhoas service-registry list [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 rhoas service-registry list
@@ -23,21 +26,18 @@ rhoas service-registry list
 
 === Options
 
-....
-      --limit int32     The maximum number of Service Registry instances to be returned. (default 100)
-  -o, --output string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml".
-      --page int32      Display the Service Registry instances from the specified page number.
-      --search string   Text search to filter the Service Registry instances by name.
-....
+      --limit:: int32     The maximum number of Service Registry instances to be returned. (default 100)
+  -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml".
+      --page:: int32      Display the Service Registry instances from the specified page number.
+      --search:: string   Text search to filter the Service Registry instances by name.
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_list.adoc
+++ b/docs/commands/rhoas_service-registry_list.adoc
@@ -24,20 +24,22 @@ rhoas service-registry list
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --limit:: int32     The maximum number of Service Registry instances to be returned. (default 100)
   -o, --output:: string   Format in which to display the Service Registry instance. Choose from: "json", "yml", "yaml".
       --page:: int32      Display the Service Registry instances from the specified page number.
       --search:: string   Text search to filter the Service Registry instances by name.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_use.adoc
+++ b/docs/commands/rhoas_service-registry_use.adoc
@@ -24,17 +24,19 @@ rhoas service-registry use <id>
 
 ....
 
-=== Options
+[discrete]
+== Options
 
       --id:: string   Unique ID of the Service Registry instance you want to set as the current instance.
 
-=== Options inherited from parent commands
+[discrete]
+== Options inherited from parent commands
 
   -d, --debug::   Enable debug mode
   -h, --help::    Show help for a command
 
 [discrete]
-== See Also
+== See also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/docs/commands/rhoas_service-registry_use.adoc
+++ b/docs/commands/rhoas_service-registry_use.adoc
@@ -1,10 +1,12 @@
-== rhoas service-registry use
+= rhoas service-registry use
 
+[role="_abstract"]
 ifdef::env-github,env-browser[:relfilesuffix: .adoc]
 
 Use a Service Registry instance
 
-=== Synopsis
+[discrete]
+== Synopsis
 
  
 Select a Service Registry instance to use with all instance-specific commands.
@@ -14,7 +16,8 @@ Select a Service Registry instance to use with all instance-specific commands.
 rhoas service-registry use [flags]
 ....
 
-=== Examples
+[discrete]
+== Examples
 
 ....
 rhoas service-registry use <id>
@@ -23,18 +26,15 @@ rhoas service-registry use <id>
 
 === Options
 
-....
-      --id string   Unique ID of the Service Registry instance you want to set as the current instance.
-....
+      --id:: string   Unique ID of the Service Registry instance you want to set as the current instance.
 
 === Options inherited from parent commands
 
-....
-  -d, --debug   Enable debug mode
-  -h, --help    Show help for a command
-....
+  -d, --debug::   Enable debug mode
+  -h, --help::    Show help for a command
 
-=== SEE ALSO
+[discrete]
+== See Also
 
 * link:rhoas_service-registry{relfilesuffix}[rhoas service-registry]	 - [Preview] Service Registry commands
 

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,0 +1,79 @@
+package status
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/profile"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	IO        *iostreams.IOStreams
+	Config    config.IConfig
+	Logger    func() (logging.Logger, error)
+	localizer localize.Localizer
+
+	devPreview bool
+}
+
+const DevPreviewConfigArgument = "devPreview"
+
+var validArguments = []string{DevPreviewConfigArgument}
+
+func NewConfigCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		IO:        f.IOStreams,
+		Config:    f.Config,
+		Logger:    f.Logger,
+		localizer: f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:       "config",
+		Short:     opts.localizer.MustLocalize("config.cmd.shortDescription"),
+		Long:      opts.localizer.MustLocalize("config.cmd.longDescription"),
+		Example:   opts.localizer.MustLocalize("config.cmd.example"),
+		ValidArgs: validArguments,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return errors.New("Command accepts two arguments")
+			}
+
+			invalidConfigArg := true
+			for _, configArg := range validArguments {
+				if configArg == args[0] {
+					invalidConfigArg = false
+				}
+			}
+
+			if invalidConfigArg {
+				return errors.New("First argument should contain: " + strings.Join(validArguments, ","))
+			}
+
+			if _, err := strconv.ParseBool(args[1]); err != nil {
+				return errors.New("Second argument should be boolean")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if args[0] == DevPreviewConfigArgument {
+				devPreview, _ := strconv.ParseBool(args[1])
+				_, err := profile.EnableDevPreview(f, devPreview)
+				return err
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,4 +1,4 @@
-package status
+package config
 
 import (
 	"strconv"
@@ -40,9 +40,9 @@ func NewConfigCommand(f *factory.Factory) *cobra.Command {
 
 	devPreview := &cobra.Command{
 		Use:       "devPreview",
-		Short:     opts.localizer.MustLocalize("devPreview"),
-		Long:      opts.localizer.MustLocalize("config.cmd.longDescription"),
-		Example:   opts.localizer.MustLocalize("config.cmd.example"),
+		Short:     opts.localizer.MustLocalize("devpreview.cmd.shortDescription"),
+		Long:      opts.localizer.MustLocalize("devpreview.cmd.longDescription"),
+		Example:   opts.localizer.MustLocalize("devpreview.cmd.example"),
 		ValidArgs: []string{"true", "false"},
 		Args:      cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -38,7 +38,7 @@ func NewConfigCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	devPreview := &cobra.Command{
-		Use:       "devPreview",
+		Use:       "dev-preview",
 		Short:     opts.localizer.MustLocalize("devpreview.cmd.shortDescription"),
 		Long:      opts.localizer.MustLocalize("devpreview.cmd.longDescription"),
 		Example:   opts.localizer.MustLocalize("devpreview.cmd.example"),

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -46,7 +47,7 @@ func NewConfigCommand(f *factory.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devPreview, err := strconv.ParseBool(args[0])
 			if err != nil {
-				return err
+				return errors.New(opts.localizer.MustLocalize("devpreview.error.enablement"))
 			}
 			_, err = profile.EnableDevPreview(f, devPreview)
 			return err

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -19,8 +19,6 @@ type Options struct {
 	Config    config.IConfig
 	Logger    func() (logging.Logger, error)
 	localizer localize.Localizer
-
-	devPreview bool
 }
 
 func NewConfigCommand(f *factory.Factory) *cobra.Command {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
-	"github.com/redhat-developer/app-services-cli/pkg/profile"
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/login"
@@ -25,8 +24,6 @@ import (
 )
 
 func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
-	var devpreview string
-
 	cmd := &cobra.Command{
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -34,14 +31,6 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 		Short:         f.Localizer.MustLocalize("root.cmd.shortDescription"),
 		Long:          f.Localizer.MustLocalize("root.cmd.longDescription"),
 		Example:       f.Localizer.MustLocalize("root.cmd.example"),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if devpreview == "" {
-				return cmd.Help()
-			}
-
-			_, err := profile.EnableDevPreview(f, devpreview)
-			return err
-		},
 	}
 	fs := cmd.PersistentFlags()
 	arguments.AddDebugFlag(fs)
@@ -49,7 +38,6 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 	var help bool
 
 	fs.BoolVarP(&help, "help", "h", false, f.Localizer.MustLocalize("root.cmd.flag.help.description"))
-	cmd.Flags().StringVarP(&devpreview, "devpreview", "", "", f.Localizer.MustLocalize("root.cmd.flag.devpreview.description"))
 
 	cmd.Version = version
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,8 @@ package root
 import (
 	"flag"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/config"
+
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
@@ -54,6 +56,7 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 	cmd.AddCommand(completion.NewCompletionCommand(f))
 	cmd.AddCommand(whoami.NewWhoAmICmd(f))
 	cmd.AddCommand(cliversion.NewVersionCmd(f))
+	cmd.AddCommand(config.NewConfigCommand(f))
 
 	// Early stage/dev preview commands
 	cmd.AddCommand(registry.NewServiceRegistryCommand(f))

--- a/pkg/localize/locales/en/cmd/config.en.toml
+++ b/pkg/localize/locales/en/cmd/config.en.toml
@@ -9,7 +9,7 @@ Change configuration of the cli by executing one of the available subcommands
 [config.cmd.example]
 one = '''
 # change dev preview configuration
-$ rhoas config devpreview true
+$ rhoas config dev-preview true
 '''
 
 [devpreview.cmd.shortDescription]
@@ -24,7 +24,7 @@ Those commands usually work against alpha versions of the API and might often ha
 [devpreview.cmd.example]
 one = '''
 # change dev preview configuration
-$ rhoas config devpreview true
+$ rhoas config dev-preview true
 '''
  
 [devpreview.error.enablement]

--- a/pkg/localize/locales/en/cmd/config.en.toml
+++ b/pkg/localize/locales/en/cmd/config.en.toml
@@ -27,5 +27,5 @@ one = '''
 $ rhoas config devpreview true
 '''
  
-
- 
+[devpreview.error.enablement]
+one = 'Invalid positional argument. Valid values are "true" or "false"'

--- a/pkg/localize/locales/en/cmd/config.en.toml
+++ b/pkg/localize/locales/en/cmd/config.en.toml
@@ -4,16 +4,28 @@ one = 'Change specific configuration for the options'
 [config.cmd.longDescription]
 one = '''
 Change configuration of the cli by executing one of the available subcommands
-rhoas config --devpreview=true
 '''
 
 [config.cmd.example]
 one = '''
 # change dev preview configuration
-$ rhoas config --devpreview=true
+$ rhoas config devpreview true
 '''
 
-[config.flag.devpreview.description]
+[devpreview.cmd.shortDescription]
 one = 'Sets development preview features in config'
+
+[devpreview.cmd.longDescription]
+one = '''
+Dev preview is used to enable commands in the CLI that are not available for general use. 
+Those commands usually work against alpha versions of the API and might often have breaking changes.
+'''
+
+[devpreview.cmd.example]
+one = '''
+# change dev preview configuration
+$ rhoas config devpreview true
+'''
+ 
 
  

--- a/pkg/localize/locales/en/cmd/config.en.toml
+++ b/pkg/localize/locales/en/cmd/config.en.toml
@@ -1,0 +1,19 @@
+[config.cmd.shortDescription]
+one = 'Change specific configuration for the options'
+
+[config.cmd.longDescription]
+one = '''
+Change configuration of the cli by executing one of the available subcommands
+rhoas config --devpreview=true
+'''
+
+[config.cmd.example]
+one = '''
+# change dev preview configuration
+$ rhoas config --devpreview=true
+'''
+
+[config.flag.devpreview.description]
+one = 'Sets development preview features in config'
+
+ 

--- a/pkg/localize/locales/en/cmd/root.en.en.toml
+++ b/pkg/localize/locales/en/cmd/root.en.en.toml
@@ -24,6 +24,4 @@ $ rhoas cluster connect
 
 [root.cmd.flag.help.description]
 one = 'Show help for a command'
-
-[root.cmd.flag.devpreview.description]
-one = 'Enable commands that are available under early developer preview. Use --devpreview=yes'
+ 

--- a/pkg/localize/locales/en/profile.en.toml
+++ b/pkg/localize/locales/en/profile.en.toml
@@ -1,0 +1,8 @@
+[profile.error.enablement]
+one = 'Cannot enable dev preview.'
+
+[profile.status.devpreview.enabled]
+one = 'Developer Preview commands activated. Use help command to view them.'
+
+[profile.status.devpreview.disabled]
+one = 'Developer Preview commands deactivated.'

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -36,26 +36,26 @@ func DevPreviewEnabled(f *factory.Factory) bool {
 func EnableDevPreview(f *factory.Factory, enablement bool) (*config.Config, error) {
 	logger, err := f.Logger()
 	if err != nil {
-		logger.Info("Cannot enable dev preview. ", err)
+		logger.Info(f.Localizer.MustLocalize("profile.error.enablement"), err)
 		return nil, err
 	}
 
 	config, err := f.Config.Load()
 	if err != nil {
-		logger.Info("Cannot enable dev preview.", err)
+		logger.Info(f.Localizer.MustLocalize("profile.error.enablement"), err)
 		return nil, err
 	}
 
 	config.DevPreviewEnabled = enablement
 	err = f.Config.Save(config)
 	if err != nil {
-		logger.Info("Cannot enable dev preview. ", err)
+		logger.Info(f.Localizer.MustLocalize("profile.error.enablement"), err)
 		return nil, err
 	}
 	if config.DevPreviewEnabled {
-		logger.Info("Developer Preview commands activated. Use help command to view them.")
+		logger.Info(f.Localizer.MustLocalize("profile.status.devpreview.enabled"))
 	} else {
-		logger.Info("Developer Preview commands deactivated.")
+		logger.Info(f.Localizer.MustLocalize("profile.status.devpreview.disabled"))
 	}
 	return config, err
 }

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -2,8 +2,6 @@
 package profile
 
 import (
-	"strings"
-
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 )
@@ -35,16 +33,11 @@ func DevPreviewEnabled(f *factory.Factory) bool {
 }
 
 // Enable dev preview
-func EnableDevPreview(f *factory.Factory, enablement string) (*config.Config, error) {
+func EnableDevPreview(f *factory.Factory, enablement bool) (*config.Config, error) {
 	logger, err := f.Logger()
 	if err != nil {
 		logger.Info("Cannot enable dev preview. ", err)
 		return nil, err
-	}
-
-	if enablement == "" {
-		// Flag not present no action needed.
-		return nil, nil
 	}
 
 	config, err := f.Config.Load()
@@ -53,7 +46,7 @@ func EnableDevPreview(f *factory.Factory, enablement string) (*config.Config, er
 		return nil, err
 	}
 
-	config.DevPreviewEnabled = strings.ToLower(enablement) == "true" || enablement == "yes" || enablement == "y"
+	config.DevPreviewEnabled = enablement
 	err = f.Config.Save(config)
 	if err != nil {
 		logger.Info("Cannot enable dev preview. ", err)

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -6,15 +6,18 @@ import (
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/internal/mockutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/localize/goi18n"
 )
 
 func TestEnableDevPreviewConfig(t *testing.T) {
+	localizer, _ := goi18n.New(nil)
 	testVal := true
-	factoryObj := factory.New("dev", nil)
+	factoryObj := factory.New("dev", localizer)
+
 	factoryObj.Config = mockutil.NewConfigMock(&config.Config{})
 	config, err := EnableDevPreview(factoryObj, testVal)
-	if config != nil {
-		t.Errorf("TestEnableDevPreviewConfig config = %v, want %v", config, nil)
+	if config.DevPreviewEnabled == false {
+		t.Errorf("TestEnableDevPreviewConfig config = %v, want %v", config.DevPreviewEnabled, true)
 	}
 	if err != nil {
 		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
@@ -32,11 +35,14 @@ func TestEnableDevPreviewConfig(t *testing.T) {
 }
 
 func TestDevPreviewEnabled(t *testing.T) {
-	factoryObj := factory.New("dev", nil)
+	localizer, _ := goi18n.New(nil)
+	factoryObj := factory.New("dev", localizer)
 	factoryObj.Config = mockutil.NewConfigMock(&config.Config{})
 	testVal := false
-	config, _ := EnableDevPreview(factoryObj, testVal)
-	t.Log("Ess", config)
+	_, err := EnableDevPreview(factoryObj, testVal)
+	if err != nil {
+		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
+	}
 	enabled := DevPreviewEnabled(factoryObj)
 
 	if enabled {

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEnableDevPreviewConfig(t *testing.T) {
-	testVal := ""
+	testVal := true
 	factoryObj := factory.New("dev", nil)
 	factoryObj.Config = mockutil.NewConfigMock(&config.Config{})
 	config, err := EnableDevPreview(factoryObj, testVal)
@@ -20,7 +20,7 @@ func TestEnableDevPreviewConfig(t *testing.T) {
 		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
 	}
 
-	testVal = "giberish"
+	testVal = false
 	config, err = EnableDevPreview(factoryObj, testVal)
 	if config.DevPreviewEnabled == true {
 		t.Errorf("TestEnableDevPreviewConfig() config.DevPreviewEnabled = %v, want %v", config.DevPreviewEnabled, false)
@@ -29,29 +29,12 @@ func TestEnableDevPreviewConfig(t *testing.T) {
 		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
 	}
 
-	testVal = "true"
-	config, err = EnableDevPreview(factoryObj, testVal)
-	if config.DevPreviewEnabled != true {
-		t.Errorf("TestEnableDevPreviewConfig config.DevPreviewEnabled = %v, want %v", config.DevPreviewEnabled, true)
-	}
-	if err != nil {
-		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
-	}
-
-	testVal = "yes"
-	config, err = EnableDevPreview(factoryObj, testVal)
-	if config.DevPreviewEnabled != true {
-		t.Errorf("TestEnableDevPreviewConfig config.DevPreviewEnabled = %v, want %v", config.DevPreviewEnabled, true)
-	}
-	if err != nil {
-		t.Errorf("TestEnableDevPreviewConfig error = %v, want %v", err, nil)
-	}
 }
 
 func TestDevPreviewEnabled(t *testing.T) {
 	factoryObj := factory.New("dev", nil)
 	factoryObj.Config = mockutil.NewConfigMock(&config.Config{})
-	testVal := "false"
+	testVal := false
 	config, _ := EnableDevPreview(factoryObj, testVal)
 	t.Log("Ess", config)
 	enabled := DevPreviewEnabled(factoryObj)
@@ -60,7 +43,7 @@ func TestDevPreviewEnabled(t *testing.T) {
 		t.Errorf("TestEnableDevPreviewConfig enabled = %v, want %v", enabled, false)
 	}
 
-	testVal = "true"
+	testVal = true
 	_, _ = EnableDevPreview(factoryObj, testVal)
 
 	enabled = DevPreviewEnabled(factoryObj)


### PR DESCRIPTION
## Verification

```
[wtrocki@graphapi app-services-cli (config)]$ rhoas config devPreview true
Developer Preview commands activated. Use help command to view them.
[wtrocki@graphapi app-services-cli (config)]$ rhoas config devPreview trueds
Error: invalid argument "trueds" for "rhoas config devPreview"
[wtrocki@graphapi app-services-cli (config)]$ rhoas config devPreview false 
Developer Preview commands deactivated.
[wtrocki@graphapi app-services-cli (config)]$ 
```

## Approach

In 0b79620 I have used single command approach and 2 arguments - one which is config key second is value. 
I think that is overly complex and convoluted.
Current approach uses separate command for each key. 

Drawback is for that approach we getting documentation file generated and there is little bit of duplication in docs, but much simpler and easier to work with. 

## What is outstanding

- [x] base implementation
- [x] unit tests
- [x] Error handling mapping instead of system error
- [x] I18n :) 