### PR TITLE
feat(kafka topic): partitions flag for update

### DIFF
--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -29,6 +29,7 @@ $ rhoas kafka topic update topic-1 --retention-ms -1
 
       `--cleanup-policy` _string_::    Determines whether log messages are deleted, compacted, or both
   `-o`, `--output` _string_::          Format in which to display the Kafka topic. Choose from: "json", "yml", "yaml" (default "json")
+      `--partitions` _string_::        The number of partitions in the topic
       `--retention-bytes` _string_::   The maximum total size of a partition log segments before old log segments are deleted to free up space
       `--retention-ms` _string_::      The period of time in milliseconds the broker will retain a partition log before deleting it
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openconfig/goyang v0.2.7
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
-	github.com/redhat-developer/app-services-sdk-go v0.6.2
+	github.com/redhat-developer/app-services-sdk-go v0.7.0
 	github.com/redhat-developer/service-binding-operator v0.8.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-developer/app-services-sdk-go v0.6.2 h1:qOtukYepaClepwoj2iSo2k9aQlGTyoRIWboqpIbVIro=
-github.com/redhat-developer/app-services-sdk-go v0.6.2/go.mod h1:X7S6t/ePwn6NQ8/ouA+VwiojWjGfDL6jytsL5LyA4Wc=
+github.com/redhat-developer/app-services-sdk-go v0.7.0 h1:5c0NJDQRtPF9/mJM0CqDsZ6x3Us/HBEZ452Uarva9u4=
+github.com/redhat-developer/app-services-sdk-go v0.7.0/go.mod h1:X7S6t/ePwn6NQ8/ouA+VwiojWjGfDL6jytsL5LyA4Wc=
 github.com/redhat-developer/service-binding-operator v0.8.0 h1:33nrUwKm+Osr8I/g9qZZ6Hf41dfePfZndS02/xyAYiI=
 github.com/redhat-developer/service-binding-operator v0.8.0/go.mod h1:Z3fFouJGqy08JVWBFgb9ZyDcddcqx+AUIuMOeMFU8pQ=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -175,8 +175,8 @@ func runList(opts *Options) (err error) {
 		_ = dump.YAML(opts.IO.Out, data)
 	default:
 		logger.Info("")
-		topics := consumerGroupData.GetItems()
-		rows := mapConsumerGroupResultsToTableFormat(topics)
+		consumerGroups := consumerGroupData.GetItems()
+		rows := mapConsumerGroupResultsToTableFormat(consumerGroups)
 		dump.Table(opts.IO.Out, rows)
 
 		return nil

--- a/pkg/kafka/topic/validators.go
+++ b/pkg/kafka/topic/validators.go
@@ -87,7 +87,6 @@ func (v *Validator) ValidatePartitionsN(val interface{}) error {
 	}
 
 	if partitions < v.CurPartitions {
-		// return errors.New("partitions can only increase")
 		return errors.New(v.Localizer.MustLocalize("kafka.topic.common.validation.partitions.error.invalid.lesserValue", localize.NewEntry("CurrPartitions", v.CurPartitions), localize.NewEntry("Partitions", partitions)))
 	}
 

--- a/pkg/kafka/topic/validators_test.go
+++ b/pkg/kafka/topic/validators_test.go
@@ -244,13 +244,6 @@ func TestValidatePartitionsN(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Should be invalid when null string is passed",
-			args: args{
-				partitions: "",
-			},
-			wantErr: true,
-		},
-		{
 			name: "Should be valid when equal to max allowed value(100)",
 			args: args{
 				partitions: "100",

--- a/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_common.en.toml
@@ -59,6 +59,9 @@ one = 'invalid topic name "{{.Name}}"; only letters (Aa-Zz), numbers, "_", "." a
 [kafka.topic.common.validation.partitions.error.invalid.minValue]
 one = 'invalid partition count {{.Partitions}}, minimum value is {{.Min}}'
 
+[kafka.topic.common.validation.partitions.error.invalid.lesserValue]
+one = 'Topic currently has {{.CurrPartitions}} partitions, which is higher than the requested {{.Partitions}}.'
+
 [kafka.topic.common.validation.partitions.error.invalid.maxValue]
 one = 'invalid partition count {{.Partitions}}, maximum value is {{.Max}}'
 

--- a/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_topic_update.en.toml
@@ -50,3 +50,11 @@ one = 'Cleanup Policy [optional]:'
 [kafka.topic.update.input.cleanupPolicy.help]
 description = 'Help for the Cleanup policy input'
 one = 'Determines whether log messages are deleted, compacted, or both. Leave blank to skip updating this value.'
+
+[kafka.topic.update.input.partitions.message]
+description = 'Message for the Partitions input'
+one = 'Number of Partitions [optional]:'
+
+[kafka.topic.update.input.partitions.help]
+description = 'Help for the Partitions input'
+one = 'The number of partitions in the topic. Leave blank to skip updating this value.'


### PR DESCRIPTION
User should be able to update number of partitions in a topic. The number of partitions can only increase.

Closes #762 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a Kafka topic and update its partition count using `--partitions` flag.
```
./rhoas kafka topic update rama-topic --partitions 5
```
2. Partitions can only increase, trying to reduce number of partitions should throw error.
3. Validate the interactive update flow. Try providing values smaller and bigger than current partitions count.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer