### PR TITLE
feat(consumer-group describe): show unconsumed partitions

### DIFF
--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -166,6 +166,11 @@ func mapConsumerGroupDescribeToTableFormat(consumers []kafkainstanceclient.Consu
 			CurrentOffset: int(consumer.GetOffset()),
 			OffsetLag:     int(consumer.GetLag()),
 		}
+
+		if consumer.GetMemberId() == "" {
+			row.MemberID = "unconsumed"
+		}
+
 		rows = append(rows, row)
 	}
 
@@ -184,8 +189,9 @@ func printConsumerGroupDetails(w io.Writer, consumerGroupData kafkainstanceclien
 
 	activeMembersCount := cgutil.GetActiveConsumersCount(consumers)
 	partitionsWithLagCount := cgutil.GetPartitionsWithLag(consumers)
+	unconsumedPartitions := cgutil.GetUnconsumedPartitions(consumers)
 
-	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount)
+	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unconsumedPartitions")), unconsumedPartitions)
 	fmt.Fprintln(w, "")
 
 	rows := mapConsumerGroupDescribeToTableFormat(consumers)

--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -168,7 +168,7 @@ func mapConsumerGroupDescribeToTableFormat(consumers []kafkainstanceclient.Consu
 		}
 
 		if consumer.GetMemberId() == "" {
-			row.MemberID = "unconsumed"
+			row.MemberID = color.Italic("unconsumed")
 		}
 
 		rows = append(rows, row)

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -37,3 +37,9 @@ func Bold(s string) string {
 	}
 	return fmt.Sprintf("\033[1m%v\033[0m", s)
 }
+
+// Bold makes a string italicized
+func Italic(s string) string {
+	c := color.New(color.Italic)
+	return c.Sprintf(s)
+}

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -38,7 +38,7 @@ func Bold(s string) string {
 	return fmt.Sprintf("\033[1m%v\033[0m", s)
 }
 
-// Bold makes a string italicized
+// Italic makes a string italicized
 func Italic(s string) string {
 	c := color.New(color.Italic)
 	return c.Sprintf(s)

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -23,3 +23,12 @@ func GetActiveConsumersCount(consumers []kafkainstanceclient.Consumer) (count in
 	}
 	return count
 }
+
+func GetUnconsumedPartitions(consumers []kafkainstanceclient.Consumer) (unconsumedPartitions int) {
+	for _, c := range consumers {
+		if c.GetMemberId() == "" {
+			unconsumedPartitions++
+		}
+	}
+	return unconsumedPartitions
+}

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_describe.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_describe.en.toml
@@ -26,3 +26,6 @@ one = 'ACTIVE MEMBERS:'
 
 [kafka.consumerGroup.describe.output.partitionsWithLag]
 one = 'PARTITIONS WITH LAG:'
+
+[kafka.consumerGroup.describe.output.unconsumedPartitions]
+one = 'UNCONSUMED PARTITIONS:'


### PR DESCRIPTION
User should be able to see the number of unconsumed partitions in a consumer group using the `rhoas kafka consumer-group describe` command.

Closes #778 

![Screenshot from 2021-07-22 16-29-54](https://user-images.githubusercontent.com/23582438/126630071-d1c242ef-5960-4269-ab00-f9d2f0b25526.png)


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Start the mock server by running `make mock-api/start`.
2. Login
```
./rhoas login --api-gateway=http://localhost:8000
```
3. Create a kafka instance
```
./rhoas kafka create <name-of-instance>
```
4. Select the kafka instance running the command `./rhoas kafka use --id <id-of-instance>`.
```
./rhoas kafka use --id <id-of-instance>
```
5. View the consumer group with id `consumer_group_1`.
```
./rhoas kafka consumer-group describe --id consumer_group_1
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer