### PR TITLE
fix(service-account): remove period from description validation error

### DIFF
--- a/pkg/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/localize/locales/en/cmd/serviceaccount.en.toml
@@ -83,7 +83,7 @@ one = 'service account name cannot exceed {{.MaxNameLen}} characters'
 one = 'invalid service account name "{{.Name}}"; only lowercase letters (a-z), numbers, and "-" are accepted'
 
 [serviceAccount.common.validation.description.error.invalidChars]
-one = 'invalid service account description: only alphanumeric characters and "-", ".", "," are accepted.'
+one = 'invalid service account description: only alphanumeric characters and "-", ".", "," are accepted'
 
 [serviceAccount.common.validation.description.error.lengthError]
 one = 'service account description cannot exceed {{.MaxLen}} characters'


### PR DESCRIPTION
The service-account description validation error message ended with a period which added an extra dot to message printed by terminal.

![Screenshot from 2021-08-11 16-07-45](https://user-images.githubusercontent.com/23582438/129015189-44eae308-049f-4b26-8413-68b6d10e3831.png)

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer