### PR TITLE
chore: auto-add "needs-triage" label to new issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+needs-triage:
+    - '(?i).*.*'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,14 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2
+      with:
+        repo-token: "${{ secrets.ISSUE_LABELER_TOKEN }}"
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
This PR uses https://github.com/marketplace/actions/regex-issue-labeler to add a "needs-triage" label to all new issues.