### PR TITLE
refactor(dump): create constants for output formats

### DIFF
--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -140,10 +140,10 @@ func runCmd(opts *Options) error {
 
 	stdout := opts.IO.Out
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(consumerGroupData)
 		_ = dump.JSON(stdout, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(consumerGroupData)
 		_ = dump.YAML(stdout, data)
 	default:

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -166,10 +166,10 @@ func runList(opts *Options) (err error) {
 	}
 
 	switch opts.output {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(consumerGroupData)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(consumerGroupData)
 		_ = dump.YAML(opts.IO.Out, data)
 	default:

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -194,10 +194,10 @@ func runCreate(opts *Options) error {
 	logger.Info(opts.localizer.MustLocalize("kafka.create.info.successMessage", localize.NewEntry("Name", response.GetName())))
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.MarshalIndent(response, "", cmdutil.DefaultJSONIndent)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	}

--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -122,7 +122,7 @@ func runDescribe(opts *Options) error {
 
 func printKafka(kafka *kafkamgmtclient.KafkaRequest, opts *Options) error {
 	switch opts.outputFormat {
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, err := yaml.Marshal(kafka)
 		if err != nil {
 			return err

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -127,10 +127,10 @@ func runList(opts *options) error {
 	}
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(response)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	default:

--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -204,10 +204,10 @@ func runCmd(opts *Options) error {
 	logger.Info(opts.localizer.MustLocalize("kafka.topic.create.log.info.topicCreated", localize.NewEntry("TopicName", response.GetName()), localize.NewEntry("InstanceName", kafkaInstance.GetName())))
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(response)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	}

--- a/pkg/cmd/kafka/topic/describe/describe.go
+++ b/pkg/cmd/kafka/topic/describe/describe.go
@@ -134,10 +134,10 @@ func runCmd(opts *Options) error {
 	}
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(topicResponse)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(topicResponse)
 		_ = dump.YAML(opts.IO.Out, data)
 	}

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -172,10 +172,10 @@ func runCmd(opts *Options) error {
 
 	stdout := opts.IO.Out
 	switch opts.output {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(topicData)
 		_ = dump.JSON(stdout, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(topicData)
 		_ = dump.YAML(stdout, data)
 	default:

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -309,10 +309,10 @@ func runCmd(opts *Options) error {
 	logger.Info(opts.localizer.MustLocalize("kafka.topic.update.log.info.topicUpdated", topicNameTmplPair, kafkaNameTmplPair))
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(response)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	}

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -149,10 +149,10 @@ func runCreate(opts *Options) error {
 	logger.Info(opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.MarshalIndent(response, "", cmdutil.DefaultJSONIndent)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	}

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -118,7 +118,7 @@ func runDescribe(opts *Options) error {
 
 func printService(w io.Writer, registry interface{}, outputFormat string) error {
 	switch outputFormat {
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, err := yaml.Marshal(registry)
 		if err != nil {
 			return err

--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -113,10 +113,10 @@ func runList(opts *options) error {
 	}
 
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(response)
 		_ = dump.JSON(opts.IO.Out, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(response)
 		_ = dump.YAML(opts.IO.Out, data)
 	default:

--- a/pkg/cmd/serviceaccount/describe/describe.go
+++ b/pkg/cmd/serviceaccount/describe/describe.go
@@ -84,7 +84,7 @@ func runDescribe(opts *Options) error {
 	}
 
 	switch opts.outputFormat {
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(res)
 		_ = dump.YAML(opts.IO.Out, data)
 	default:

--- a/pkg/cmd/serviceaccount/list/list.go
+++ b/pkg/cmd/serviceaccount/list/list.go
@@ -95,10 +95,10 @@ func runList(opts *Options) (err error) {
 
 	outStream := opts.IO.Out
 	switch opts.output {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.MarshalIndent(res, "", cmdutil.DefaultJSONIndent)
 		_ = dump.JSON(outStream, data)
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(res)
 		_ = dump.YAML(outStream, data)
 	default:

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -119,11 +119,11 @@ func runStatus(opts *Options) error {
 
 	stdout := opts.IO.Out
 	switch opts.outputFormat {
-	case "json":
+	case dump.JSONFormat:
 		data, _ := json.Marshal(status)
 		_ = dump.JSON(stdout, data)
 		return nil
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		data, _ := yaml.Marshal(status)
 		_ = dump.YAML(stdout, data)
 		return nil

--- a/pkg/cmdutil/flags/flags.go
+++ b/pkg/cmdutil/flags/flags.go
@@ -1,10 +1,13 @@
 // flags package is a helper package for processing and interactive command line flags
 package flags
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/spf13/cobra"
+)
 
 var (
-	ValidOutputFormats       = []string{"json", "yml", "yaml"}
+	ValidOutputFormats       = []string{dump.JSONFormat, dump.YAMLFormat, dump.YMLFormat}
 	CredentialsOutputFormats = []string{"env", "json", "properties"}
 )
 

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -1,4 +1,4 @@
-// Package dump contains functions used to dump documents to JSON, YAML and Table formats
+// Package dump contains functions used to print documents to JSON, YAML and Table formats
 package dump
 
 import (
@@ -15,6 +15,12 @@ import (
 
 	"gitlab.com/c0b/go-ordered-json"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	JSONFormat = "json"
+	YAMLFormat = "yaml"
+	YMLFormat  = "yml"
 )
 
 // JSON dumps the given data to the given stream so that it looks pretty. If the data is a valid

--- a/pkg/localize/goi18n/go_i18n.go
+++ b/pkg/localize/goi18n/go_i18n.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"gopkg.in/yaml.v2"
 
@@ -121,9 +122,9 @@ func (l *Goi18n) MustLocalizeFile(files fs.FS, path string) (err error) {
 	switch l.format {
 	case "toml":
 		unmarshalFunc = toml.Unmarshal
-	case "yaml", "yml":
+	case dump.YAMLFormat, dump.YMLFormat:
 		unmarshalFunc = yaml.Unmarshal
-	case "json":
+	case dump.JSONFormat:
 		unmarshalFunc = json.Unmarshal
 	default:
 		return fmt.Errorf("unsupported format \"%v\"", l.format)

--- a/pkg/serviceaccount/credentials/credentials.go
+++ b/pkg/serviceaccount/credentials/credentials.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/redhat-developer/app-services-cli/pkg/color"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
 
 	"github.com/AlecAivazis/survey/v2"
 
@@ -49,7 +50,7 @@ func GetDefaultPath(outputFormat string) (filePath string) {
 		filePath = ".env"
 	case "properties":
 		filePath = "credentials.properties"
-	case "json":
+	case dump.JSONFormat:
 		filePath = "credentials.json"
 	}
 
@@ -83,7 +84,7 @@ func getFileFormat(output string) (format string) {
 		format = templateEnv
 	case "properties":
 		format = templateProperties
-	case "json":
+	case dump.JSONFormat:
 		format = templateJSON
 	}
 


### PR DESCRIPTION
This PR adds a constant for each of the output formats (json, yaml, yml). Everything should remain the same functionally.

### Verification Steps

Run `rhoas kafka describe --output (json|yaml|yml)` and it should print the format that is expected.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Refactor

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer