### PR TITLE
fix: update version of the kafka admin SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openconfig/goyang v0.2.7
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
-	github.com/redhat-developer/app-services-sdk-go v0.7.0
+	github.com/redhat-developer/app-services-sdk-go v0.9.0
 	github.com/redhat-developer/service-binding-operator v0.8.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-developer/app-services-sdk-go v0.7.0 h1:5c0NJDQRtPF9/mJM0CqDsZ6x3Us/HBEZ452Uarva9u4=
-github.com/redhat-developer/app-services-sdk-go v0.7.0/go.mod h1:X7S6t/ePwn6NQ8/ouA+VwiojWjGfDL6jytsL5LyA4Wc=
+github.com/redhat-developer/app-services-sdk-go v0.9.0 h1:m9Y7xxuLCw+CdaK6AaF3y/qIVYHRBJEOWjVUqRHYVzg=
+github.com/redhat-developer/app-services-sdk-go v0.9.0/go.mod h1:X7S6t/ePwn6NQ8/ouA+VwiojWjGfDL6jytsL5LyA4Wc=
 github.com/redhat-developer/service-binding-operator v0.8.0 h1:33nrUwKm+Osr8I/g9qZZ6Hf41dfePfZndS02/xyAYiI=
 github.com/redhat-developer/service-binding-operator v0.8.0/go.mod h1:Z3fFouJGqy08JVWBFgb9ZyDcddcqx+AUIuMOeMFU8pQ=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,7 +11,7 @@ import (
 type API struct {
 	Kafka          func() kafkamgmtclient.DefaultApi
 	ServiceAccount func() kafkamgmtclient.SecurityApi
-	KafkaAdmin     func(kafkaID string) (kafkainstanceclient.DefaultApi, *kafkamgmtclient.KafkaRequest, error)
+	KafkaAdmin     func(kafkaID string) (*kafkainstanceclient.APIClient, *kafkamgmtclient.KafkaRequest, error)
 	AccountMgmt    func() amsclient.DefaultApi
 
 	ServiceRegistryMgmt func() srsmgmtclient.RegistriesApi

--- a/pkg/cmd/kafka/consumergroup/delete/delete.go
+++ b/pkg/cmd/kafka/consumergroup/delete/delete.go
@@ -95,7 +95,7 @@ func runCmd(opts *Options) error {
 
 	ctx := context.Background()
 
-	_, httpRes, err := api.GetConsumerGroupById(ctx, opts.id).Execute()
+	_, httpRes, err := api.GroupsApi.GetConsumerGroupById(ctx, opts.id).Execute()
 
 	cgIDPair := localize.NewEntry("ID", opts.id)
 	kafkaNameTmplPair := localize.NewEntry("InstanceName", kafkaInstance.GetName())
@@ -124,7 +124,7 @@ func runCmd(opts *Options) error {
 		}
 	}
 
-	httpRes, err = api.DeleteConsumerGroupById(ctx, opts.id).Execute()
+	httpRes, err = api.GroupsApi.DeleteConsumerGroupById(ctx, opts.id).Execute()
 
 	if err != nil {
 		if httpRes == nil {

--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -112,7 +112,7 @@ func runCmd(opts *Options) error {
 
 	ctx := context.Background()
 
-	consumerGroupData, httpRes, err := api.GetConsumerGroupById(ctx, opts.id).Execute()
+	consumerGroupData, httpRes, err := api.GroupsApi.GetConsumerGroupById(ctx, opts.id).Execute()
 	if err != nil {
 		if httpRes == nil {
 			return err

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -123,7 +123,7 @@ func runList(opts *Options) (err error) {
 		return err
 	}
 
-	req := api.GetConsumerGroups(ctx)
+	req := api.GroupsApi.GetConsumerGroups(ctx)
 
 	if opts.topic != "" {
 		req = req.Topic(opts.topic)

--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -168,7 +168,7 @@ func runCmd(opts *Options) error {
 		return err
 	}
 
-	createTopicReq := api.CreateTopic(ctx)
+	createTopicReq := api.TopicsApi.CreateTopic(ctx)
 
 	topicInput := kafkainstanceclient.NewTopicInput{
 		Name: opts.topicName,

--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -102,7 +102,7 @@ func runCmd(opts *Options) error {
 	}
 
 	// perform delete topic API request
-	_, httpRes, err := api.GetTopic(context.Background(), opts.topicName).
+	_, httpRes, err := api.TopicsApi.GetTopic(context.Background(), opts.topicName).
 		Execute()
 
 	topicNameTmplPair := localize.NewEntry("TopicName", opts.topicName)
@@ -131,7 +131,7 @@ func runCmd(opts *Options) error {
 	}
 
 	// perform delete topic API request
-	httpRes, err = api.DeleteTopic(context.Background(), opts.topicName).
+	httpRes, err = api.TopicsApi.DeleteTopic(context.Background(), opts.topicName).
 		Execute()
 	if err != nil {
 		if httpRes == nil {

--- a/pkg/cmd/kafka/topic/describe/describe.go
+++ b/pkg/cmd/kafka/topic/describe/describe.go
@@ -105,7 +105,7 @@ func runCmd(opts *Options) error {
 	}
 
 	// fetch the topic
-	topicResponse, httpRes, err := api.
+	topicResponse, httpRes, err := api.TopicsApi.
 		GetTopic(context.Background(), opts.topicName).
 		Execute()
 	if err != nil {

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -129,7 +129,7 @@ func runCmd(opts *Options) error {
 		return err
 	}
 
-	a := api.GetTopics(context.Background())
+	a := api.TopicsApi.GetTopics(context.Background())
 
 	if opts.search != "" {
 		logger.Debug(opts.localizer.MustLocalize("kafka.topic.list.log.debug.filteringTopicList", localize.NewEntry("Search", opts.search)))

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -230,7 +230,7 @@ func runCmd(opts *Options) error {
 	// track if any values have changed
 	var needsUpdate bool
 
-	topic, httpRes, err := api.GetTopic(context.Background(), opts.topicName).Execute()
+	topic, httpRes, err := api.TopicsApi.GetTopic(context.Background(), opts.topicName).Execute()
 
 	topicNameTmplPair := localize.NewEntry("TopicName", opts.topicName)
 	kafkaNameTmplPair := localize.NewEntry("InstanceName", kafkaInstance.GetName())
@@ -246,7 +246,7 @@ func runCmd(opts *Options) error {
 	// map to store the config entries which will be updated
 	configEntryMap := map[string]*string{}
 
-	updateTopicReq := api.UpdateTopic(context.Background(), opts.topicName)
+	updateTopicReq := api.TopicsApi.UpdateTopic(context.Background(), opts.topicName)
 
 	topicSettings := &kafkainstanceclient.UpdateTopicInput{}
 
@@ -333,7 +333,7 @@ func runInteractivePrompt(opts *Options) (err error) {
 	}
 
 	// check if topic exists
-	topic, httpRes, err := api.GetTopic(context.Background(), opts.topicName).
+	topic, httpRes, err := api.TopicsApi.GetTopic(context.Background(), opts.topicName).
 		Execute()
 
 	topicNameTmplPair := localize.NewEntry("TopicName", opts.topicName)

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -48,7 +48,7 @@ func FilterValidTopicNameArgs(f *factory.Factory, toComplete string) (validNames
 	if err != nil {
 		return validNames, directive
 	}
-	req := api.GetTopics(context.Background())
+	req := api.TopicsApi.GetTopics(context.Background())
 	if toComplete != "" {
 		req = req.Filter(toComplete)
 	}
@@ -89,7 +89,7 @@ func FilterValidConsumerGroupIDs(f *factory.Factory, toComplete string) (validID
 	if err != nil {
 		return validIDs, directive
 	}
-	req := api.GetConsumerGroups(context.Background())
+	req := api.GroupsApi.GetConsumerGroups(context.Background())
 	if toComplete != "" {
 		req = req.GroupIdFilter(toComplete)
 	}

--- a/pkg/connection/keycloak_connection.go
+++ b/pkg/connection/keycloak_connection.go
@@ -179,7 +179,7 @@ func (c *KeycloakConnection) API() *api.API {
 		return srsAPIClient.RegistriesApi
 	}
 
-	kafkaAdminAPIFunc := func(kafkaID string) (kafkainstanceclient.DefaultApi, *kafkamgmtclient.KafkaRequest, error) {
+	kafkaAdminAPIFunc := func(kafkaID string) (*kafkainstanceclient.APIClient, *kafkamgmtclient.KafkaRequest, error) {
 		api := kafkaAPIFunc()
 
 		kafkaInstance, resp, err := api.GetKafkaById(context.Background(), kafkaID).Execute()
@@ -215,9 +215,9 @@ func (c *KeycloakConnection) API() *api.API {
 		}
 
 		// create the client
-		apiClient := c.createKafkaAdminAPI(bootstrapURL)
+		client := c.createKafkaAdminAPI(bootstrapURL)
 
-		return *apiClient, &kafkaInstance, nil
+		return client, &kafkaInstance, nil
 	}
 
 	return &api.API{
@@ -254,7 +254,7 @@ func (c *KeycloakConnection) createServiceRegistryAPIClient() *registrymgmtclien
 }
 
 // Create a new KafkaAdmin API client
-func (c *KeycloakConnection) createKafkaAdminAPI(bootstrapURL string) *kafkainstanceclient.DefaultApi {
+func (c *KeycloakConnection) createKafkaAdminAPI(bootstrapURL string) *kafkainstanceclient.APIClient {
 	host, port, _ := net.SplitHostPort(bootstrapURL)
 
 	var apiURL *url.URL
@@ -282,7 +282,7 @@ func (c *KeycloakConnection) createKafkaAdminAPI(bootstrapURL string) *kafkainst
 		HTTPClient: c.createOAuthTransport(c.MASToken.AccessToken),
 	})
 
-	return &client.DefaultApi
+	return client
 }
 
 func (c *KeycloakConnection) createAmsAPIClient() *amsclient.APIClient {

--- a/pkg/kafka/topic/validators.go
+++ b/pkg/kafka/topic/validators.go
@@ -153,7 +153,7 @@ func (v *Validator) ValidateNameIsAvailable(val interface{}) error {
 		return err
 	}
 
-	_, httpRes, _ := api.GetTopic(context.Background(), name).Execute()
+	_, httpRes, _ := api.TopicsApi.GetTopic(context.Background(), name).Execute()
 
 	if httpRes != nil && httpRes.StatusCode == 200 {
 		return errors.New(v.Localizer.MustLocalize("kafka.topic.create.error.conflictError", localize.NewEntry("TopicName", name), localize.NewEntry("InstanceName", kafkaInstance.GetName())))


### PR DESCRIPTION
New API splits for topics/groups/acls.
I did not add ACL API yet but have concerns how to do update CLI.

We can either do this:

<img width="1243" alt="Screenshot 2021-07-28 at 15 46 09" src="https://user-images.githubusercontent.com/981838/127343963-9131bbfc-1841-41e1-821b-0258b009761f.png">
Or this:
<img width="1188" alt="Screenshot 2021-07-28 at 15 45 37" src="https://user-images.githubusercontent.com/981838/127343972-65fa62b4-5e4e-4323-987b-4a5d4f880e5b.png">

Opinions? FIrst approach is implemented in PR