### PR TITLE
Apicurio CLI 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -233,6 +233,21 @@
       "args": [
         "version"
       ]
-    }
+    },
+    {
+      "name": "Artifact Delete",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/rhoas",
+      "env": {},
+      "args": [
+        "service-registry",
+        "artifact",
+        "delete",
+        "--group=tgdsfgdfg",
+        "--yes"
+      ]
+    },
   ]
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -4,15 +4,17 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/api/ams/amsclient"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
-	srsmgmtclient "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	registrymgmtclient "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
 )
 
 // API is a type which defines a number of API creator functions
 type API struct {
-	Kafka          func() kafkamgmtclient.DefaultApi
-	ServiceAccount func() kafkamgmtclient.SecurityApi
-	KafkaAdmin     func(kafkaID string) (*kafkainstanceclient.APIClient, *kafkamgmtclient.KafkaRequest, error)
-	AccountMgmt    func() amsclient.DefaultApi
+	Kafka                   func() kafkamgmtclient.DefaultApi
+	ServiceAccount          func() kafkamgmtclient.SecurityApi
+	KafkaAdmin              func(kafkaID string) (*kafkainstanceclient.APIClient, *kafkamgmtclient.KafkaRequest, error)
+	ServiceRegistryInstance func(registryID string) (*registryinstanceclient.APIClient, *registrymgmtclient.RegistryRest, error)
+	AccountMgmt             func() amsclient.DefaultApi
 
-	ServiceRegistryMgmt func() srsmgmtclient.RegistriesApi
+	ServiceRegistryMgmt func() registrymgmtclient.RegistriesApi
 }

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -28,25 +28,25 @@ This set of commands provide create, read, update, and delete operations for sch
 `,
 		Example: `
 ## Create artifact in my-group from schema.json file
-rhoas service-registry artifact create --artifact=my-artifact --group=my-group artifact.json
+rhoas service-registry artifact create --artifact-id=my-artifact --group=my-group artifact.json
 
 ## Get artifact content
-rhoas service-registry artifact get --artifact=my-artifact --group=my-group file.json 
+rhoas service-registry artifact get --artifact-id=my-artifact --group=my-group file.json 
 
 ## Delete artifact
-rhoas service-registry artifact delete --artifact=my-artifact
+rhoas service-registry artifact delete --artifact-id=my-artifact
 
 ## Get artifact metadata
-rhoas service-registry artifact metadata --artifact=my-artifact --group=my-group
+rhoas service-registry artifact metadata --artifact-id=my-artifact --group=my-group
 
 ## Update artifact
-rhoas service-registry artifact update --artifact=my-artifact artifact-new.json
+rhoas service-registry artifact update --artifact-id=my-artifact artifact-new.json
 
 ## List Artifacts
 rhoas service-registry artifact list --group=my-group --limit=10 page=1
 
 ## View artifact versions
-rhoas service-registry artifact versions --artifact=my-artifact --group=my-group
+rhoas service-registry artifact versions --artifact-id=my-artifact --group=my-group
 		`,
 		Args: cobra.MinimumNArgs(1),
 	}

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -1,0 +1,53 @@
+package artifact
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/crud/create"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/crud/delete"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/crud/get"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/crud/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/crud/update"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/download"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/metadata"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/versions"
+	"github.com/spf13/cobra"
+)
+
+func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "artifacts",
+		Short: "Manage Service Registry Artifacts commands",
+		Long: `Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
+				For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.
+				Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 
+				For example, this includes rules for content validation and version compatibility.
+				
+				Registry commands enable client applications to manage the artifacts in the registry. 
+				This set of commands provide create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.`,
+		Example: `
+		## Create artifact in my-group from schema.json file
+		rhoas service-registry artifacts create my-group schema.json
+
+		## List Artifacts
+		rhoas service-registry artifacts list my-group
+		`,
+		Args: cobra.MinimumNArgs(1),
+	}
+
+	// add sub-commands
+	cmd.AddCommand(
+		// CRUD
+		create.NewCreateCommand(f),
+		get.NewGetCommand(f),
+		delete.NewDeleteCommand(f),
+		list.NewListCommand(f),
+		update.NewUpdateCommand(f),
+
+		// Misc
+		metadata.NewMetadataCommand(f),
+		versions.NewVersionsCommand(f),
+		download.NewDownloadCommand(f),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -16,7 +16,7 @@ import (
 func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "artifact",
-		Short: "Manage Service Registry Artifacts commands",
+		Short: "Manage Service Registry Artifacts",
 		Long: `
 Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
 For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -15,21 +15,38 @@ import (
 
 func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "artifacts",
+		Use:   "artifact",
 		Short: "Manage Service Registry Artifacts commands",
-		Long: `Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
-				For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.
-				Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 
-				For example, this includes rules for content validation and version compatibility.
-				
-				Registry commands enable client applications to manage the artifacts in the registry. 
-				This set of commands provide create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.`,
-		Example: `
-		## Create artifact in my-group from schema.json file
-		rhoas service-registry artifacts create my-group schema.json
+		Long: `
+Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
+For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.
+Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 
+For example, this includes rules for content validation and version compatibility.
 
-		## List Artifacts
-		rhoas service-registry artifacts list my-group
+Registry commands enable client applications to manage the artifacts in the registry. 
+This set of commands provide create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.
+`,
+		Example: `
+## Create artifact in my-group from schema.json file
+rhoas service-registry artifact create --artifact=my-artifact --group=my-group artifact.json
+
+## Get artifact content
+rhoas service-registry artifact get --artifact=my-artifact --group=my-group file.json 
+
+## Delete artifact
+rhoas service-registry artifact delete --artifact=my-artifact
+
+## Get artifact metadata
+rhoas service-registry artifact metadata --artifact=my-artifact --group=my-group
+
+## Update artifact
+rhoas service-registry artifact update --artifact=my-artifact artifact-new.json
+
+## List Artifacts
+rhoas service-registry artifact list --group=my-group --limit=10 page=1
+
+## View artifact versions
+rhoas service-registry artifact versions --artifact=my-artifact --group=my-group
 		`,
 		Args: cobra.MinimumNArgs(1),
 	}

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -128,7 +128,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", "Type of artifact. Choose from:  "+util.GetAllowedArtifactTypeEnumValuesAsString())
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -159,7 +159,7 @@ func runCreate(opts *Options) error {
 	}
 
 	if opts.group == util.DefaultArtifactGroup {
-		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
+		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -87,14 +87,11 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		Short: "Creates new artifact from file or standard input",
 		Long:  longDescription,
 		Example: `
-## Create artifact in my-group from schema.json file
-rhoas service-registry artifacts create my-group schema.json
-
 # Create an artifact in default group
-rhoas service-registry artifacts create my-artifact.json
+rhoas service-registry artifact create my-artifact.json
 
 # Create an artifact with specified type
-rhoas service-registry artifacts create --type=JSON my-artifact.json
+rhoas service-registry artifact create --type=JSON my-artifact.json
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -2,18 +2,15 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
 	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
-	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
@@ -197,14 +194,7 @@ func runCreate(opts *Options) error {
 	}
 	logger.Info("Artifact created")
 
-	switch opts.outputFormat {
-	case "json":
-		data, _ := json.MarshalIndent(metadata, "", cmdutil.DefaultJSONIndent)
-		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
-		data, _ := yaml.Marshal(metadata)
-		_ = dump.YAML(opts.IO.Out, data)
-	}
+	dump.PrintDataInFormat(opts.outputFormat, metadata, opts.IO.Out)
 
 	return nil
 }

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -129,7 +129,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", "Type of artifact. Choose from:  "+util.GetAllowedArtifactTypeEnumValuesAsString())
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 
@@ -158,8 +158,8 @@ func runCreate(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
-		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+	if opts.group == util.DefaultArtifactGroup {
+		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 
@@ -171,7 +171,7 @@ func runCreate(opts *Options) error {
 			return err
 		}
 	} else {
-		logger.Info("Reading file content from stdin")
+		logger.Info("Reading file content from standard input")
 		specifiedFile, err = util.CreateFileFromStdin()
 		if err != nil {
 			return err

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -112,12 +112,12 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 
 			if opts.artifactType != "" {
 				if _, err = registryinstanceclient.NewArtifactTypeFromValue(opts.artifactType); err != nil {
-					return errors.New("Invalid artifact type. Please use one of following values: " + util.GetAllowedArtifactTypeEnumValuesAsString())
+					return errors.New("invalid artifact type. Please use one of following values: " + util.GetAllowedArtifactTypeEnumValuesAsString())
 				}
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' use to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -1,0 +1,213 @@
+package create
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	"gopkg.in/yaml.v2"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+)
+
+type Options struct {
+	artifact string
+	group    string
+
+	file         string
+	artifactType string
+
+	registryID   string
+	outputFormat string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     func() (logging.Logger, error)
+	localizer  localize.Localizer
+}
+
+var longDescription = `
+Creates a new artifact by posting the artifact content to the registry.
+
+Artifacts can be typically in JSON format for most of the supported types, but may be in another format for a few (for example, PROTOBUF).
+The registry attempts to figure out what kind of artifact is being added from the following supported list:
+
+- Avro (AVRO)
+- Protobuf (PROTOBUF)
+- JSON Schema (JSON)
+- Kafka Connect (KCONNECT)
+- OpenAPI (OPENAPI)
+- AsyncAPI (ASYNCAPI)
+- GraphQL (GRAPHQL)
+- Web Services Description Language (WSDL)
+- XML Schema (XSD)
+
+An artifact is created using the content provided in the body of the request.  
+This content is created under a unique artifact ID that can be provided by user.
+If not provided in the request, the server generates a unique ID for the artifact. 
+It is typically recommended that callers provide the ID, because this is a meaningful identifier, and for most use cases should be supplied by the caller.
+If an artifact with the provided artifact ID already exists command will fail with error.
+
+
+When --group parameter is missing the command will create a new artifact under the "default" group.
+when --registry is missing the command will create a new artifact for currently active service registry (visible in rhoas service-registry describe)
+`
+
+func NewCreateCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates new artifact from file or standard input",
+		Long:  longDescription,
+		Example: `
+## Create artifact in my-group from schema.json file
+rhoas service-registry artifacts create my-group schema.json
+
+# Create an artifact in default group
+rhoas service-registry artifacts create my-artifact.json
+
+# Create an artifact with specified type
+rhoas service-registry artifacts create --type=JSON my-artifact.json
+		`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			validOutputFormats := flagutil.ValidOutputFormats
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
+				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
+			}
+
+			if len(args) > 0 {
+				opts.file = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runCreate(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if opts.artifactType != "" {
+				if _, err = registryinstanceclient.NewArtifactTypeFromValue(opts.artifactType); err != nil {
+					return errors.New("Invalid artifact type. Please use one of following values: " + util.GetAllowedArtifactTypeEnumValuesAsString())
+				}
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runCreate(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
+	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", "Type of artifact. Choose from:  "+util.GetAllowedArtifactTypeEnumValuesAsString())
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+	_ = cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return util.AllowedArtifactTypeEnumValues, cobra.ShellCompDirectiveNoSpace
+	})
+
+	return cmd
+}
+
+func runCreate(opts *Options) error {
+
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	var specifiedFile *os.File
+	if opts.file != "" {
+		logger.Info("Opening file: " + opts.file)
+		specifiedFile, err = os.Open(opts.file)
+		if err != nil {
+			return err
+		}
+	} else {
+		logger.Info("Reading file content from stdin")
+		specifiedFile, err = util.CreateFileFromStdin()
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx := context.Background()
+	request := dataAPI.ArtifactsApi.CreateArtifact(ctx, opts.group)
+	if opts.artifactType != "" {
+		request = request.XRegistryArtifactType(registryinstanceclient.ArtifactType(opts.artifactType))
+	}
+	if opts.artifact != "" {
+		request = request.XRegistryArtifactId(opts.artifact)
+	}
+
+	request = request.Body(specifiedFile)
+	metadata, _, err := request.Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+	logger.Info("Artifact created")
+
+	switch opts.outputFormat {
+	case "json":
+		data, _ := json.MarshalIndent(metadata, "", cmdutil.DefaultJSONIndent)
+		_ = dump.JSON(opts.IO.Out, data)
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(metadata)
+		_ = dump.YAML(opts.IO.Out, data)
+	}
+
+	return nil
+}

--- a/pkg/cmd/registry/artifact/crud/crud.go
+++ b/pkg/cmd/registry/artifact/crud/crud.go
@@ -1,0 +1,1 @@
+package crud

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -93,7 +93,7 @@ rhoas service-registry artifact delete my-artifact
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' use to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
@@ -149,7 +149,7 @@ func runDelete(opts *Options) error {
 	} else {
 		_, _, err := dataAPI.MetadataApi.GetArtifactMetaData(ctx, opts.group, opts.artifact).Execute()
 		if err != nil {
-			return errors.New("Artifact " + opts.artifact + " not found")
+			return errors.New("artifact " + opts.artifact + " not found")
 		}
 		logger.Info("Deleting artifact " + opts.artifact)
 		err = confirmDelete(opts, "Do you want to delete artifact "+opts.artifact+" from group "+opts.group)

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -145,7 +145,7 @@ func runDelete(opts *Options) error {
 		if err != nil {
 			return registryinstanceerror.TransformError(err)
 		}
-		logger.Info("Artifacts in group" + opts.group + " deleted")
+		logger.Info("Artifacts in group " + opts.group + " deleted")
 	} else {
 		_, _, err := dataAPI.MetadataApi.GetArtifactMetaData(ctx, opts.group, opts.artifact).Execute()
 		if err != nil {

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -56,8 +56,8 @@ Deletes all of the artifacts that exist in a given group.
 
 Delete command works in two modes:
 
-	- When --artifact argument is missing delete will delete all artifacts in the group
-	- When --artifact is specified delete deletes only single artifact and its version
+	- When --artifact-id argument is missing delete will delete all artifacts in the group
+	- When --artifact-id is specified delete deletes only single artifact and its version
 
 When --group parameter is missing the command will create a new artifact under the "default" group.
 		`,
@@ -104,7 +104,7 @@ rhoas service-registry artifact delete my-artifact
 	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, "Delete without prompt")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	flagutil.EnableOutputFlagCompletion(cmd)

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -129,7 +129,7 @@ func runDelete(opts *Options) error {
 	}
 
 	if opts.group == util.DefaultArtifactGroup {
-		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
+		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -105,7 +105,7 @@ rhoas service-registry artifact delete my-artifact
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	flagutil.EnableOutputFlagCompletion(cmd)
 
@@ -128,8 +128,8 @@ func runDelete(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
-		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+	if opts.group == util.DefaultArtifactGroup {
+		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -1,0 +1,184 @@
+package delete
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	artifact string
+	group    string
+
+	registryID string
+
+	outputFormat string
+	force        bool
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     func() (logging.Logger, error)
+	localizer  localize.Localizer
+}
+
+func NewDeleteCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Deletes all of the artifacts that exist in a given group",
+		Long: `
+Deletes all of the artifacts that exist in a given group. 
+
+Delete command works in two modes:
+
+	- When --artifact argument is missing delete will delete all artifacts in the group
+	- When --artifact is specified delete deletes only single artifact and its version
+
+When --group parameter is missing the command will create a new artifact under the "default" group.
+		`,
+		Example: `
+## Delete all artifacts in the group "default"
+rhoas service-registry artifact delete 
+
+## Delete artifact in the group "default" with name "my-artifact"
+rhoas service-registry artifact delete my-artifact
+		`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !opts.IO.CanPrompt() && !opts.force {
+				return flag.RequiredWhenNonInteractiveError("yes")
+			}
+
+			validOutputFormats := flagutil.ValidOutputFormats
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
+				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
+			}
+
+			if len(args) > 0 {
+				opts.artifact = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runDelete(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runDelete(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, "Delete without prompt")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runDelete(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	if opts.artifact == "" {
+		logger.Info("Artifact was not specified. Command will delete all artifacts in the group")
+		err = confirmDelete(opts, "Do you want to delete ALL ARTIFACTS from group "+opts.group)
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		request := dataAPI.ArtifactsApi.DeleteArtifactsInGroup(ctx, opts.group)
+		_, err = request.Execute()
+		if err != nil {
+			return registryinstanceerror.TransformError(err)
+		}
+		logger.Info("Artifacts in group" + opts.group + " deleted")
+	} else {
+		logger.Info("Deleting artifact " + opts.artifact)
+		err = confirmDelete(opts, "Do you want to delete artifact "+opts.artifact+" from group "+opts.group)
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		request := dataAPI.ArtifactsApi.DeleteArtifact(ctx, opts.group, opts.artifact)
+
+		_, err := request.Execute()
+		if err != nil {
+			return registryinstanceerror.TransformError(err)
+		}
+		logger.Info("Artifact deleted: " + opts.artifact)
+	}
+
+	return nil
+}
+
+func confirmDelete(opts *Options, message string) error {
+	if !opts.force {
+		var shouldContinue bool
+		confirm := &survey.Confirm{
+			Message: message,
+		}
+		err := survey.AskOne(confirm, &shouldContinue)
+		if err != nil {
+			return err
+		}
+
+		if !shouldContinue {
+			return errors.New("")
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -133,13 +133,13 @@ func runDelete(opts *Options) error {
 		opts.group = util.DefaultArtifactGroup
 	}
 
+	ctx := context.Background()
 	if opts.artifact == "" {
 		logger.Info("Artifact was not specified. Command will delete all artifacts in the group")
 		err = confirmDelete(opts, "Do you want to delete ALL ARTIFACTS from group "+opts.group)
 		if err != nil {
 			return err
 		}
-		ctx := context.Background()
 		request := dataAPI.ArtifactsApi.DeleteArtifactsInGroup(ctx, opts.group)
 		_, err = request.Execute()
 		if err != nil {
@@ -147,15 +147,18 @@ func runDelete(opts *Options) error {
 		}
 		logger.Info("Artifacts in group" + opts.group + " deleted")
 	} else {
+		_, _, err := dataAPI.MetadataApi.GetArtifactMetaData(ctx, opts.group, opts.artifact).Execute()
+		if err != nil {
+			return errors.New("Artifact " + opts.artifact + " not found")
+		}
 		logger.Info("Deleting artifact " + opts.artifact)
 		err = confirmDelete(opts, "Do you want to delete artifact "+opts.artifact+" from group "+opts.group)
 		if err != nil {
 			return err
 		}
-		ctx := context.Background()
 		request := dataAPI.ArtifactsApi.DeleteArtifact(ctx, opts.group, opts.artifact)
 
-		_, err := request.Execute()
+		_, err = request.Execute()
 		if err != nil {
 			return registryinstanceerror.TransformError(err)
 		}

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -180,7 +180,7 @@ func confirmDelete(opts *Options, message string) error {
 		}
 
 		if !shouldContinue {
-			return errors.New("")
+			return errors.New("command stopped by user")
 		}
 	}
 	return nil

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -57,16 +57,16 @@ For fetching artifacts using global identifiers please use "service-registry dow
 `,
 		Example: `
 ## Get latest artifact by name
-rhoas service-registry artifacts get myschema
+rhoas service-registry artifact get myschema
 
 ## Get latest artifact and save its content to file
-rhoas service-registry artifacts get myschema myschema.json
+rhoas service-registry artifact get myschema myschema.json
 
 ## Get latest artifact and pipe it to other command 
-rhoas service-registry artifacts get myschema | grep -i 'user'
+rhoas service-registry artifact get myschema | grep -i 'user'
 
 ## Get latest artifact by specifying custom group, registry and name as flag
-rhoas service-registry artifacts get --group mygroup --instance-id=myregistry --artifact myartifact
+rhoas service-registry artifact get --group mygroup --instance-id=myregistry --artifact myartifact
 `,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -75,7 +75,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact-id flag")
+				return errors.New("artifact is required. Please specify artifact as positional argument or by using --artifact-id flag")
 			}
 
 			if len(args) > 1 {
@@ -92,7 +92,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -66,7 +66,7 @@ rhoas service-registry artifact get myschema myschema.json
 rhoas service-registry artifact get myschema | grep -i 'user'
 
 ## Get latest artifact by specifying custom group, registry and name as flag
-rhoas service-registry artifact get --group mygroup --instance-id=myregistry --artifact myartifact
+rhoas service-registry artifact get --group mygroup --instance-id=myregistry --artifact-id myartifact
 `,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -75,7 +75,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact flag")
+				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact-id flag")
 			}
 
 			if len(args) > 1 {
@@ -100,7 +100,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFile, "output-file", "", "", "Filename of the output file")

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -101,7 +101,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFile, "output-file", "", "", "Filename of the output file")
 	cmd.Flags().StringVarP(&opts.version, "version", "", "", "Version of the artifact")
@@ -127,8 +127,8 @@ func runGet(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
-		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+	if opts.group == util.DefaultArtifactGroup {
+		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -1,0 +1,165 @@
+package get
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+)
+
+type Options struct {
+	artifact   string
+	group      string
+	outputFile string
+
+	registryID string
+	version    string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Logger     func() (logging.Logger, error)
+	Connection factory.ConnectionFunc
+	localizer  localize.Localizer
+}
+
+func NewGetCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Logger:     f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get artifact by id and group",
+		Long: `Get artifact by specifying id and group.
+Command will fetch the latest artifact from the registry based on the artifactId and group.
+
+When --version is specified command will fetch the specific version of the artifact.
+Get command will fetch artifacts based on group and artifactId and version.
+For fetching artifacts using global identifiers please use "service-registry download" command
+`,
+		Example: `
+## Get latest artifact by name
+rhoas service-registry artifacts get myschema
+
+## Get latest artifact and save its content to file
+rhoas service-registry artifacts get myschema myschema.json
+
+## Get latest artifact and pipe it to other command 
+rhoas service-registry artifacts get myschema | grep -i 'user'
+
+## Get latest artifact by specifying custom group, registry and name as flag
+rhoas service-registry artifacts get --group mygroup --instance-id=myregistry --artifact myartifact
+`,
+		Args: cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.artifact = args[0]
+			}
+
+			if opts.artifact == "" {
+				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact flag")
+			}
+
+			if len(args) > 1 {
+				opts.outputFile = args[1]
+			}
+
+			if opts.registryID != "" {
+				return runGet(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runGet(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+	cmd.Flags().StringVarP(&opts.outputFile, "output-file", "", "", "Filename of the output file")
+	cmd.Flags().StringVarP(&opts.version, "version", "", "", "Version of the artifact")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runGet(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	ctx := context.Background()
+	var dataFile *os.File
+	if opts.version != "" {
+		logger.Info("Fetching artifact with version: " + opts.version)
+		request := dataAPI.VersionsApi.GetArtifactVersion(ctx, opts.group, opts.artifact, opts.version)
+		dataFile, _, err = request.Execute()
+	} else {
+		logger.Info("Fetching latest artifact")
+		request := dataAPI.ArtifactsApi.GetLatestArtifact(ctx, opts.group, opts.artifact)
+		dataFile, _, err = request.Execute()
+	}
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+	fileContent, err := ioutil.ReadFile(dataFile.Name())
+	if err != nil {
+		return err
+	}
+	if opts.outputFile != "" {
+		err := os.WriteFile(opts.outputFile, fileContent, 0600)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Print to stdout
+		fmt.Fprintf(os.Stdout, "%v\n", string(fileContent))
+	}
+
+	logger.Info("Successfully fetched artifact")
+	return nil
+}

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -128,7 +128,7 @@ func runGet(opts *Options) error {
 	}
 
 	if opts.group == util.DefaultArtifactGroup {
-		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
+		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -75,13 +75,13 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 		Long:  "List all artifacts for the group by specified output format (by default table)",
 		Example: `
 ## List all artifacts for the default artifacts group
-rhoas service-registry artifacts list
+rhoas service-registry artifact list
 
 ## List all artifacts with explicit group 
-rhoas service-registry artifacts list --group=my=group
+rhoas service-registry artifact list --group=my-group
 
 ## List all artifacts with limit and group
-rhoas service-registry artifacts list --page=2 --limit=10
+rhoas service-registry artifact list --page=2 --limit=10
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -1,0 +1,199 @@
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
+	"gopkg.in/yaml.v2"
+)
+
+// row is the details of a Service Registry instance needed to print to a table
+type artifactRow struct {
+	// The ID of a single artifact.
+	Id string `json:"id" header:"ID"`
+
+	Name string `json:"name,omitempty" header:"Name"`
+
+	CreatedOn string `json:"createdOn" header:"Created on"`
+
+	CreatedBy string `json:"createdBy" header:"Created By"`
+
+	Type registryinstanceclient.ArtifactType `json:"type" header:"Type"`
+
+	State registryinstanceclient.ArtifactState `json:"state" header:"State"`
+}
+
+type Options struct {
+	group string
+
+	registryID   string
+	outputFormat string
+	orderBy      string
+
+	page  int32
+	limit int32
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     func() (logging.Logger, error)
+	localizer  localize.Localizer
+}
+
+// NewListCommand creates a new command for listing service registries.
+func NewListCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List artifacts",
+		Long:  "List all artifacts for the group by specified output format (by default table)",
+		Example: `
+## List all artifacts for the default artifacts group
+rhoas service-registry artifacts list
+
+## List all artifacts with explicit group 
+rhoas service-registry artifacts list --group=my=group
+
+## List all artifacts with limit and group
+rhoas service-registry artifacts list --page=2 --limit=10
+		`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, flagutil.ValidOutputFormats...) {
+				return flag.InvalidValueError("output", opts.outputFormat, flagutil.ValidOutputFormats...)
+			}
+
+			if len(args) > 0 {
+				opts.group = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runList(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use rhoas registry use to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+
+			return runList(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Artifact group")
+
+	cmd.Flags().Int32VarP(&opts.page, "page", "", 1, "Page number")
+	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, "Page limit")
+	cmd.Flags().StringVarP(&opts.orderBy, "order", "", "", "Order by fields (id, name etc.) ")
+
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml, table)")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runList(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	connection, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	api := connection.API()
+
+	a, _, err := api.ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+	request := a.ArtifactsApi.ListArtifactsInGroup(context.Background(), opts.group)
+	request = request.Offset(opts.page * opts.limit)
+	request = request.Limit(opts.limit)
+
+	response, _, err := request.Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	if len(response.Artifacts) == 0 && opts.outputFormat == "" {
+		logger.Info("No artifacts available for this group and registry instance")
+		return nil
+	}
+
+	switch opts.outputFormat {
+	case "json":
+		data, _ := json.Marshal(response)
+		_ = dump.JSON(opts.IO.Out, data)
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(response)
+		_ = dump.YAML(opts.IO.Out, data)
+	default:
+		rows := mapResponseItemsToRows(&response.Artifacts)
+		dump.Table(opts.IO.Out, rows)
+		logger.Info("")
+	}
+
+	return nil
+}
+
+func mapResponseItemsToRows(artifacts *[]registryinstanceclient.SearchedArtifact) []artifactRow {
+	rows := []artifactRow{}
+
+	for i := range *artifacts {
+		k := (*artifacts)[i]
+		row := artifactRow{
+			Id:        k.GetId(),
+			Name:      k.GetName(),
+			CreatedOn: k.GetCreatedOn(),
+			CreatedBy: k.GetCreatedBy(),
+			Type:      k.GetType(),
+			State:     k.GetState(),
+		}
+
+		rows = append(rows, row)
+	}
+
+	return rows
+}

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -93,6 +93,10 @@ rhoas service-registry artifact list --page=2 --limit=10
 				opts.group = args[0]
 			}
 
+			if opts.page < 1 || opts.limit < 1 {
+				return errors.New("page and limit values should be bigger than 1")
+			}
+
 			if opts.registryID != "" {
 				return runList(opts)
 			}
@@ -149,7 +153,8 @@ func runList(opts *Options) error {
 		return err
 	}
 	request := a.ArtifactsApi.ListArtifactsInGroup(context.Background(), opts.group)
-	request = request.Offset(opts.page * opts.limit)
+
+	request = request.Offset((opts.page - 1) * opts.limit)
 	request = request.Limit(opts.limit)
 
 	response, _, err := request.Execute()
@@ -158,7 +163,7 @@ func runList(opts *Options) error {
 	}
 
 	if len(response.Artifacts) == 0 && opts.outputFormat == "" {
-		logger.Info("No artifacts available for this group and registry instance")
+		logger.Info("No artifacts available for " + opts.group + " group and registry id " + opts.registryID)
 		return nil
 	}
 

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -135,7 +135,7 @@ func runList(opts *Options) error {
 	}
 
 	if opts.group == util.DefaultArtifactGroup {
-		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
+		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -134,8 +134,8 @@ func runList(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
-		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+	if opts.group == util.DefaultArtifactGroup {
+		logger.Info("Group was not specified. Using ", util.DefaultArtifactGroup, " artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -162,6 +162,12 @@ func runList(opts *Options) error {
 		return registryinstanceerror.TransformError(err)
 	}
 
+	totalCount := opts.page * opts.limit
+	if len(response.Artifacts) != 0 && response.GetCount() < totalCount {
+		logger.Info("Provided limit and page arguments are larger than total count of elements on the server", response.GetCount())
+		return nil
+	}
+
 	if len(response.Artifacts) == 0 && opts.outputFormat == "" {
 		logger.Info("No artifacts available for " + opts.group + " group and registry id " + opts.registryID)
 		return nil

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -121,7 +121,7 @@ rhoas service-registry artifact list --page=2 --limit=10
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, "Page limit")
 
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml, table)")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 
@@ -162,12 +162,6 @@ func runList(opts *Options) error {
 		return registryinstanceerror.TransformError(err)
 	}
 
-	totalCount := opts.page * opts.limit
-	if len(response.Artifacts) != 0 && response.GetCount() < totalCount {
-		logger.Info("Provided limit and page arguments are larger than total count of elements on the server", response.GetCount())
-		return nil
-	}
-
 	if len(response.Artifacts) == 0 && opts.outputFormat == "" {
 		logger.Info("No artifacts available for " + opts.group + " group and registry id " + opts.registryID)
 		return nil
@@ -181,7 +175,7 @@ func runList(opts *Options) error {
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	default:
-		rows := mapResponseItemsToRows(&response.Artifacts)
+		rows := mapResponseItemsToRows(response.Artifacts)
 		dump.Table(opts.IO.Out, rows)
 		logger.Info("")
 	}
@@ -189,11 +183,11 @@ func runList(opts *Options) error {
 	return nil
 }
 
-func mapResponseItemsToRows(artifacts *[]registryinstanceclient.SearchedArtifact) []artifactRow {
+func mapResponseItemsToRows(artifacts []registryinstanceclient.SearchedArtifact) []artifactRow {
 	rows := []artifactRow{}
 
-	for i := range *artifacts {
-		k := (*artifacts)[i]
+	for i := range artifacts {
+		k := (artifacts)[i]
 		row := artifactRow{
 			Id:        k.GetId(),
 			Name:      k.GetName(),

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -154,8 +154,8 @@ func runList(opts *Options) error {
 
 	request = request.Offset((opts.page - 1) * opts.limit)
 	request = request.Limit(opts.limit)
-	request = request.Orderby(registryinstanceclient.CREATED_ON)
-	request = request.Order(registryinstanceclient.ASC)
+	request = request.Orderby(registryinstanceclient.SORTBY_CREATED_ON)
+	request = request.Order(registryinstanceclient.SORTORDER_ASC)
 
 	response, _, err := request.Execute()
 	if err != nil {

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -47,7 +47,6 @@ type Options struct {
 
 	registryID   string
 	outputFormat string
-	orderBy      string
 
 	page  int32
 	limit int32
@@ -120,7 +119,6 @@ rhoas service-registry artifact list --page=2 --limit=10
 
 	cmd.Flags().Int32VarP(&opts.page, "page", "", 1, "Page number")
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, "Page limit")
-	cmd.Flags().StringVarP(&opts.orderBy, "order", "", "", "Order by fields (id, name etc.) ")
 
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml, table)")
@@ -156,6 +154,8 @@ func runList(opts *Options) error {
 
 	request = request.Offset((opts.page - 1) * opts.limit)
 	request = request.Limit(opts.limit)
+	request = request.Orderby(registryinstanceclient.CREATED_ON)
+	request = request.Order(registryinstanceclient.ASC)
 
 	response, _, err := request.Execute()
 	if err != nil {

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -58,7 +58,7 @@ type Options struct {
 	localizer  localize.Localizer
 }
 
-// NewListCommand creates a new command for listing service registries.
+// NewListCommand creates a new command for listing registry artifacts.
 func NewListCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
 		Config:     f.Config,

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -106,7 +106,7 @@ rhoas service-registry artifact list --page=2 --limit=10
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use rhoas registry use to select your registry")
+				return errors.New("no service Registry selected. Use rhoas registry use to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -106,7 +106,7 @@ rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifac
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 
 	flagutil.EnableOutputFlagCompletion(cmd)
@@ -131,7 +131,7 @@ func runUpdate(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
+	if opts.group == util.DefaultArtifactGroup {
 		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -40,6 +40,7 @@ type Options struct {
 	localizer  localize.Localizer
 }
 
+// NewUpdateCommand creates a new command for updating binary content of registry artifacts.
 func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
 		IO:         f.IOStreams,

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -77,7 +77,7 @@ rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifac
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact by using --artifact-id flag")
+				return errors.New("artifact is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if len(args) > 0 {
@@ -94,7 +94,7 @@ rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifac
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' use to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -2,16 +2,13 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
-	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
@@ -166,14 +163,7 @@ func runUpdate(opts *Options) error {
 	}
 	logger.Info("Artifact updated")
 
-	switch opts.outputFormat {
-	case "json":
-		data, _ := json.MarshalIndent(metadata, "", cmdutil.DefaultJSONIndent)
-		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
-		data, _ := yaml.Marshal(metadata)
-		_ = dump.YAML(opts.IO.Out, data)
-	}
+	dump.PrintDataInFormat(opts.outputFormat, metadata, opts.IO.Out)
 
 	return nil
 }

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -132,7 +132,7 @@ func runUpdate(opts *Options) error {
 	}
 
 	if opts.group == "" {
-		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		logger.Info("Group was not specified. Using", util.DefaultArtifactGroup, "artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}
 

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -69,7 +69,7 @@ This content is updated under a unique artifactId provided by user.
 		`,
 		Example: `
 ## update artifact from group and artifact-id
-rhoas service-registry artifacts update my-artifact.json --artifact=my-artifact --group my-group
+rhoas service-registry artifact update my-artifact.json --artifact=my-artifact --group my-group
 `,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -67,7 +67,7 @@ This content is updated under a unique artifactId provided by user.
 		`,
 		Example: `
 ## update artifact from group and artifact-id
-rhoas service-registry artifact update my-artifact.json --artifact=my-artifact --group my-group
+rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifact --group my-group
 `,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -77,7 +77,7 @@ rhoas service-registry artifact update my-artifact.json --artifact=my-artifact -
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact by using --artifact flag")
+				return errors.New("Artifact is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if len(args) > 0 {
@@ -105,7 +105,7 @@ rhoas service-registry artifact update my-artifact.json --artifact=my-artifact -
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -68,23 +68,19 @@ This content is updated under a unique artifactId provided by user.
 ## update artifact from group and artifact-id
 rhoas service-registry artifact update my-artifact.json --artifact=my-artifact --group my-group
 `,
-		Args: cobra.RangeArgs(0, 2),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validOutputFormats := flagutil.ValidOutputFormats
 			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
 				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
-			if len(args) > 0 {
-				opts.artifact = args[0]
-			}
-
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact flag")
+				return errors.New("Artifact is required. Please specify artifact by using --artifact flag")
 			}
 
-			if len(args) > 1 {
-				opts.file = args[1]
+			if len(args) > 0 {
+				opts.file = args[0]
 			}
 
 			if opts.registryID != "" {

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -1,0 +1,179 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"gopkg.in/yaml.v2"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+)
+
+type Options struct {
+	artifact string
+	group    string
+
+	file string
+
+	registryID   string
+	outputFormat string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     func() (logging.Logger, error)
+	localizer  localize.Localizer
+}
+
+func NewUpdateCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update artifact",
+		Long: `
+Update artifact from file or directly standard input
+
+Artifacts can be typically in JSON format for most of the supported types, but may be in another format for a few (for example, PROTOBUF).
+The type of the content should be compatible with the artifact's type.
+(it would be an error to update an AVRO artifact with new OPENAPI content, for example).
+
+When successful, this creates a new version of the artifact, making it the most recent (and therefore official) version of the artifact.
+
+An artifact is update using the content provided in the body of the request.  
+This content is updated under a unique artifactId provided by user.
+		`,
+		Example: `
+## update artifact from group and artifact-id
+rhoas service-registry artifacts update my-artifact.json --artifact=my-artifact --group my-group
+`,
+		Args: cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			validOutputFormats := flagutil.ValidOutputFormats
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
+				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
+			}
+
+			if len(args) > 0 {
+				opts.artifact = args[0]
+			}
+
+			if opts.artifact == "" {
+				return errors.New("Artifact is required. Please specify artifact as positional argument or by using --artifact flag")
+			}
+
+			if len(args) > 1 {
+				opts.file = args[1]
+			}
+
+			if opts.registryID != "" {
+				return runUpdate(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' use to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runUpdate(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
+	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runUpdate(opts *Options) error {
+
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using " + util.DefaultArtifactGroup + " artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	var specifiedFile *os.File
+	if opts.file != "" {
+		logger.Info("Opening file: " + opts.file)
+		specifiedFile, err = os.Open(opts.file)
+		if err != nil {
+			return err
+		}
+	} else {
+		logger.Info("Reading file content from stdin")
+		specifiedFile, err = util.CreateFileFromStdin()
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx := context.Background()
+	request := dataAPI.ArtifactsApi.UpdateArtifact(ctx, opts.group, opts.artifact)
+	request = request.Body(specifiedFile)
+	metadata, _, err := request.Execute()
+	if err != nil {
+		return err
+	}
+	logger.Info("Artifact updated")
+
+	switch opts.outputFormat {
+	case "json":
+		data, _ := json.MarshalIndent(metadata, "", cmdutil.DefaultJSONIndent)
+		_ = dump.JSON(opts.IO.Out, data)
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(metadata)
+		_ = dump.YAML(opts.IO.Out, data)
+	}
+
+	return nil
+}

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -62,16 +62,16 @@ func NewDownloadCommand(f *factory.Factory) *cobra.Command {
 		--hash - SHA-256 hash of the content`,
 		Example: `
 ## Get latest artifact by content id
-rhoas service-registry artifacts download --content-id=183282932983
+rhoas service-registry artifact download --content-id=183282932983
 
 ## Get latest artifact by content id to specific file
-rhoas service-registry artifacts download --content-id=183282932983 schema.json
+rhoas service-registry artifact download --content-id=183282932983 schema.json
 
 ## Get latest artifact by global id
-rhoas service-registry artifacts download --global-id=383282932983
+rhoas service-registry artifact download --global-id=383282932983
 
 ## Get latest artifact by hash
-rhoas service-registry artifacts download --hash=c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 `,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -90,7 +90,7 @@ rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec6
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -40,6 +40,7 @@ type Options struct {
 	localizer  localize.Localizer
 }
 
+// NewDownloadCommand creates a new command for downloading binary content for registry artifacts.
 func NewDownloadCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
 		Config:     f.Config,

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -98,7 +98,7 @@ rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec6
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.hash, "hash", "", "", "SHA-256 hash of the artifact")
 	cmd.Flags().Int64VarP(&opts.globalId, "global-id", "", unusedFlagIdValue, "Global ID of the artifact")
 	cmd.Flags().Int64VarP(&opts.contentId, "content-id", "", unusedFlagIdValue, "ContentId of the artifact")
@@ -127,7 +127,7 @@ func runGet(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
+	if opts.group == util.DefaultArtifactGroup {
 		logger.Info("Group was not specified. Using 'default' artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -1,0 +1,172 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+)
+
+var unusedFlagIdValue int64 = -1
+
+type Options struct {
+	group string
+
+	contentId  int64
+	globalId   int64
+	hash       string
+	outputFile string
+
+	registryID string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Logger     func() (logging.Logger, error)
+	Connection factory.ConnectionFunc
+	localizer  localize.Localizer
+}
+
+func NewDownloadCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Logger:     f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Download artifacts from registry by using global identifiers",
+		Long: `Get single or more artifacts by group, content, hash or globalIds. 
+		NOTE: Use "service-registry get" command if you wish to download artifact by artifactId.
+
+		Flags are used to specify the artifact to download:
+
+		--contentId - id if the content from metadata
+		--globalId - globalId of the content from metadata
+		--hash - SHA-256 hash of the content`,
+		Example: `
+## Get latest artifact by content id
+rhoas service-registry artifacts download --content-id=183282932983
+
+## Get latest artifact by content id to specific file
+rhoas service-registry artifacts download --content-id=183282932983 schema.json
+
+## Get latest artifact by global id
+rhoas service-registry artifacts download --global-id=383282932983
+
+## Get latest artifact by hash
+rhoas service-registry artifacts download --hash=c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.outputFile = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runGet(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runGet(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.hash, "hash", "", "", "SHA-256 hash of the artifact")
+	cmd.Flags().Int64VarP(&opts.globalId, "global-id", "", unusedFlagIdValue, "Global ID of the artifact")
+	cmd.Flags().Int64VarP(&opts.contentId, "content-id", "", unusedFlagIdValue, "ContentId of the artifact")
+
+	cmd.Flags().StringVarP(&opts.outputFile, "output-file", "", "", "Filename of the output file")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runGet(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using 'default' artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	logger.Info("Fetching artifact")
+
+	ctx := context.Background()
+	var dataFile *os.File
+	// nolint
+	if opts.contentId != -1 {
+		request := dataAPI.ArtifactsApi.GetContentById(ctx, opts.contentId)
+		dataFile, _, err = request.Execute()
+	} else if opts.globalId != -1 {
+		request := dataAPI.ArtifactsApi.GetContentByGlobalId(ctx, opts.globalId)
+		dataFile, _, err = request.Execute()
+	} else if opts.hash != "" {
+		request := dataAPI.ArtifactsApi.GetContentByHash(ctx, opts.hash)
+		dataFile, _, err = request.Execute()
+	} else {
+		return errors.New("Please specify at least one flag: [contentId, globalId, hash]")
+	}
+
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	fileContent, err := ioutil.ReadFile(dataFile.Name())
+	if err != nil {
+		return err
+	}
+	if opts.outputFile != "" {
+		err := os.WriteFile(opts.outputFile, fileContent, 0600)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Print to stdout
+		fmt.Fprintf(os.Stdout, "%v\n", string(fileContent))
+	}
+
+	logger.Info("Successfully fetched artifact")
+	return nil
+}

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -147,7 +147,7 @@ func runGet(opts *Options) error {
 		request := dataAPI.ArtifactsApi.GetContentByHash(ctx, opts.hash)
 		dataFile, _, err = request.Execute()
 	} else {
-		return errors.New("Please specify at least one flag: [contentId, globalId, hash]")
+		return errors.New("please specify at least one flag: [contentId, global-id, hash]")
 	}
 
 	if err != nil {

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -1,0 +1,137 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+)
+
+type Options struct {
+	artifact     string
+	group        string
+	outputFormat string
+
+	registryID string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Logger     func() (logging.Logger, error)
+	Connection factory.ConnectionFunc
+	localizer  localize.Localizer
+}
+
+func NewMetadataCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Logger:     f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "metadata",
+		Short: "Get artifact metadata",
+		Long: `
+Gets the metadata for an artifact in the service registry. 
+The returned metadata includes both generated (read-only) and editable metadata (such as name and description).
+`,
+		Example: `
+## Get latest artifact metadata for default group
+rhoas service-registry artifacts metadata my-artifact
+
+## Get latest artifact metadata for my-group group
+rhoas service-registry artifacts metadata my-artifact --group mygroup 
+		`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.artifact = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runGet(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runGet(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runGet(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using 'default' artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	logger.Info("Fetching artifact metadata")
+
+	ctx := context.Background()
+	request := dataAPI.MetadataApi.GetArtifactMetaData(ctx, opts.group, opts.artifact)
+	response, _, err := request.Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	logger.Info("Successfully fetched artifact metadata")
+
+	switch opts.outputFormat {
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(response)
+		_ = dump.YAML(opts.IO.Out, data)
+	default:
+		data, _ := json.Marshal(response)
+		_ = dump.JSON(opts.IO.Out, data)
+	}
+	return nil
+}

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -54,10 +54,10 @@ The returned metadata includes both generated (read-only) and editable metadata 
 `,
 		Example: `
 ## Get latest artifact metadata for default group
-rhoas service-registry artifacts metadata my-artifact
+rhoas service-registry artifact metadata my-artifact
 
 ## Get latest artifact metadata for my-group group
-rhoas service-registry artifacts metadata my-artifact --group mygroup 
+rhoas service-registry artifact metadata my-artifact --group mygroup 
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -63,6 +63,10 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 				opts.artifact = args[0]
 			}
 
+			if opts.artifact == "" {
+				return errors.New("Artifact is required. Please specify artifact by using --artifact flag")
+			}
+
 			if opts.registryID != "" {
 				return runGet(opts)
 			}

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -65,7 +65,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact by using --artifact-id flag")
+				return errors.New("artifact is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if opts.registryID != "" {
@@ -78,7 +78,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
@@ -125,13 +123,7 @@ func runGet(opts *Options) error {
 
 	logger.Info("Successfully fetched artifact metadata")
 
-	switch opts.outputFormat {
-	case "yaml", "yml":
-		data, _ := yaml.Marshal(response)
-		_ = dump.YAML(opts.IO.Out, data)
-	default:
-		data, _ := json.Marshal(response)
-		_ = dump.JSON(opts.IO.Out, data)
-	}
+	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
+
 	return nil
 }

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -34,6 +34,7 @@ type Options struct {
 	localizer  localize.Localizer
 }
 
+// NewMetadataCommand creates a new command for fetching metadata for registry artifacts.
 func NewMetadataCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
 		Config:     f.Config,

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -65,7 +65,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 			}
 
 			if opts.artifact == "" {
-				return errors.New("Artifact is required. Please specify artifact by using --artifact flag")
+				return errors.New("Artifact is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if opts.registryID != "" {
@@ -86,7 +86,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -87,7 +87,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
 
@@ -112,7 +112,7 @@ func runGet(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
+	if opts.group == util.DefaultArtifactGroup {
 		logger.Info("Group was not specified. Using 'default' artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}

--- a/pkg/cmd/registry/artifact/util/constants.go
+++ b/pkg/cmd/registry/artifact/util/constants.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"strings"
+)
+
+var DefaultArtifactGroup = "default"
+
+var AllowedArtifactTypeEnumValues = []string{
+	"AVRO",
+	"PROTOBUF",
+	"JSON",
+	"OPENAPI",
+	"ASYNCAPI",
+	"GRAPHQL",
+	"KCONNECT",
+	"WSDL",
+	"XSD",
+	"XML",
+}
+
+// GetAllowedArtifactTypeEnumValues gets artifact types as string.
+func GetAllowedArtifactTypeEnumValuesAsString() string {
+	return strings.Join(AllowedArtifactTypeEnumValues, ", ")
+}

--- a/pkg/cmd/registry/artifact/util/constants.go
+++ b/pkg/cmd/registry/artifact/util/constants.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-var DefaultArtifactGroup = "default"
+const DefaultArtifactGroup = "default"
 
 var AllowedArtifactTypeEnumValues = []string{
 	"AVRO",

--- a/pkg/cmd/registry/artifact/util/files.go
+++ b/pkg/cmd/registry/artifact/util/files.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func CreateFileFromStdin() (*os.File, error) {
+	var specifiedFile *os.File
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	specifiedFile, err = ioutil.TempFile("", "rhoas-std-input")
+	if err != nil {
+		return nil, err
+	}
+	_, err = (*specifiedFile).Write(data)
+	if err != nil {
+		return nil, err
+	}
+	_, err = (*specifiedFile).Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+	return specifiedFile, nil
+}

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -70,7 +70,7 @@ rhoas service-registry artifact versions my-artifact --group mygroup
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -51,10 +51,10 @@ func NewVersionsCommand(f *factory.Factory) *cobra.Command {
 		Long:  "Get latest artifact versions by specifying group and artifacts id",
 		Example: `
 ## Get latest artifact versions for default group
-rhoas service-registry artifacts versions my-artifact
+rhoas service-registry artifact versions my-artifact
 
 ## Get latest artifact versions for my-group group
-rhoas service-registry artifacts versions my-artifact --group mygroup 
+rhoas service-registry artifact versions my-artifact --group mygroup 
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -78,7 +78,7 @@ rhoas service-registry artifact versions my-artifact --group mygroup
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -1,0 +1,134 @@
+package versions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+)
+
+type Options struct {
+	artifact     string
+	group        string
+	outputFormat string
+
+	registryID string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Logger     func() (logging.Logger, error)
+	Connection factory.ConnectionFunc
+	localizer  localize.Localizer
+}
+
+func NewVersionsCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Logger:     f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Get latest artifact versions by id and group",
+		Long:  "Get latest artifact versions by specifying group and artifacts id",
+		Example: `
+## Get latest artifact versions for default group
+rhoas service-registry artifacts versions my-artifact
+
+## Get latest artifact versions for my-group group
+rhoas service-registry artifacts versions my-artifact --group mygroup 
+		`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.artifact = args[0]
+			}
+
+			if opts.registryID != "" {
+				return runGet(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("No service Registry selected. Use 'rhoas service-registry use' to select your registry")
+			}
+
+			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
+			return runGet(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runGet(opts *Options) error {
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == "" {
+		logger.Info("Group was not specified. Using 'default' artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	logger.Info("Fetching artifact versions")
+
+	ctx := context.Background()
+	request := dataAPI.VersionsApi.ListArtifactVersions(ctx, opts.group, opts.artifact)
+	response, _, err := request.Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	logger.Info("Successfully fetched artifact versions")
+
+	switch opts.outputFormat {
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(response)
+		_ = dump.YAML(opts.IO.Out, data)
+	default:
+		data, _ := json.Marshal(response)
+		_ = dump.JSON(opts.IO.Out, data)
+	}
+	return nil
+}

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -79,7 +79,7 @@ rhoas service-registry artifact versions my-artifact --group mygroup
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", "", "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
 	cmd.Flags().StringVarP(&opts.registryID, "instance-id", "", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
 
@@ -104,7 +104,7 @@ func runGet(opts *Options) error {
 		return err
 	}
 
-	if opts.group == "" {
+	if opts.group == util.DefaultArtifactGroup {
 		logger.Info("Group was not specified. Using 'default' artifacts group.")
 		opts.group = util.DefaultArtifactGroup
 	}

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -2,7 +2,6 @@ package versions
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
@@ -122,13 +120,7 @@ func runGet(opts *Options) error {
 
 	logger.Info("Successfully fetched artifact versions")
 
-	switch opts.outputFormat {
-	case "yaml", "yml":
-		data, _ := yaml.Marshal(response)
-		_ = dump.YAML(opts.IO.Out, data)
-	default:
-		data, _ := json.Marshal(response)
-		_ = dump.JSON(opts.IO.Out, data)
-	}
+	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
+
 	return nil
 }

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -23,11 +22,9 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 )
 
 type Options struct {
@@ -147,14 +144,7 @@ func runCreate(opts *Options) error {
 
 	logger.Info(opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
 
-	switch opts.outputFormat {
-	case dump.JSONFormat:
-		data, _ := json.MarshalIndent(response, "", cmdutil.DefaultJSONIndent)
-		_ = dump.JSON(opts.IO.Out, data)
-	case dump.YAMLFormat, dump.YMLFormat:
-		data, _ := yaml.Marshal(response)
-		_ = dump.YAML(opts.IO.Out, data)
-	}
+	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
 
 	registryConfig := &config.ServiceRegistryConfig{
 		InstanceID: response.GetId(),

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -93,7 +93,6 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	return cmd
 }
 
-// nolint:funlen
 func runCreate(opts *Options) error {
 	logger, err := opts.Logger()
 	if err != nil {

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -2,9 +2,7 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"io"
 
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
@@ -19,7 +17,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	srsmgmtv1 "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 type Options struct {
@@ -113,22 +110,7 @@ func runDescribe(opts *Options) error {
 		}
 	}
 
-	return printService(opts.IO.Out, registry, opts.outputFormat)
-}
+	dump.PrintDataInFormat(opts.outputFormat, registry, opts.IO.Out)
 
-func printService(w io.Writer, registry interface{}, outputFormat string) error {
-	switch outputFormat {
-	case dump.YAMLFormat, dump.YMLFormat:
-		data, err := yaml.Marshal(registry)
-		if err != nil {
-			return err
-		}
-		return dump.YAML(w, data)
-	default:
-		data, err := json.Marshal(registry)
-		if err != nil {
-			return err
-		}
-		return dump.JSON(w, data)
-	}
+	return nil
 }

--- a/pkg/cmd/registry/registry.go
+++ b/pkg/cmd/registry/registry.go
@@ -3,9 +3,11 @@ package registry
 
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/create"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/describe"
+
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/list"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/use"
 	"github.com/redhat-developer/app-services-cli/pkg/profile"
@@ -23,7 +25,6 @@ func NewServiceRegistryCommand(f *factory.Factory) *cobra.Command {
 		Example: f.Localizer.MustLocalize("registry.cmd.example"),
 		Args:    cobra.MinimumNArgs(1),
 	}
-
 	// add sub-commands
 	cmd.AddCommand(
 		create.NewCreateCommand(f),
@@ -31,6 +32,7 @@ func NewServiceRegistryCommand(f *factory.Factory) *cobra.Command {
 		delete.NewDeleteCommand(f),
 		list.NewListCommand(f),
 		use.NewUseCommand(f),
+		artifact.NewArtifactsCommand(f),
 	)
 
 	return cmd

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -137,7 +137,7 @@ func haveYQ(minVersion int) bool {
 	return false
 }
 
-// Dump prints the given data to the given format
+// PrintDataInFormat prints the given data to the given format
 func PrintDataInFormat(format string, data interface{}, writter io.Writer) {
 	switch format {
 	case YAMLFormat, YMLFormat:

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -136,3 +136,15 @@ func haveYQ(minVersion int) bool {
 
 	return false
 }
+
+// Dump prints the given data to the given format
+func PrintDataInFormat(format string, data interface{}, writter io.Writer) {
+	switch format {
+	case YAMLFormat, YMLFormat:
+		data, _ := yaml.Marshal(data)
+		_ = YAML(writter, data)
+	default:
+		data, _ := json.Marshal(data)
+		_ = JSON(writter, data)
+	}
+}

--- a/pkg/serviceregistry/registry_util.go
+++ b/pkg/serviceregistry/registry_util.go
@@ -18,7 +18,7 @@ func ValidateName(val interface{}) error {
 	}
 
 	if len(name) < 1 || len(name) > 32 {
-		return errors.New("ServiceRegistry instance name must be between 1 and 32 characters")
+		return errors.New("serviceRegistry instance name must be between 1 and 32 characters")
 	}
 
 	matched := validNameRegexp.MatchString(name)
@@ -27,5 +27,5 @@ func ValidateName(val interface{}) error {
 		return nil
 	}
 
-	return errors.New("Invalid service registry name: " + name)
+	return errors.New("invalid service registry name: " + name)
 }

--- a/pkg/serviceregistry/registryinstanceerror/error.go
+++ b/pkg/serviceregistry/registryinstanceerror/error.go
@@ -1,0 +1,43 @@
+package registryinstanceerror
+
+import (
+	"errors"
+	"fmt"
+
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+)
+
+type Error struct {
+	Err error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprint(e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// GetAPIError gets a strongly typed error from an error
+func GetAPIError(err error) (e registryinstanceclient.Error, ok bool) {
+	var apiError registryinstanceclient.GenericOpenAPIError
+
+	if ok = errors.As(err, &apiError); ok {
+		errModel := apiError.Model()
+
+		e, ok = errModel.(registryinstanceclient.Error)
+	}
+
+	return e, ok
+}
+
+// Error code contains message that can be returned to the user
+func TransformError(err error) error {
+	mappedErr, ok := GetAPIError(err)
+	if !ok {
+		return err
+	}
+
+	return errors.New(mappedErr.GetName() + ": " + mappedErr.GetMessage())
+}

--- a/pkg/serviceregistry/registryinstanceerror/error.go
+++ b/pkg/serviceregistry/registryinstanceerror/error.go
@@ -32,7 +32,7 @@ func GetAPIError(err error) (e registryinstanceclient.Error, ok bool) {
 	return e, ok
 }
 
-// Error code contains message that can be returned to the user
+// TransformError code contains message that can be returned to the user
 func TransformError(err error) error {
 	mappedErr, ok := GetAPIError(err)
 	if !ok {


### PR DESCRIPTION
## Description

Set of commands to interact with service registry dataplane:
```
Available Commands:
  create      Creates new artifact from file or standard input
  delete      Deletes all of the artifacts that exist in a given group
  download    Download artifacts from registry by using global identifiers
  get         Get artifact by id and group
  list        List artifacts
  metadata    Get artifact metadata
  update      Update artifact
  versions    Get latest artifact versions by id and group
```


# Verification

## Create artifact in my-group from schema.json file
rhoas service-registry artifact create --artifact=my-artifact --group=my-group artifact.json

## Get artifact content
rhoas service-registry artifact get --artifact=my-artifact --group=my-group file.json 

## Delete artifact
rhoas service-registry artifact delete --artifact=my-artifact

## Get artifact metadata
rhoas service-registry artifact metadata --artifact=my-artifact --group=my-group

## Update artifact
rhoas service-registry artifact update --artifact=my-artifact artifact-new.json

## List Artifacts
rhoas service-registry artifact list --group=my-group --limit=10 page=1

## View artifact versions
rhoas service-registry artifact versions --artifact=my-artifact --group=my-group