### PR TITLE
feat(consumer-group): add reset-offset command

### DIFF
--- a/docs/commands/rhoas_kafka_consumer-group.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group.adoc
@@ -60,3 +60,10 @@ ifdef::pantheonenv[]
 * link:{path}#ref-rhoas-kafka-consumer-group-list_{context}[rhoas kafka consumer-group list]	 - List all consumer groups
 endif::[]
 
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka_consumer-group_reset-offset.adoc#rhoas-kafka-consumer-group-reset-offset[rhoas kafka consumer-group reset-offset]	 - Reset offset of a consumer group
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-consumer-group-reset-offset_{context}[rhoas kafka consumer-group reset-offset]	 - Reset offset of a consumer group
+endif::[]
+

--- a/docs/commands/rhoas_kafka_consumer-group.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group.adoc
@@ -61,9 +61,9 @@ ifdef::pantheonenv[]
 endif::[]
 
 ifdef::env-github,env-browser[]
-* link:rhoas_kafka_consumer-group_reset-offset.adoc#rhoas-kafka-consumer-group-reset-offset[rhoas kafka consumer-group reset-offset]	 - Reset offset of a consumer group
+* link:rhoas_kafka_consumer-group_reset-offset.adoc#rhoas-kafka-consumer-group-reset-offset[rhoas kafka consumer-group reset-offset]	 - Reset offset for a consumer group
 endif::[]
 ifdef::pantheonenv[]
-* link:{path}#ref-rhoas-kafka-consumer-group-reset-offset_{context}[rhoas kafka consumer-group reset-offset]	 - Reset offset of a consumer group
+* link:{path}#ref-rhoas-kafka-consumer-group-reset-offset_{context}[rhoas kafka consumer-group reset-offset]	 - Reset offset for a consumer group
 endif::[]
 

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -3,12 +3,12 @@ ifdef::env-github,env-browser[:context: cmd]
 = rhoas kafka consumer-group reset-offset
 
 [role="_abstract"]
-Reset offset of a consumer group
+Reset offset for a consumer group
 
 [discrete]
 == Synopsis
 
-Reset offset for a consumer group from the Kafka instance.
+Reset the offset for a consumer group.
 
 
 ....
@@ -31,12 +31,12 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 == Options
 
       `--id` _string_::               The unique ID of the consumer group to reset-offset
-      `--offset` _string_::           Offset type (earliest, latest, absolute, timestamp)
-  `-o`, `--output` _string_::         Output in which to display reset offset result
-      `--partitions` _int32Slice_::   Partitions on which reset-offset is to be carried upon (space separated integers) (default [])
+      `--offset` _string_::           Offset type (choose from: "earliest", "latest", "absolute", "timestamp")
+  `-o`, `--output` _string_::         Format in which to display reset offset result (choose from: "json", "yml", "yaml")
+      `--partitions` _int32Slice_::   Partitions on which to reset the consumer group offset (space separated integers) (default [])
       `--topic` _string_::            Select topic for which consumer group offsets are to be reset
-      `--value` _string_::            Custom offset value (required when offset is absolute or timestamp)
-  `-y`, `--yes`::                     Skip confirmation to forcibly reset-offset of a consumer group
+      `--value` _string_::            Custom offset value (required when offset is "absolute" or "timestamp")
+  `-y`, `--yes`::                     Skip confirmation to forcibly reset the offset for the consumer group
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -8,7 +8,7 @@ Reset offset for a consumer group
 [discrete]
 == Synopsis
 
-Reset the offset for a consumer group.
+Reset the offset for consumers in a consumer group reading from a given topic.
 
 
 ....
@@ -33,7 +33,7 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
       `--id` _string_::               The unique ID of the consumer group to reset-offset
       `--offset` _string_::           Offset type (choose from: "earliest", "latest", "absolute", "timestamp")
   `-o`, `--output` _string_::         Format in which to display reset offset result (choose from: "json", "yml", "yaml")
-      `--partitions` _int32Slice_::   Partitions on which to reset the consumer group offset (space separated integers) (default [])
+      `--partitions` _int32Slice_::   Partitions on which to reset the consumer group offset (comma-separated integers) (default [])
       `--topic` _string_::            Select topic for which consumer group offsets are to be reset
       `--value` _string_::            Custom offset value (required when offset is "absolute" or "timestamp")
   `-y`, `--yes`::                     Skip confirmation to forcibly reset the offset for the consumer group

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -49,9 +49,9 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 
 
 ifdef::env-github,env-browser[]
-* link:rhoas_kafka_consumer-group.adoc#rhoas-kafka-consumer-group[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
+* link:rhoas_kafka_consumer-group.adoc#rhoas-kafka-consumer-group[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Apache Kafka instance
 endif::[]
 ifdef::pantheonenv[]
-* link:{path}#ref-rhoas-kafka-consumer-group_{context}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
+* link:{path}#ref-rhoas-kafka-consumer-group_{context}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Apache Kafka instance
 endif::[]
 

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -23,19 +23,19 @@ rhoas kafka consumer-group reset-offset [flags]
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
 
 # reset offset for specific consumers in a consumer group
-$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions "1 2"
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions 0,1
 
 ....
 
 [discrete]
 == Options
 
-      `--id` _string_::           The unique ID of the consumer group to reset-offset
-      `--offset` _string_::       Offset type (earliest, latest, absolute, timestamp)
-      `--partitions` _string_::   Partitions on which reset-offset is to be carried upon (space separated integers)
-      `--topic` _string_::        Select topic for which consumer group offsets are to be reset
-      `--value` _string_::        Custom offset value (required when offset is absolute or timestamp)
-  `-y`, `--yes`::                 Skip confirmation to forcibly reset-offset of a consumer group
+      `--id` _string_::               The unique ID of the consumer group to reset-offset
+      `--offset` _string_::           Offset type (earliest, latest, absolute, timestamp)
+      `--partitions` _int32Slice_::   Partitions on which reset-offset is to be carried upon (space separated integers) (default [])
+      `--topic` _string_::            Select topic for which consumer group offsets are to be reset
+      `--value` _string_::            Custom offset value (required when offset is absolute or timestamp)
+  `-y`, `--yes`::                     Skip confirmation to forcibly reset-offset of a consumer group
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -43,7 +43,6 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 
   `-h`, `--help`::      Show help for a command
   `-v`, `--verbose`::   Enable verbose mode
-      `--version`::     Show rhoas version
 
 [discrete]
 == See also

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -1,0 +1,57 @@
+ifdef::env-github,env-browser[:context: cmd]
+[id='ref-rhoas-kafka-consumer-group-reset-offset_{context}']
+= rhoas kafka consumer-group reset-offset
+
+[role="_abstract"]
+Reset offset of a consumer group
+
+[discrete]
+== Synopsis
+
+Reset offset for a consumer group from the Kafka instance.
+
+
+....
+rhoas kafka consumer-group reset-offset [flags]
+....
+
+[discrete]
+== Examples
+
+....
+# reset offset for a consumer group
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
+
+# reset offset for specific consumers in a consumer group
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions "1 2"
+
+....
+
+[discrete]
+== Options
+
+      `--id` _string_::           The unique ID of the consumer group to reset-offset
+      `--offset` _string_::       Offset type (earliest, latest, absolute, timestamp)
+      `--partitions` _string_::   Partitions on which reset-offset is to be carried upon (space separated integers)
+      `--topic` _string_::        Select topic for which consumer group offsets are to be reset
+      `--value` _string_::        Custom offset value (required when offset is absolute or timestamp)
+  `-y`, `--yes`::                 Skip confirmation to forcibly reset-offset of a consumer group
+
+[discrete]
+== Options inherited from parent commands
+
+  `-h`, `--help`::      Show help for a command
+  `-v`, `--verbose`::   Enable verbose mode
+      `--version`::     Show rhoas version
+
+[discrete]
+== See also
+
+
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka_consumer-group.adoc#rhoas-kafka-consumer-group[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-consumer-group_{context}[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Kafka instance.
+endif::[]
+

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -32,6 +32,7 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 
       `--id` _string_::               The unique ID of the consumer group to reset-offset
       `--offset` _string_::           Offset type (earliest, latest, absolute, timestamp)
+  `-o`, `--output` _string_::         Output in which to display reset offset result
       `--partitions` _int32Slice_::   Partitions on which reset-offset is to be carried upon (space separated integers) (default [])
       `--topic` _string_::            Select topic for which consumer group offsets are to be reset
       `--value` _string_::            Custom offset value (required when offset is absolute or timestamp)

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -10,6 +10,9 @@ Reset offset for a consumer group
 
 Reset the offset for consumers in a consumer group reading from a given topic.
 
+Offset types: earliest, latest, absolute, timestamp
+You can choose specific partition to reset offset from (advanced usage)
+
 
 ....
 rhoas kafka consumer-group reset-offset [flags]
@@ -19,10 +22,19 @@ rhoas kafka consumer-group reset-offset [flags]
 == Examples
 
 ....
-# reset offset for a consumer group
+# reset offset for a consumer group to latest
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
 
-# reset offset for specific consumers in a consumer group
+# reset offset for a consumer group to earliest
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset earliest
+
+# reset offset for a consumer group to an absolute value
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset absolute --value 0
+
+# reset offset for a consumer group to a timestamp
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset timestamp --value "2016-06-23T09:07:21-07:00"
+
+# reset offset for specific partitions in a consumer group
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions 0,1
 
 ....

--- a/pkg/cmd/flag/validation.go
+++ b/pkg/cmd/flag/validation.go
@@ -14,14 +14,3 @@ func ValidateOutput(v string) error {
 
 	return InvalidValueError("output", v, flagutil.ValidOutputFormats...)
 }
-
-// ValidateOffset checks if value v is a valid value for --offset
-func ValidateOffset(v string) error {
-	isValid := flagutil.IsValidInput(v, flagutil.ValidOffsets...)
-
-	if isValid {
-		return nil
-	}
-
-	return InvalidValueError("output", v, flagutil.ValidOffsets...)
-}

--- a/pkg/cmd/flag/validation.go
+++ b/pkg/cmd/flag/validation.go
@@ -4,7 +4,7 @@ import (
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 )
 
-// ValidOutput checks if value v is a valid value for --output
+// ValidateOutput checks if value v is a valid value for --output
 func ValidateOutput(v string) error {
 	isValid := flagutil.IsValidInput(v, flagutil.ValidOutputFormats...)
 
@@ -13,4 +13,15 @@ func ValidateOutput(v string) error {
 	}
 
 	return InvalidValueError("output", v, flagutil.ValidOutputFormats...)
+}
+
+// ValidateOffset checks if value v is a valid value for --offset
+func ValidateOffset(v string) error {
+	isValid := flagutil.IsValidInput(v, flagutil.ValidOffsets...)
+
+	if isValid {
+		return nil
+	}
+
+	return InvalidValueError("output", v, flagutil.ValidOffsets...)
 }

--- a/pkg/cmd/kafka/consumergroup/consumergroup.go
+++ b/pkg/cmd/kafka/consumergroup/consumergroup.go
@@ -5,6 +5,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/describe"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/resetoffset"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ func NewConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		list.NewListConsumerGroupCommand(f),
 		delete.NewDeleteConsumerGroupCommand(f),
 		describe.NewDescribeConsumerGroupCommand(f),
+		resetoffset.NewResetOffsetConsumerGroupCommand(f),
 	)
 
 	return cmd

--- a/pkg/cmd/kafka/consumergroup/delete/delete.go
+++ b/pkg/cmd/kafka/consumergroup/delete/delete.go
@@ -64,7 +64,6 @@ func NewDeleteConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "delete"))
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.consumerGroup.delete.flag.yes.description"))
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "delete")))
 	_ = cmd.MarkFlagRequired("id")

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -262,12 +262,12 @@ func runCmd(opts *Options) error {
 
 	switch opts.output {
 	case "":
-		dump.PrintDataInFormat(opts.output, updatedConsumers, opts.IO.Out)
-	default:
 		opts.Logger.Info("")
 		consumers := updatedConsumers.GetItems()
 		rows := mapResetOffsetResultToTableFormat(consumers)
 		dump.Table(opts.IO.Out, rows)
+	default:
+		dump.PrintDataInFormat(opts.output, updatedConsumers, opts.IO.Out)
 	}
 
 	return nil

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -2,8 +2,8 @@ package resetoffset
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -13,11 +13,13 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 type Options struct {
@@ -28,12 +30,19 @@ type Options struct {
 	offset      string
 	topic       string
 	partitions  []int32
+	output      string
 
 	IO         *iostreams.IOStreams
 	Config     config.IConfig
 	Connection factory.ConnectionFunc
 	Logger     func() (logging.Logger, error)
 	localizer  localize.Localizer
+}
+
+type UpdatedConsumerRow struct {
+	Topic     string `json:"groupId,omitempty" header:"Topic"`
+	Partition int32  `json:"active_members,omitempty" header:"Partition"`
+	Offset    int32  `json:"lag,omitempty" header:"Offset"`
 }
 
 // NewResetOffsetConsumerGroupCommand gets a new command for resetting offset for a consumer group.
@@ -53,6 +62,10 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		Example: opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.cmd.example"),
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			if opts.output != "" && !flagutil.IsValidInput(opts.output, flagutil.ValidOutputFormats...) {
+				return flag.InvalidValueError("output", opts.output, flagutil.ValidOutputFormats...)
+			}
 
 			if opts.offset != "" {
 				if err = flag.ValidateOffset(opts.offset); err != nil {
@@ -85,9 +98,11 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.offset, "offset", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.offset"))
 	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.topic"))
 	cmd.Flags().Int32SliceVar(&opts.partitions, "partitions", []int32{}, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.partitions"))
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.output"))
 
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("offset")
+	_ = cmd.MarkFlagRequired("topic")
 
 	// flag based completions for ID
 	_ = cmd.RegisterFlagCompletionFunc("id", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -99,6 +114,7 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
 	})
 
+	flagutil.EnableOutputFlagCompletion(cmd)
 	flagutil.EnableStaticFlagCompletion(cmd, "offset", flagutil.ValidOffsets)
 
 	return cmd
@@ -166,8 +182,6 @@ func runCmd(opts *Options) error {
 	}
 
 	updatedConsumers, httpRes, err := a.Execute()
-	// display the response object(todo)
-	fmt.Println(updatedConsumers)
 
 	if err != nil {
 
@@ -193,6 +207,40 @@ func runCmd(opts *Options) error {
 
 	defer httpRes.Body.Close()
 
+	logger.Info(opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.log.info.successful", localize.NewEntry("ConsumerGroupID", opts.id), localize.NewEntry("InstanceName", kafkaInstance.GetName())))
+
+	switch opts.output {
+	case "json":
+		data, _ := json.Marshal(updatedConsumers)
+		_ = dump.JSON(opts.IO.Out, data)
+	case "yaml", "yml":
+		data, _ := yaml.Marshal(updatedConsumers)
+		_ = dump.YAML(opts.IO.Out, data)
+	default:
+		logger.Info("")
+		consumers := updatedConsumers.GetItems()
+		rows := mapResetOffsetResultToTableFormat(consumers)
+		dump.Table(opts.IO.Out, rows)
+
+		return nil
+	}
+
 	return nil
 
+}
+
+func mapResetOffsetResultToTableFormat(consumers []kafkainstanceclient.ConsumerGroupResetOffsetResultItem) []UpdatedConsumerRow {
+	rows := []UpdatedConsumerRow{}
+
+	for _, t := range consumers {
+
+		row := UpdatedConsumerRow{
+			Topic:     t.GetTopic(),
+			Partition: t.GetPartition(),
+			Offset:    t.GetOffset(),
+		}
+		rows = append(rows, row)
+	}
+
+	return rows
 }

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/internal/config"
@@ -177,18 +178,20 @@ func runCmd(opts *Options) error {
 		operationTmplPair := localize.NewEntry("Operation", "reset offset")
 
 		switch httpRes.StatusCode {
-		case 401:
+		case http.StatusUnauthorized:
 			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.unauthorized", operationTmplPair))
-		case 403:
+		case http.StatusForbidden:
 			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.forbidden", operationTmplPair))
-		case 500:
+		case http.StatusInternalServerError:
 			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.internalServerError"))
-		case 503:
+		case http.StatusServiceUnavailable:
 			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.unableToConnectToKafka", localize.NewEntry("Name", kafkaInstance.GetName())))
 		default:
 			return err
 		}
 	}
+
+	defer httpRes.Body.Close()
 
 	return nil
 

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -72,7 +72,7 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 				}
 			}
 
-			if opts.value == "" && (opts.offset == consumergroup.OffsetAbssolute || opts.offset == consumergroup.OffsetTimestamp) {
+			if opts.value == "" && (opts.offset == consumergroup.OffsetAbsolute || opts.offset == consumergroup.OffsetTimestamp) {
 				return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.valueRequired", localize.NewEntry("Offset", opts.offset)))
 			}
 
@@ -150,7 +150,7 @@ func runCmd(opts *Options) error {
 		offsetResetParams.Value = &opts.value
 	}
 
-	if opts.offset == consumergroup.OffsetAbssolute || opts.offset == consumergroup.OffsetTimestamp {
+	if opts.offset == consumergroup.OffsetAbsolute || opts.offset == consumergroup.OffsetTimestamp {
 		if err = validator.ValidateOffsetValue(opts.offset, opts.value); err != nil {
 			return err
 		}

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -44,6 +44,8 @@ type updatedConsumerRow struct {
 	Offset    int32  `json:"lag,omitempty" header:"Offset"`
 }
 
+var validator consumergroup.Validator
+
 // NewResetOffsetConsumerGroupCommand gets a new command for resetting offset for a consumer group.
 func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 	opts := &Options{
@@ -66,8 +68,12 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 				return flag.InvalidValueError("output", opts.output, flagutil.ValidOutputFormats...)
 			}
 
+			validator = consumergroup.Validator{
+				Localizer: opts.localizer,
+			}
+
 			if opts.offset != "" {
-				if err = consumergroup.ValidateOffset(opts.offset); err != nil {
+				if err = validator.ValidateOffset(opts.offset); err != nil {
 					return err
 				}
 			}
@@ -137,10 +143,6 @@ func runCmd(opts *Options) error {
 	}
 
 	ctx := context.Background()
-
-	validator := consumergroup.Validator{
-		Localizer: opts.localizer,
-	}
 
 	offsetResetParams := kafkainstanceclient.ConsumerGroupResetOffsetParameters{
 		Offset: opts.offset,

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -1,0 +1,209 @@
+package resetoffset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	kafkaID     string
+	id          string
+	skipConfirm bool
+	value       string
+	offset      string
+	topic       string
+	partitions  string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     func() (logging.Logger, error)
+	localizer  localize.Localizer
+}
+
+// NewResetOffsetConsumerGroupCommand gets a new command for resetting offset for a consumer group.
+func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
+	opts := &Options{
+		Connection: f.Connection,
+		Config:     f.Config,
+		IO:         f.IOStreams,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "reset-offset",
+		Short:   opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.cmd.shortDescription"),
+		Long:    opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.cmd.longDescription"),
+		Example: opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			if opts.offset != "" {
+				if err = flag.ValidateOffset(opts.offset); err != nil {
+					return err
+				}
+			}
+
+			if opts.kafkaID != "" {
+				return runCmd(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasKafka() {
+				return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.noKafkaSelected"))
+			}
+
+			opts.kafkaID = cfg.Services.Kafka.ClusterID
+
+			return runCmd(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.yes"))
+	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "reset-offset")))
+	cmd.Flags().StringVar(&opts.value, "value", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.value"))
+	cmd.Flags().StringVar(&opts.offset, "offset", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.offset"))
+	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.topic"))
+	cmd.Flags().StringVar(&opts.partitions, "partitions", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.partitions"))
+
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("offset")
+
+	// flag based completions for ID
+	_ = cmd.RegisterFlagCompletionFunc("id", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.FilterValidConsumerGroupIDs(f, toComplete)
+	})
+
+	// flag based completions for topic
+	_ = cmd.RegisterFlagCompletionFunc("topic", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
+	})
+
+	flagutil.EnableStaticFlagCompletion(cmd, "offset", flagutil.ValidOffsets)
+
+	return cmd
+}
+
+// nolint:funlen
+func runCmd(opts *Options) error {
+
+	fmt.Println("reset offset")
+	logger, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	api, kafkaInstance, err := conn.API().KafkaAdmin(opts.kafkaID)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	offsetResetParams := kafkainstanceclient.ConsumerGroupResetOffsetParameters{
+		Offset: opts.offset,
+	}
+
+	if opts.value != "" {
+		offsetResetParams.Value = &opts.value
+	}
+
+	if opts.topic != "" {
+		topicToReset := kafkainstanceclient.TopicsToResetOffset{
+			Topic: opts.topic,
+		}
+
+		if opts.partitions != "" {
+			partitionsStr := strings.Fields(opts.partitions)
+
+			partitionsArr := []int32{}
+
+			for _, partition := range partitionsStr {
+				partitionInt, convErr := strconv.ParseInt(partition, 10, 32)
+				if convErr != nil {
+					return convErr
+				}
+				partitionsArr = append(partitionsArr, int32(partitionInt))
+			}
+
+			topicToReset.Partitions = &partitionsArr
+		}
+
+		topicsToResetArr := []kafkainstanceclient.TopicsToResetOffset{topicToReset}
+
+		offsetResetParams.Topics = &topicsToResetArr
+	}
+
+	a := api.GroupsApi.ResetConsumerGroupOffset(ctx, opts.id).ConsumerGroupResetOffsetParameters(offsetResetParams)
+
+	if !opts.skipConfirm {
+
+		var confirmReset bool
+		opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.input.confirmReset.message", localize.NewEntry("ID", opts.id))
+		promptConfirmReset := &survey.Confirm{
+			Message: opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.input.confirmReset.message", localize.NewEntry("ID", opts.id)),
+		}
+
+		if err = survey.AskOne(promptConfirmReset, &confirmReset); err != nil {
+			return err
+		}
+		if !confirmReset {
+			logger.Debug(opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.log.debug.cancelledReset"))
+			return nil
+		}
+	}
+
+	_, httpRes, err := a.Execute()
+	fmt.Println("status code", httpRes.StatusCode)
+
+	if err != nil {
+
+		if httpRes == nil {
+			return err
+		}
+
+		operationTmplPair := localize.NewEntry("Operation", "reset offset")
+
+		switch httpRes.StatusCode {
+		case 401:
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.unauthorized", operationTmplPair))
+		case 403:
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.forbidden", operationTmplPair))
+		case 500:
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.internalServerError"))
+		case 503:
+			return errors.New(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.unableToConnectToKafka", localize.NewEntry("Name", kafkaInstance.GetName())))
+		default:
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -108,7 +108,6 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 // nolint:funlen
 func runCmd(opts *Options) error {
 
-	fmt.Println("reset offset")
 	logger, err := opts.Logger()
 	if err != nil {
 		return err
@@ -179,8 +178,9 @@ func runCmd(opts *Options) error {
 		}
 	}
 
-	_, httpRes, err := a.Execute()
-	fmt.Println("status code", httpRes.StatusCode)
+	updatedConsumers, httpRes, err := a.Execute()
+	// display the response object(todo)
+	fmt.Println(updatedConsumers)
 
 	if err != nil {
 

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -238,16 +238,16 @@ func runCmd(opts *Options) error {
 }
 
 func mapResetOffsetResultToTableFormat(consumers []kafkainstanceclient.ConsumerGroupResetOffsetResultItem) []updatedConsumerRow {
-	rows := []updatedConsumerRow{}
+	rows := make([]updatedConsumerRow, len(consumers))
 
-	for _, t := range consumers {
+	for i, t := range consumers {
 
 		row := updatedConsumerRow{
 			Topic:     t.GetTopic(),
 			Partition: t.GetPartition(),
 			Offset:    t.GetOffset(),
 		}
-		rows = append(rows, row)
+		rows[i] = row
 	}
 
 	return rows

--- a/pkg/cmdutil/flags/flags.go
+++ b/pkg/cmdutil/flags/flags.go
@@ -9,6 +9,7 @@ import (
 var (
 	ValidOutputFormats       = []string{dump.JSONFormat, dump.YAMLFormat, dump.YMLFormat}
 	CredentialsOutputFormats = []string{"env", "json", "properties"}
+	ValidOffsets             = []string{"timestamp", "absolute", "latest", "earliest"}
 )
 
 // IsValidInput checks if the input value is in the range of valid values

--- a/pkg/cmdutil/flags/flags.go
+++ b/pkg/cmdutil/flags/flags.go
@@ -3,13 +3,14 @@ package flags
 
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
 	"github.com/spf13/cobra"
 )
 
 var (
 	ValidOutputFormats       = []string{dump.JSONFormat, dump.YAMLFormat, dump.YMLFormat}
 	CredentialsOutputFormats = []string{"env", "json", "properties"}
-	ValidOffsets             = []string{"timestamp", "absolute", "latest", "earliest"}
+	ValidOffsets             = []string{consumergroup.AbsoluteOffset, consumergroup.EarliestOffset, consumergroup.TimestampOffset, consumergroup.LatestOffset}
 )
 
 // IsValidInput checks if the input value is in the range of valid values

--- a/pkg/cmdutil/flags/flags.go
+++ b/pkg/cmdutil/flags/flags.go
@@ -3,14 +3,12 @@ package flags
 
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
-	"github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
 	"github.com/spf13/cobra"
 )
 
 var (
 	ValidOutputFormats       = []string{dump.JSONFormat, dump.YAMLFormat, dump.YMLFormat}
 	CredentialsOutputFormats = []string{"env", "json", "properties"}
-	ValidOffsets             = []string{consumergroup.AbsoluteOffset, consumergroup.EarliestOffset, consumergroup.TimestampOffset, consumergroup.LatestOffset}
 )
 
 // IsValidInput checks if the input value is in the range of valid values

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -1,10 +1,6 @@
 package consumergroup
 
 import (
-	"regexp"
-
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 )
 
@@ -17,8 +13,6 @@ const (
 )
 
 var ValidOffsets = []string{OffsetAbsolute, OffsetEarliest, OffsetTimestamp, OffsetLatest}
-
-var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
 
 // GetPartitionsWithLag returns the number of partitions having lag for a consumer group
 func GetPartitionsWithLag(consumers []kafkainstanceclient.Consumer) (partitionsWithLag int) {
@@ -47,15 +41,4 @@ func GetUnassignedPartitions(consumers []kafkainstanceclient.Consumer) (unassign
 		}
 	}
 	return unassignedPartitions
-}
-
-// ValidateOffset checks if value v is a valid value for --offset
-func ValidateOffset(v string) error {
-	isValid := flagutil.IsValidInput(v, ValidOffsets...)
-
-	if isValid {
-		return nil
-	}
-
-	return flag.InvalidValueError("output", v, ValidOffsets...)
 }

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -10,13 +10,13 @@ import (
 
 // valid values for consumer group reset offset operaion
 const (
-	OffsetAbssolute = "absolute"
+	OffsetAbsolute  = "absolute"
 	OffsetEarliest  = "earliest"
 	OffsetTimestamp = "timestamp"
 	OffsetLatest    = "latest"
 )
 
-var ValidOffsets = []string{OffsetAbssolute, OffsetEarliest, OffsetTimestamp, OffsetLatest}
+var ValidOffsets = []string{OffsetAbsolute, OffsetEarliest, OffsetTimestamp, OffsetLatest}
 
 var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
 

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -1,20 +1,22 @@
 package consumergroup
 
 import (
-	"errors"
 	"regexp"
 
-	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 )
 
 // valid values for consumer group reset offset operaion
 const (
-	AbsoluteOffset  = "absolute"
-	EarliestOffset  = "earliest"
-	TimestampOffset = "timestamp"
-	LatestOffset    = "latest"
+	OffsetAbssolute = "absolute"
+	OffsetEarliest  = "earliest"
+	OffsetTimestamp = "timestamp"
+	OffsetLatest    = "latest"
 )
+
+var ValidOffsets = []string{OffsetAbssolute, OffsetEarliest, OffsetTimestamp, OffsetLatest}
 
 var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
 
@@ -47,15 +49,13 @@ func GetUnassignedPartitions(consumers []kafkainstanceclient.Consumer) (unassign
 	return unassignedPartitions
 }
 
-// ValidateTimestampValue validates the value for timestamp offset
-// value should be in format "yyyy-MM-dd'T'HH:mm:ss"
-func ValidateTimestampValue(localizer localize.Localizer, time string) error {
-	offsetValueTmplPair := localize.NewEntry("Value", time)
-	matched := timestampOffsetRegExp.MatchString(time)
+// ValidateOffset checks if value v is a valid value for --offset
+func ValidateOffset(v string) error {
+	isValid := flagutil.IsValidInput(v, ValidOffsets...)
 
-	if matched {
+	if isValid {
 		return nil
 	}
 
-	return errors.New(localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair))
+	return flag.InvalidValueError("output", v, ValidOffsets...)
 }

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -1,8 +1,22 @@
 package consumergroup
 
 import (
+	"errors"
+	"regexp"
+
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
 )
+
+// valid values for consumer group reset offset operaion
+const (
+	AbsoluteOffset  = "absolute"
+	EarliestOffset  = "earliest"
+	TimestampOffset = "timestamp"
+	LatestOffset    = "latest"
+)
+
+var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
 
 // GetPartitionsWithLag returns the number of partitions having lag for a consumer group
 func GetPartitionsWithLag(consumers []kafkainstanceclient.Consumer) (partitionsWithLag int) {
@@ -31,4 +45,17 @@ func GetUnassignedPartitions(consumers []kafkainstanceclient.Consumer) (unassign
 		}
 	}
 	return unassignedPartitions
+}
+
+// ValidateTimestampValue validates the value for timestamp offset
+// value should be in format "yyyy-MM-dd'T'HH:mm:ss"
+func ValidateTimestampValue(localizer localize.Localizer, time string) error {
+	offsetValueTmplPair := localize.NewEntry("Value", time)
+	matched := timestampOffsetRegExp.MatchString(time)
+
+	if matched {
+		return nil
+	}
+
+	return errors.New(localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair))
 }

--- a/pkg/kafka/consumergroup/validators.go
+++ b/pkg/kafka/consumergroup/validators.go
@@ -1,0 +1,31 @@
+package consumergroup
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+)
+
+type Validator struct {
+	Localizer localize.Localizer
+}
+
+// ValidateOffsetValue validates value for timestamp and absolute offset
+// value for absolute offset should be integer and timestamp should be in format "yyyy-MM-dd'T'HH:mm:ss"
+func (v *Validator) ValidateOffsetValue(offset string, value string) error {
+	offsetValueTmplPair := localize.NewEntry("Value", value)
+	switch offset {
+	case "timestamp":
+		matched := timestampOffsetRegExp.MatchString(value)
+		if !matched {
+			return errors.New(v.Localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair))
+		}
+	case OffsetAbssolute:
+		if _, parseErr := strconv.Atoi(value); parseErr != nil {
+			offsetValueTmplPair := localize.NewEntry("Value", value)
+			return errors.New(v.Localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidAbsoluteOffset", offsetValueTmplPair))
+		}
+	}
+	return nil
+}

--- a/pkg/kafka/consumergroup/validators.go
+++ b/pkg/kafka/consumergroup/validators.go
@@ -21,7 +21,7 @@ func (v *Validator) ValidateOffsetValue(offset string, value string) error {
 		if !matched {
 			return errors.New(v.Localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair))
 		}
-	case OffsetAbssolute:
+	case OffsetAbsolute:
 		if _, parseErr := strconv.Atoi(value); parseErr != nil {
 			offsetValueTmplPair := localize.NewEntry("Value", value)
 			return errors.New(v.Localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidAbsoluteOffset", offsetValueTmplPair))

--- a/pkg/kafka/consumergroup/validators.go
+++ b/pkg/kafka/consumergroup/validators.go
@@ -2,21 +2,37 @@ package consumergroup
 
 import (
 	"errors"
+	"regexp"
 	"strconv"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 )
+
+var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
 
 type Validator struct {
 	Localizer localize.Localizer
 }
 
+// ValidateOffset checks if value v is a valid value for --offset
+func (v *Validator) ValidateOffset(offset string) error {
+	isValid := flagutil.IsValidInput(offset, ValidOffsets...)
+
+	if isValid {
+		return nil
+	}
+
+	return flag.InvalidValueError("output", v, ValidOffsets...)
+}
+
 // ValidateOffsetValue validates value for timestamp and absolute offset
-// value for absolute offset should be integer and timestamp should be in format "yyyy-MM-dd'T'HH:mm:ss"
+// value for absolute offset should be integer and timestamp should be in format "yyyy-MM-dd'T'HH:mm:ssz"
 func (v *Validator) ValidateOffsetValue(offset string, value string) error {
 	offsetValueTmplPair := localize.NewEntry("Value", value)
 	switch offset {
-	case "timestamp":
+	case OffsetTimestamp:
 		matched := timestampOffsetRegExp.MatchString(value)
 		if !matched {
 			return errors.New(v.Localizer.MustLocalize("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair))

--- a/pkg/kafka/consumergroup/validators_test.go
+++ b/pkg/kafka/consumergroup/validators_test.go
@@ -1,0 +1,165 @@
+package consumergroup
+
+import (
+	"testing"
+
+	"github.com/redhat-developer/app-services-cli/pkg/localize/goi18n"
+)
+
+var validator *Validator
+
+func init() {
+	localizer, _ := goi18n.New(nil)
+
+	validator = &Validator{
+		Localizer: localizer,
+	}
+}
+
+func TestValidateOffset(t *testing.T) {
+	type args struct {
+		offset string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Should be valid when 'absolute' is provided",
+			args: args{
+				offset: "absolute",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should be valid when 'latest' is provided",
+			args: args{
+				offset: "latest",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should be valid when 'earliest' is provided",
+			args: args{
+				offset: "earliest",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should be valid when 'timestamp' is provided",
+			args: args{
+				offset: "timestamp",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should throw error when a valid offset type is capitalized",
+			args: args{
+				offset: "Timestamp",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw error when a valid offset type is contains uppercase letters",
+			args: args{
+				offset: "offsEt",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw error when an invalid value for offset type is provided",
+			args: args{
+				offset: "random",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// nolint
+			if err := validator.ValidateOffset(tt.args.offset); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOffsetValue(t *testing.T) {
+	type args struct {
+		offset string
+		value  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Should be valid when value for absolute offset is an integer",
+			args: args{
+				offset: "absolute",
+				value:  "1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should throw error when value for absolute offset is a string",
+			args: args{
+				offset: "absolute",
+				value:  "random-value",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw error when value for absolute offset contains special characters",
+			args: args{
+				offset: "absolute",
+				value:  "random-value-*",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw error when value for absolute offset contains numerics and alphabets",
+			args: args{
+				offset: "absolute",
+				value:  "1rt2",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should be valid when value for timestamp offset is in format 'yyyy-MM-dd'T'HH:mm:ssz'",
+			args: args{
+				offset: "timestamp",
+				value:  "2016-06-23T09:07:21-07:00",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should throw an error when value for timestamp offset is not in format 'yyyy-MM-dd'T'HH:mm:ssz'",
+			args: args{
+				offset: "timestamp",
+				value:  "2016-06-23T09:07:21",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw an error when value for timestamp offset is a string",
+			args: args{
+				offset: "timestamp",
+				value:  "random-string-value",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// nolint
+			if err := validator.ValidateOffsetValue(tt.args.offset, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -40,7 +40,7 @@ one = 'Are you sure you want to reset the offset for consumer group "{{.ID}}"?'
 one = 'You have chosen not to reset the consumer group offset.'
 
 [kafka.consumerGroup.resetOffset.log.info.successful]
-one = 'Offset has been reset for consumers of Consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'
+one = 'Offset has been reset for members of consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'
 
 [kafka.consumerGroup.resetOffset.error.valueRequired]
 one = 'value is required  when "{{.Offset}}" offset is used'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -43,4 +43,4 @@ one = 'You have chosen not to reset the consumer group offset.'
 one = 'Offset has been reset for consumers of Consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'
 
 [kafka.consumerGroup.resetOffset.error.valueRequired]
-one = 'Value is required  when "{{.Offset}}" offset is used'
+one = 'value is required  when "{{.Offset}}" offset is used'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -30,8 +30,14 @@ one = 'Custom offset value (required when offset is absolute or timestamp)'
 [kafka.consumerGroup.resetOffset.flag.partitions]
 one = 'Partitions on which reset-offset is to be carried upon (space separated integers)'
 
+[kafka.consumerGroup.resetOffset.flag.output]
+one = 'Output in which to display reset offset result'
+
 [kafka.consumerGroup.resetOffset.input.confirmReset.message]
 one = 'Are you sure you want to reset the offset for consumer group "{{.ID}}"?'
 
 [kafka.consumerGroup.resetOffset.log.debug.cancelledReset]
 one = 'You have chosen to not reset the consumer group offset.'
+
+[kafka.consumerGroup.resetOffset.log.info.successful]
+one = 'Offset has been reset for consumers of Consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -1,9 +1,9 @@
 [kafka.consumerGroup.resetOffset.cmd.shortDescription]
-one = 'Reset offset of a consumer group'
+one = 'Reset offset for a consumer group'
 
 [kafka.consumerGroup.resetOffset.cmd.longDescription]
 one = '''
-Reset offset for a consumer group from the Kafka instance.
+Reset the offset for a consumer group.
 '''
 
 [kafka.consumerGroup.resetOffset.cmd.example]
@@ -19,25 +19,25 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 one = 'Select topic for which consumer group offsets are to be reset'
 
 [kafka.consumerGroup.resetOffset.flag.yes]
-one = 'Skip confirmation to forcibly reset-offset of a consumer group'
+one = 'Skip confirmation to forcibly reset the offset for the consumer group'
 
 [kafka.consumerGroup.resetOffset.flag.offset]
-one = 'Offset type (earliest, latest, absolute, timestamp)'
+one = 'Offset type (choose from: "earliest", "latest", "absolute", "timestamp")'
 
 [kafka.consumerGroup.resetOffset.flag.value]
-one = 'Custom offset value (required when offset is absolute or timestamp)'
+one = 'Custom offset value (required when offset is "absolute" or "timestamp")'
 
 [kafka.consumerGroup.resetOffset.flag.partitions]
-one = 'Partitions on which reset-offset is to be carried upon (space separated integers)'
+one = 'Partitions on which to reset the consumer group offset (space separated integers)'
 
 [kafka.consumerGroup.resetOffset.flag.output]
-one = 'Output in which to display reset offset result'
+one = 'Format in which to display reset offset result (choose from: "json", "yml", "yaml")'
 
 [kafka.consumerGroup.resetOffset.input.confirmReset.message]
 one = 'Are you sure you want to reset the offset for consumer group "{{.ID}}"?'
 
 [kafka.consumerGroup.resetOffset.log.debug.cancelledReset]
-one = 'You have chosen to not reset the consumer group offset.'
+one = 'You have chosen not to reset the consumer group offset.'
 
 [kafka.consumerGroup.resetOffset.log.info.successful]
 one = 'Offset has been reset for consumers of Consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -41,3 +41,6 @@ one = 'You have chosen not to reset the consumer group offset.'
 
 [kafka.consumerGroup.resetOffset.log.info.successful]
 one = 'Offset has been reset for consumers of Consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'
+
+[kafka.consumerGroup.resetOffset.error.valueRequired]
+one = 'Value is required  when "{{.Offset}}" offset is used'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -3,7 +3,7 @@ one = 'Reset offset for a consumer group'
 
 [kafka.consumerGroup.resetOffset.cmd.longDescription]
 one = '''
-Reset the offset for a consumer group.
+Reset the offset for consumers in a consumer group reading from a given topic.
 '''
 
 [kafka.consumerGroup.resetOffset.cmd.example]
@@ -28,7 +28,7 @@ one = 'Offset type (choose from: "earliest", "latest", "absolute", "timestamp")'
 one = 'Custom offset value (required when offset is "absolute" or "timestamp")'
 
 [kafka.consumerGroup.resetOffset.flag.partitions]
-one = 'Partitions on which to reset the consumer group offset (space separated integers)'
+one = 'Partitions on which to reset the consumer group offset (comma-separated integers)'
 
 [kafka.consumerGroup.resetOffset.flag.output]
 one = 'Format in which to display reset offset result (choose from: "json", "yml", "yaml")'
@@ -44,3 +44,9 @@ one = 'Offset has been reset for consumers of Consumer group with ID "{{.Consume
 
 [kafka.consumerGroup.resetOffset.error.valueRequired]
 one = 'value is required  when "{{.Offset}}" offset is used'
+
+[kafka.consumerGroup.resetOffset.error.invalidAbsoluteOffset]
+one = 'invalid value "{{.Value}}" for absolute offset, should be an integer'
+
+[kafka.consumerGroup.resetOffset.error.invalidTimestampOffset]
+one = "invalid value \"{{.Value}}\" for timestamp offset, must be in format \"yyyy-MM-dd'T'HH:mm:ssz\""

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -4,14 +4,26 @@ one = 'Reset offset for a consumer group'
 [kafka.consumerGroup.resetOffset.cmd.longDescription]
 one = '''
 Reset the offset for consumers in a consumer group reading from a given topic.
+
+Offset types: earliest, latest, absolute, timestamp
+You can choose specific partition to reset offset from (advanced usage)
 '''
 
 [kafka.consumerGroup.resetOffset.cmd.example]
 one = '''
-# reset offset for a consumer group
+# reset offset for a consumer group to latest
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
 
-# reset offset for specific consumers in a consumer group
+# reset offset for a consumer group to earliest
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset earliest
+
+# reset offset for a consumer group to an absolute value
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset absolute --value 0
+
+# reset offset for a consumer group to a timestamp
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset timestamp --value "2016-06-23T09:07:21-07:00"
+
+# reset offset for specific partitions in a consumer group
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions 0,1
 '''
 

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -12,7 +12,7 @@ one = '''
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
 
 # reset offset for specific consumers in a consumer group
-$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions "1 2"
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions 0,1
 '''
 
 [kafka.consumerGroup.resetOffset.flag.topic]

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -1,0 +1,37 @@
+[kafka.consumerGroup.resetOffset.cmd.shortDescription]
+one = 'Reset offset of a consumer group'
+
+[kafka.consumerGroup.resetOffset.cmd.longDescription]
+one = '''
+Reset offset for a consumer group from the Kafka instance.
+'''
+
+[kafka.consumerGroup.resetOffset.cmd.example]
+one = '''
+# reset offset for a consumer group
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest
+
+# reset offset for specific consumers in a consumer group
+$ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions "1 2"
+'''
+
+[kafka.consumerGroup.resetOffset.flag.topic]
+one = 'Select topic for which consumer group offsets are to be reset'
+
+[kafka.consumerGroup.resetOffset.flag.yes]
+one = 'Skip confirmation to forcibly reset-offset of a consumer group'
+
+[kafka.consumerGroup.resetOffset.flag.offset]
+one = 'Offset type (earliest, latest, absolute, timestamp)'
+
+[kafka.consumerGroup.resetOffset.flag.value]
+one = 'Custom offset value (required when offset is absolute or timestamp)'
+
+[kafka.consumerGroup.resetOffset.flag.partitions]
+one = 'Partitions on which reset-offset is to be carried upon (space separated integers)'
+
+[kafka.consumerGroup.resetOffset.input.confirmReset.message]
+one = 'Are you sure you want to reset the offset for consumer group "{{.ID}}"?'
+
+[kafka.consumerGroup.resetOffset.log.debug.cancelledReset]
+one = 'You have chosen to not reset the consumer group offset.'

--- a/pkg/localize/locales/en/cmd/serviceaccount_reset_credentials.en.toml
+++ b/pkg/localize/locales/en/cmd/serviceaccount_reset_credentials.en.toml
@@ -68,7 +68,7 @@ one = 'File format in which to save the service account credentials:'
 one = 'Are you sure you want to reset the credentials for service account "{{.ID}}"?'
 
 [serviceAccount.resetCredentials.log.debug.cancelledReset]
-one = 'You have chosen to not reset the service account credentials.'
+one = 'You have chosen not to reset the service account credentials.'
 
 [serviceAccount.resetCredentials.error.resetError]
 one = 'could not reset credentials for service account "{{.Name}}"'


### PR DESCRIPTION
Implement `rhoas kafka consumer-group reset-offset` command.

Closes #763 

### Verification Steps against mock
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->

1. Start mock server.
```
make mock-api/start
```
2. Select a Kafka instance using
```
rhoas kafka use --id <id-of-instance>
```
3. Run the following command to reset offset for a consumer group:
```
go run ./cmd/rhoas kafka consumer-group reset-offset --id my-app --offset earliest --topic topic-1
```
4. The output should be updated consumers in a tabular form

### Verification Steps against stage (WIP)
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a Kafka instance,a Kafka topic and Kafka consumer group.
2. After consuming a few messages, disconnect the consumer group.
3. Run the following command to reset offset for a consumer group:
```
./rhoas kafka consumer-group reset-offset --id my-group --offset earliest -v
```
4. Run the following command to reset offset for specific consumers in a consumer group:
```
./rhoas kafka consumer-group reset-offset --id my-group --topic rama --offset earliest --partitions "1 2" -v
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer