### PR TITLE
fix(kafka consumer-group): use group id filter for dynamic completions

### DIFF
--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -90,6 +90,9 @@ func FilterValidConsumerGroupIDs(f *factory.Factory, toComplete string) (validID
 		return validIDs, directive
 	}
 	req := api.GetConsumerGroups(context.Background())
+	if toComplete != "" {
+		req = req.GroupIdFilter(toComplete)
+	}
 
 	cgRes, _, err := req.Execute()
 	if err != nil {


### PR DESCRIPTION
Dynamic completions for `kafka consumer-group describe` and `kafka consumer-group delete` used to fetch all the consumer groups instead of filtering(as it was not present in server).

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create some consumer groups using bin scripts.
2. Press tab twice after setting some initial text for `--id` flag of `kafka consumer-group describe` command.
```
./rhoas kafka consumer-group describe --id co
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer