### PR TITLE
fix(login): use mas-sso host in login success message

### DIFF
--- a/pkg/auth/login/mas_sso_redirect_handler.go
+++ b/pkg/auth/login/mas_sso_redirect_handler.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -28,6 +29,7 @@ type masRedirectPageHandler struct {
 	Logger        logging.Logger
 	ServerAddr    string
 	Port          int
+	AuthURL       *url.URL
 	AuthOptions   []oauth2.AuthCodeOption
 	State         string
 	Oauth2Config  *oauth2.Config
@@ -86,7 +88,7 @@ func (h *masRedirectPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	pageTitle := h.Localizer.MustLocalize("login.redirectPage.title")
-	pageBody := h.Localizer.MustLocalize("login.masRedirectPage.body", localize.NewEntry("Username", rawUsername))
+	pageBody := h.Localizer.MustLocalize("login.masRedirectPage.body", localize.NewEntry("Host", h.AuthURL.Host), localize.NewEntry("Username", rawUsername))
 
 	redirectPage := fmt.Sprintf(masSSOredirectHTMLPage, pageTitle, pageTitle, pageBody)
 

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -164,12 +164,12 @@ func runLogin(opts *Options) (err error) {
 		}
 
 		ssoCfg := &login.SSOConfig{
-			AuthURL:      opts.authURL,
+			AuthURL:      authURL,
 			RedirectPath: "sso-redhat-callback",
 		}
 
 		masSsoCfg := &login.SSOConfig{
-			AuthURL:      opts.masAuthURL,
+			AuthURL:      masAuthURL,
 			RedirectPath: "mas-sso-callback",
 		}
 

--- a/pkg/localize/locales/en/cmd/login.en.toml
+++ b/pkg/localize/locales/en/cmd/login.en.toml
@@ -62,10 +62,6 @@ one = "Prints the console login URL, which you can use to log in to RHOAS from a
 description = 'Description for the --scope flag'
 one = 'Override the default OpenID scope (to specify multiple scopes, use a separate --scope for each scope)'
 
-[login.flag.skipMasSSOLogin]
-description = 'Description for the --skip-mas-login flag'
-one = 'Skip logging in to identity.api.openshift.com'
-
 [login.redirectPage.title]
 description = 'Title for the RHOAS login redirect webpage'
 one = 'Welcome to RHOAS'
@@ -76,7 +72,7 @@ one = 'You are now logged in as <span style="font-weight:700">{{.Username}}</spa
 
 [login.masRedirectPage.body]
 description = 'Title for the identity.api.openshift.com login redirect webpage'
-one = 'You are now logged in to identity.api.openshift.com as <span style="font-weight:700">{{.Username}}</span>.'
+one = 'You are now logged in to <span style="font-weight:700">{{.Host}}</span> as <span style="font-weight:700">{{.Username}}</span>.'
 
 [login.error.schemeMissingFromUrl]
 description = 'Error message for when scheme is missing from the Auth URL'
@@ -113,10 +109,10 @@ one = 'Logging in...'
 one = 'Logged in successfully'
 
 [login.log.info.loggingInMAS]
-one = 'Logging in to identity.api.openshift.com...'
+one = 'Logging in to {{.Host}}...'
 
 [login.log.info.loggedInMAS]
-one = 'Logged in successfully to identity.api.openshift.com'
+one = 'Logged in successfully to {{.Host}}'
 
 [login.error.noRealmInURL]
 one = 'the authentication URL is missing a realm'


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes https://github.com/redhat-developer/app-services-cli/issues/886

### Verification Steps

1. Log in to MAS-SSO staging: `rhoas login --mas-auth-url=stg`
2. Note the success message on the redirect URL and terminal output. They should both reflect that MAS-SSO URL.

```shell
❯ ./rhoas login --mas-auth-url stg
Logging in...

Logged in successfully
Logging in to identity.api.stage.openshift.com...

Logged in successfully to identity.api.stage.openshift.com
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer