### PR TITLE
feat: enable auto completion for output flag in service-registry commands

### DIFF
--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -88,6 +88,8 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().BoolVar(&opts.autoUse, "use", true, opts.localizer.MustLocalize("registry.cmd.create.flag.use.description"))
 
+	flagutil.EnableOutputFlagCompletion(cmd)
+
 	return cmd
 }
 

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -86,6 +86,8 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.common.flag.id"))
 
+	flagutil.EnableOutputFlagCompletion(cmd)
+
 	return cmd
 }
 

--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -75,6 +75,8 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, opts.localizer.MustLocalize("registry.list.flag.limit"))
 	cmd.Flags().StringVarP(&opts.search, "search", "", "", opts.localizer.MustLocalize("registry.list.flag.search"))
 
+	flagutil.EnableOutputFlagCompletion(cmd)
+
 	return cmd
 }
 


### PR DESCRIPTION
Enable static auto-completion for output flag of service-registry commands.

Closes #804 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Press tab after typing in the command `rhoas service-registry list -o`.
2. It should display the valid output formats as options.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer