### PR TITLE
fix(i18n): set "locales" as root dir

### DIFF
--- a/pkg/localize/goi18n/go_i18n.go
+++ b/pkg/localize/goi18n/go_i18n.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"path/filepath"
 
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"gopkg.in/yaml.v2"
@@ -86,8 +85,7 @@ func (l *Goi18n) MustLocalize(id string, tmplEntries ...*localize.TemplateEntry)
 
 // walk the file system and load each file into memory
 func (l *Goi18n) load() error {
-	localesRoot := filepath.Join(l.path, l.language.String())
-	return fs.WalkDir(l.files, localesRoot, func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(l.files, l.path, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I did some investigation and believe that there are no issues in any libraries we are using and this could be resolved by changing the root directory of the locales.

go-i18n loads files from the root "locales" directory. The same root should be used when walking the file tree.

Closes #828 

### Verification Steps

On a Windows machine do the following:

1. Run `rhoas`
2. If successful, the CLI will print the help text to the console.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer