### PR TITLE
fix!: Remove URL from table view for serviceregistry list command

### DIFF
--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -27,7 +27,6 @@ import (
 type RegistryRow struct {
 	ID     string `json:"id" header:"ID"`
 	Name   string `json:"name" header:"Name"`
-	URL    string `json:"registryUrl" header:"Registry URL"`
 	Owner  string `json:"owner" header:"Owner"`
 	Status string `json:"status" header:"Status"`
 }
@@ -137,7 +136,6 @@ func mapResponseItemsToRows(registries *[]srsmgmtv1.RegistryRest) []RegistryRow 
 		row := RegistryRow{
 			ID:     fmt.Sprint(k.Id),
 			Name:   k.GetName(),
-			URL:    k.GetRegistryUrl(),
 			Status: string(k.GetStatus()),
 			Owner:  k.GetOwner(),
 		}


### PR DESCRIPTION
rhoas service-registry list should not return url as it is very long and obfuscates entire table

## Impact of the change

Pre:

```
  ID   NAME   REGISTRY URL                                                                                                           OWNER                  STATUS  
 ---- ------ ---------------------------------------------------------------------------------------------------------------------- ---------------------- -------- 
  3    test   https://service-registry-stage.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/t/3b8ae86d-1478-4aa8-8b7a-a45d43e299d8   wtrocki_kafka_devexp   ready  
 ```
 
 Post:
 ```
 [wtrocki@graphapi app-services-cli (registry-table)]$ rhoas service-registry list
  ID (4)    NAME    OWNER                  STATUS  
 --------- ------- ---------------------- -------- 
  3         test    wtrocki_kafka_devexp   ready   
  4         test2   wtrocki_kafka_devexp   ready   
  5         test3   wtrocki_kafka_devexp   ready   
  6         test4   wtrocki_kafka_devexp   ready   
  ```