### PR TITLE
refactor(pagination): use build variables for default pagination values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,16 @@ TERMS_REVIEW_EVENT_CODE ?= "onlineService"
 TERMS_REVIEW_SITE_CODE ?= "ocm"
 
 # see pkg/cmdutil/constants.go
-DEFAULT_PAGE_NUMBER ?= 1
-DEFAULT_PAGE_SIZE ?= 10
+DEFAULT_PAGE_NUMBER ?= "1"
+DEFAULT_PAGE_SIZE ?= "10"
 
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.Version=$(RHOAS_VERSION) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryOwner=$(REPOSITORY_OWNER) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryName=$(REPOSITORY_NAME) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.TermsReviewEventCode=$(TERMS_REVIEW_EVENT_CODE) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.TermsReviewSiteCode=$(TERMS_REVIEW_SITE_CODE) $(GO_LDFLAGS)
-
-GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/pkg/cmdutil.DefaultPageSize=$(DEFAULT_PAGE_SIZE) $(GO_LDFLAGS)
-GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/pkg/cmdutil.DefaultPageNumber=$(DEFAULT_PAGE_NUMBER) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageSize=$(DEFAULT_PAGE_SIZE) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageNumber=$(DEFAULT_PAGE_NUMBER) $(GO_LDFLAGS)
 
 BUILDFLAGS :=
 

--- a/docs/commands/rhoas_kafka_list.adoc
+++ b/docs/commands/rhoas_kafka_list.adoc
@@ -38,7 +38,7 @@ $ rhoas kafka list -o json
 
       `--limit` _int_::         The maximum number of Kafka instances to be returned (default 100)
   `-o`, `--output` _string_::   Format in which to display the Kafka instances (choose from: "json", "yml", "yaml")
-      `--page` _int_::          Display the Kafka instances from the specified page number
+      `--page` _int_::          Display the Kafka instances from the specified page number (default 1)
       `--search` _string_::     Text search to filter the Kafka instances by name, owner, cloud_provider, region and status
 
 [discrete]

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -29,6 +29,12 @@ var (
 
 	// TermsReviewSiteCode is the site code used when checking the terms review
 	TermsReviewSiteCode = "ocm"
+
+	// DefaultPageSize is the default number of items per page when using list commands
+	DefaultPageSize = "10"
+
+	// DefaultPageNumber is the default page number when using list commands
+	DefaultPageNumber = "1"
 )
 
 // Auth Build variables

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 
+	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
@@ -91,8 +92,8 @@ func NewListConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.output.description"))
 	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.topic.description"))
 	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.search"))
-	cmd.Flags().Int32VarP(&opts.page, "page", "", int32(cmdutil.DefaultPageNumber), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.page"))
-	cmd.Flags().Int32VarP(&opts.size, "size", "", int32(cmdutil.DefaultPageSize), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.size"))
+	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.page"))
+	cmd.Flags().Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.size"))
 
 	_ = cmd.RegisterFlagCompletionFunc("topic", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
@@ -85,7 +87,7 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("kafkas.common.flag.output.description"))
-	cmd.Flags().IntVarP(&opts.page, "page", "", 0, opts.localizer.MustLocalize("kafka.list.flag.page"))
+	cmd.Flags().IntVarP(&opts.page, "page", "", int(cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber)), opts.localizer.MustLocalize("kafka.list.flag.page"))
 	cmd.Flags().IntVarP(&opts.limit, "limit", "", 100, opts.localizer.MustLocalize("kafka.list.flag.limit"))
 	cmd.Flags().StringVarP(&opts.search, "search", "", "", opts.localizer.MustLocalize("kafka.list.flag.search"))
 

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -19,6 +19,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
@@ -105,8 +106,8 @@ func NewListTopicCommand(f *factory.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.topic.list.flag.output.description"))
 	cmd.Flags().StringVarP(&opts.search, "search", "", "", opts.localizer.MustLocalize("kafka.topic.list.flag.search.description"))
-	cmd.Flags().Int32VarP(&opts.page, "page", "", int32(cmdutil.DefaultPageNumber), opts.localizer.MustLocalize("kafka.topic.list.flag.page.description"))
-	cmd.Flags().Int32VarP(&opts.size, "size", "", int32(cmdutil.DefaultPageSize), opts.localizer.MustLocalize("kafka.topic.list.flag.size.description"))
+	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.topic.list.flag.page.description"))
+	cmd.Flags().Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.topic.list.flag.size.description"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
@@ -70,9 +72,8 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
-	cmd.Flags().Int32VarP(&opts.page, "page", "", 1, opts.localizer.MustLocalize("registry.list.flag.page"))
+	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("registry.list.flag.page"))
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, opts.localizer.MustLocalize("registry.list.flag.limit"))
-	cmd.Flags().StringVarP(&opts.search, "search", "", "", opts.localizer.MustLocalize("registry.list.flag.search"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/redhat-developer/app-services-cli/pkg/cloudprovider/cloudproviderutil"
@@ -156,4 +157,24 @@ func FetchCloudProviders(f *factory.Factory) (validProviders []string, directive
 	validProviders = cloudproviderutil.GetEnabledNames(cloudProviders)
 
 	return validProviders, directive
+}
+
+func ConvertPageValueToInt32(s string) int32 {
+	val, err := strconv.Atoi(s)
+
+	if err != nil {
+		return 1
+	}
+
+	return int32(val)
+}
+
+func ConvertSizeValueToInt32(s string) int32 {
+	val, err := strconv.Atoi(s)
+
+	if err != nil {
+		return 10
+	}
+
+	return int32(val)
 }

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -160,7 +160,7 @@ func FetchCloudProviders(f *factory.Factory) (validProviders []string, directive
 }
 
 func ConvertPageValueToInt32(s string) int32 {
-	val, err := strconv.Atoi(s)
+	val, err := strconv.ParseInt(s, 10, 32)
 
 	if err != nil {
 		return 1
@@ -170,7 +170,7 @@ func ConvertPageValueToInt32(s string) int32 {
 }
 
 func ConvertSizeValueToInt32(s string) int32 {
-	val, err := strconv.Atoi(s)
+	val, err := strconv.ParseInt(s, 10, 32)
 
 	if err != nil {
 		return 10

--- a/pkg/cmdutil/constants.go
+++ b/pkg/cmdutil/constants.go
@@ -3,10 +3,4 @@ package cmdutil
 const (
 	// The default indentation to use when printing data to stdout
 	DefaultJSONIndent = "    "
-
-	// DefaultPageSize is the default number of items per page when using list commands
-	DefaultPageSize = 10
-
-	// DefaultPageNumber is the default page number when using list commands
-	DefaultPageNumber = 1
 )


### PR DESCRIPTION
Default values for `Page` and `Size` should be provided as build variables.

Closes #831 

### Verification Steps
1. Create a binary of CLI by running the following command (pass 20 as default page size):
```
go build  -ldflags "-X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageNumber="1" -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageSize="20" -X github.com/redhat-developer/app-services-cli/internal/build.TermsReviewSiteCode="ocm" -X github.com/redhat-developer/app-services-cli/internal/build.TermsReviewEventCode="onlineService" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryName="app-services-cli" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryOwner="redhat-developer" -X github.com/redhat-developer/app-services-cli/internal/build.Version="dev" " -o rhoas ./cmd/rhoas
```
2. Run the `kafka topic list` command in verbose mode.
```
 ./rhoas kafka topic list -v
```
3. You should be able to see `size` route param set to 20.
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [X] Refactor

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer