### PR TITLE
chore: fix binary install path for rpm and deb

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,8 +67,7 @@ changelog:
 nfpms:
   - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     description: Command line tool for RHOAS
-    bindir: /usr
+    bindir: /usr/bin
     formats:
       - deb
       - rpm
-  


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. `goreleaser release --skip-publish --skip-validate --rm-dist`
2. `rpm -qlp ./dist/rhoas_0.26.0-alpha5_linux_amd64.rpm`
3. It should list the `/usr/bin/rhoas` and not `/usr/rhoas` 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer