### PR TITLE
refactor: add a method which returns an error

### DIFF
--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"gopkg.in/yaml.v2"
 
@@ -80,7 +79,7 @@ func NewListConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if !cfg.HasKafka() {
-				return fmt.Errorf(opts.localizer.MustLocalize("kafka.consumerGroup.common.error.noKafkaSelected"))
+				return opts.localizer.MustLocalizeError("kafka.consumerGroup.common.error.noKafkaSelected")
 			}
 
 			opts.kafkaID = cfg.Services.Kafka.ClusterID

--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
@@ -120,7 +119,7 @@ func NewCreateTopicCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if !cfg.HasKafka() {
-				return fmt.Errorf(opts.localizer.MustLocalize("kafka.topic.common.error.noKafkaSelected"))
+				return opts.localizer.MustLocalizeError("kafka.topic.common.error.noKafkaSelected")
 			}
 
 			opts.kafkaID = cfg.Services.Kafka.ClusterID

--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -3,7 +3,6 @@ package delete
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
@@ -70,7 +69,7 @@ func NewDeleteTopicCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if !cfg.HasKafka() {
-				return fmt.Errorf(opts.localizer.MustLocalize("kafka.topic.common.error.noKafkaSelected"))
+				return opts.localizer.MustLocalizeError("kafka.topic.common.error.noKafkaSelected")
 			}
 
 			opts.kafkaID = cfg.Services.Kafka.ClusterID

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -159,7 +158,7 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if !cfg.HasKafka() {
-				return fmt.Errorf(opts.localizer.MustLocalize("kafka.topic.common.error.noKafkaSelected"))
+				return opts.localizer.MustLocalizeError("kafka.topic.common.error.noKafkaSelected")
 			}
 
 			opts.kafkaID = cfg.Services.Kafka.ClusterID

--- a/pkg/localize/goi18n/go_i18n.go
+++ b/pkg/localize/goi18n/go_i18n.go
@@ -3,6 +3,7 @@ package goi18n
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 
@@ -81,6 +82,16 @@ func (l *Goi18n) MustLocalize(id string, tmplEntries ...*localize.TemplateEntry)
 	}
 	cfg := &i18n.LocalizeConfig{MessageID: id, PluralCount: 1, TemplateData: templateData}
 	return l.localizer.MustLocalize(cfg)
+}
+
+// MustLocalizeError loads a i18n message from the file system
+// and returns an error
+// Examples:
+//
+// `err := localizer.MustLocalizeError("my-message-id", &localize.TemplateEntry{"Name", "Danny"}`
+//
+func (l *Goi18n) MustLocalizeError(id string, tmplEntries ...*localize.TemplateEntry) error {
+	return errors.New(l.MustLocalize(id, tmplEntries...))
 }
 
 // walk the file system and load each file into memory

--- a/pkg/localize/localize.go
+++ b/pkg/localize/localize.go
@@ -17,6 +17,7 @@ var (
 // which defines methods to load i18n messages
 type Localizer interface {
 	MustLocalize(id string, templateEntries ...*TemplateEntry) string
+	MustLocalizeError(id string, templateEntries ...*TemplateEntry) error
 }
 
 // TemplateEntry is a type which defines


### PR DESCRIPTION
This PR adds a new method to the `Localizer` interface, which returns an error instead of a string. This is useful and can reduce boilerplate by handling error creation directly.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Refactor

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer