### PR TITLE
fix(service-account): reset-credentials prompt

### DIFF
--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -71,13 +71,15 @@ func NewResetCredentialsCommand(f *factory.Factory) *cobra.Command {
 				return flag.InvalidValueError("file-format", opts.fileFormat, flagutil.CredentialsOutputFormats...)
 			}
 
-			validator := &validation.Validator{
-				Localizer: opts.localizer,
-			}
+			if !opts.interactive {
+				validator := &validation.Validator{
+					Localizer: opts.localizer,
+				}
 
-			validID := validator.ValidateUUID(opts.id)
-			if validID != nil {
-				return validID
+				validID := validator.ValidateUUID(opts.id)
+				if validID != nil {
+					return validID
+				}
 			}
 
 			return runResetCredentials(opts)


### PR DESCRIPTION
Skip flag validations for interactive mode.

Closes #837 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Try to run `reset-credentials` in interactive mode.
```
go run ./cmd/rhoas service-account reset-credentials
``` 
2. It should prompt for values.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer