### PR TITLE
feat(consumer-group list): add flags for pagination

### DIFF
--- a/docs/commands/rhoas_kafka_consumer-group_list.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_list.adoc
@@ -28,9 +28,10 @@ $ rhoas kafka consumer-group list -o json
 [discrete]
 == Options
 
-      `--limit` _int32_::       The maximum number of consumer groups to be returned (default 1000)
   `-o`, `--output` _string_::   Format in which to display the consumer groups. Choose from: "json", "yml", "yaml"
+      `--page` _int32_::        Current page number for list of consumer groups. (default 1)
       `--search` _string_::     Text search to filter consumer groups by ID
+      `--size` _int32_::        Maximum number of consumer groups to be returned per page. (default 10)
       `--topic` _string_::      Fetch the consumer groups for a specific Kafka topic
 
 [discrete]

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -72,11 +72,11 @@ func NewListTopicCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if opts.page < 1 {
-				return errors.New(opts.localizer.MustLocalize("kafka.topic.list.validation.page.error.invalid.minValue", localize.NewEntry("Page", opts.page)))
+				return errors.New(opts.localizer.MustLocalize("kafka.common.page.error.invalid.minValue", localize.NewEntry("Page", opts.page)))
 			}
 
 			if opts.size < 1 {
-				return errors.New(opts.localizer.MustLocalize("kafka.topic.list.validation.size.error.invalid.minValue", localize.NewEntry("Size", opts.size)))
+				return errors.New(opts.localizer.MustLocalize("kafka.common.size.error.invalid.minValue", localize.NewEntry("Size", opts.size)))
 			}
 
 			if opts.search != "" {

--- a/pkg/localize/locales/en/cmd/kafka_common.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_common.en.toml
@@ -27,3 +27,9 @@ one = 'No Kafka instances were found.'
 [kafka.topic.common.error.topicNotFoundError]
 one = 'topic "{{.TopicName}}" does not exist in Kafka instance "{{.InstanceName}}"'
 
+
+[kafka.common.validation.page.error.invalid.minValue]
+one = 'invalid page number {{.Page}}, minimum value is -1'
+
+[kafka.common.validation.size.error.invalid.minValue]
+one = 'invalid value for size {{.Size}}, minimum value is -1'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_list.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_list.en.toml
@@ -25,6 +25,14 @@ one = 'The maximum number of consumer groups to be returned'
 description = 'Description for the --search flag'
 one = 'Text search to filter consumer groups by ID'
 
+[kafka.consumerGroup.list.flag.page]
+description = 'Description for the --page flag'
+one = 'Current page number for list of consumer groups.'
+
+[kafka.consumerGroup.list.flag.size]
+description = 'Description for the --size flag'
+one = 'Maximum number of consumer groups to be returned per page.'
+
 [kafka.consumerGroup.list.log.info.noConsumerGroups]
 one = 'Kafka instance "{{.InstanceName}}" has no consumer groups'
 

--- a/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_list.en.toml
@@ -33,12 +33,6 @@ one = 'Current page number for list of topics.'
 description = 'Description for the --size flag'
 one = 'Maximum number of items to be returned per page.'
 
-[kafka.topic.list.validation.page.error.invalid.minValue]
-one = 'invalid page number {{.Page}}, minimum value is -1'
-
-[kafka.topic.list.validation.size.error.invalid.minValue]
-one = 'invalid value for size {{.Size}}, minimum value is -1'
-
 [kafka.topic.list.log.debug.filteringTopicList]
 description = 'Debug message when filtering the list of Kafka topic'
 one = 'Filtering Kafka topics with the query "{{.Search}}"'


### PR DESCRIPTION
BREAKING: flag for deprecated field limit has been removed

<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes #766 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. List consumer groups after specifying value for `--page` and `--size` flag.
```
./rhoas kafka consumer-group list --page 1 --size 20
```
2. Passing `--limit` to `consumer-group list` command should throw error `unknown flag: --limit`
```
./rhoas kafka consumer-group list --limit 100
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer