### PR TITLE
docs: update documentation to clarify instance and management commands

### DIFF
--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -8,12 +8,12 @@ Create, view, use, and manage your Kafka instances
 [discrete]
 == Synopsis
 
-A collection of commands for managing and interacting with Kafka instances.
+Commands for managing and interacting with Kafka instances.
 
 Commands are divided into the following categories:
- - instance management commands: create, list etc.
- - commands executed on selected instance: topic, consumer-group
- - "use" command that selects current instance
+ - instance management commands: create, list, and so on
+ - commands executed on the selected instance: topic, consumer-group
+ - "use" command that selects the current instance
 
 
 [discrete]

--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -10,6 +10,12 @@ Create, view, use, and manage your Kafka instances
 
 A collection of commands for managing and interacting with Kafka instances.
 
+Commands are divided into the following categories:
+ - instance management commands: create, list etc.
+ - commands executed on selected instance: topic, consumer-group
+ - "use" command that selects current instance
+
+
 [discrete]
 == Examples
 

--- a/docs/commands/rhoas_kafka_consumer-group.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group.adoc
@@ -8,7 +8,10 @@ Describe, list, and delete consumer groups for the current Kafka instance.
 [discrete]
 == Synopsis
 
-Use these commands to describe, list, and delete consumer groups for the current Kafka instance.
+Use these commands to describe, list, and delete consumer groups for the current Kafka instance.'
+ 
+Commands are executed on the currently selected Kafka instance that can be overridden by --instance-id flag.
+
 
 [discrete]
 == Examples

--- a/docs/commands/rhoas_kafka_topic.adoc
+++ b/docs/commands/rhoas_kafka_topic.adoc
@@ -10,6 +10,9 @@ Create, describe, update, list and delete topics
 
 Create, describe, update, list and delete topics for the current Kafka instance.
 
+Commands are executed on the currently selected Kafka instance that can be overridden by --instance-id flag.
+
+
 [discrete]
 == Examples
 

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -27,7 +27,7 @@ For example, client applications can dynamically push or pull the latest updates
 Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 
 For example, this includes rules for content validation and version compatibility.
 
-Registry commands enable client applications to manage the artifacts in the registry. 
+Artifact commands enable client applications to manage the artifacts in the registry. 
 This set of commands provide create, read, update, and delete operations for schema and API artifacts, rules, versions, and metadata.
 `,
 		Example: `

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -18,7 +18,7 @@ func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 		Use:   "artifact",
 		Short: "Manage Service Registry Artifacts",
 		Long: `
-Manage Service Registry Artifacts using currently selected Service Registry.
+Manage Service Registry Artifacts using the currently selected Service Registry.
 
 Commands are executed on the currently selected Service Registry instance that can be overridden by --instance-id flag.
 

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -20,6 +20,8 @@ func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 		Long: `
 Manage Service Registry Artifacts using currently selected Service Registry.
 
+Commands are executed on the currently selected Service Registry instance that can be overriden by --instance-id flag.
+
 Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
 For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.
 Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -20,7 +20,7 @@ func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 		Long: `
 Manage Service Registry Artifacts using currently selected Service Registry.
 
-Commands are executed on the currently selected Service Registry instance that can be overriden by --instance-id flag.
+Commands are executed on the currently selected Service Registry instance that can be overridden by --instance-id flag.
 
 Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
 For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.

--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -18,6 +18,8 @@ func NewArtifactsCommand(f *factory.Factory) *cobra.Command {
 		Use:   "artifact",
 		Short: "Manage Service Registry Artifacts",
 		Long: `
+Manage Service Registry Artifacts using currently selected Service Registry.
+
 Apicurio Registry Artifacts enables developers to manage and share the structure of their data. 
 For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy.
 Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. 

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -67,7 +67,7 @@ If an artifact with the provided artifact ID already exists command will fail wi
 
 
 When --group parameter is missing the command will create a new artifact under the "default" group.
-when --registry is missing the command will create a new artifact for currently active service registry (visible in rhoas service-registry describe)
+when --instance-id is missing the command will create a new artifact for currently active service registry (visible in rhoas service-registry describe)
 `
 
 func NewCreateCommand(f *factory.Factory) *cobra.Command {

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -66,7 +66,7 @@ It is typically recommended that callers provide the ID, because this is a meani
 If an artifact with the provided artifact ID already exists command will fail with error.
 
 
-When --group parameter is missing the command will create a new artifact under the "default" group.
+When --group parameter is missing the command will use "default" group.
 when --instance-id is missing the command will create a new artifact for currently active service registry (visible in rhoas service-registry describe)
 `
 

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -59,7 +59,7 @@ Delete command works in two modes:
 	- When --artifact-id argument is missing delete will delete all artifacts in the group
 	- When --artifact-id is specified delete deletes only single artifact and its version
 
-When --group parameter is missing the command will create a new artifact under the "default" group.
+When --group parameter is missing the command will use "default" group.
 		`,
 		Example: `
 ## Delete all artifacts in the group "default"

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -50,9 +50,9 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Deletes all of the artifacts that exist in a given group",
+		Short: "Deletes single or all artifacts in a given group",
 		Long: `
-Deletes all of the artifacts that exist in a given group. 
+Deletes single or all artifacts in a given group. 
 
 Delete command works in two modes:
 

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -9,12 +9,12 @@ one = "Create, view, use, and manage your Kafka instances"
 [kafka.cmd.longDescription]
 description = "Long description for command"
 one = '''
-A collection of commands for managing and interacting with Kafka instances.
+Commands for managing and interacting with Kafka instances.
 
 Commands are divided into the following categories:
- - instance management commands: create, list etc.
- - commands executed on selected instance: topic, consumer-group
- - "use" command that selects current instance
+ - instance management commands: create, list, and so on
+ - commands executed on the selected instance: topic, consumer-group
+ - "use" command that selects the current instance
 '''
 
 [kafka.cmd.example]

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -13,7 +13,7 @@ A collection of commands for managing and interacting with Kafka instances.
 
 Commands are divided into the following categories:
  - instance management commands: create, list etc.
- - commands executed on selected instance: topics, consumer-group
+ - commands executed on selected instance: topic, consumer-group
  - "use" command that selects current instance
 '''
 

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -8,7 +8,14 @@ one = "Create, view, use, and manage your Kafka instances"
 
 [kafka.cmd.longDescription]
 description = "Long description for command"
-one = "A collection of commands for managing and interacting with Kafka instances."
+one = '''
+A collection of commands for managing and interacting with Kafka instances.
+
+Commands are divided into the following categories:
+ - instance management commands: create, list etc.
+ - commands executed on selected instance: topics, consumer-group
+ - "use" command that selects current instance
+'''
 
 [kafka.cmd.example]
 description = "Examples for command"

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup.en.toml
@@ -6,7 +6,11 @@ one = "consumer-group"
 one = 'Describe, list, and delete consumer groups for the current Kafka instance.'
 
 [kafka.consumerGroup.cmd.longDescription]
-one = 'Use these commands to describe, list, and delete consumer groups for the current Kafka instance.'
+one = '''
+Use these commands to describe, list, and delete consumer groups for the current Kafka instance.'
+ 
+Commands are executed on the currently selected Kafka instance that can be overriden by --instance-id flag.
+'''
 
 [kafka.consumerGroup.cmd.example]
 one = '''

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup.en.toml
@@ -9,7 +9,7 @@ one = 'Describe, list, and delete consumer groups for the current Kafka instance
 one = '''
 Use these commands to describe, list, and delete consumer groups for the current Kafka instance.'
  
-Commands are executed on the currently selected Kafka instance that can be overriden by --instance-id flag.
+Commands are executed on the currently selected Kafka instance that can be overridden by --instance-id flag.
 '''
 
 [kafka.consumerGroup.cmd.example]

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -8,9 +8,9 @@ Manage and interact with your Service Registry instances directly from the comma
 Create new Service Registry instances and interact with them by adding schema and API artifacts and downloading them to your computer.
 
 Commands are divided into the following categories:
- - instance management commands: create, list etc.
+ - instance management commands: create, list, and so on
  - commands executed on selected instance: artifacts
- - "use" command that selects current instance
+ - "use" command that selects the current instance
 '''
 
 [registry.cmd.example]

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -3,9 +3,14 @@ one = 'Service Registry commands'
 
 [registry.cmd.longDescription]
 one = ''' 
-Manage your Service Registry instances directly from the command line.
+Manage and interact with your Service Registry instances directly from the command line.
 
 Create new Service Registry instances and interact with them by adding schema and API artifacts and downloading them to your computer.
+
+Commands are divided into the following categories:
+ - instance management commands: create, list etc.
+ - commands executed on selected instance: artifacts
+ - "use" command that selects current instance
 '''
 
 [registry.cmd.example]

--- a/pkg/localize/locales/en/cmd/topic.en.toml
+++ b/pkg/localize/locales/en/cmd/topic.en.toml
@@ -8,7 +8,7 @@ one = 'Create, describe, update, list and delete topics'
 one = '''
 Create, describe, update, list and delete topics for the current Kafka instance.
 
-Commands are executed on the currently selected Kafka instance that can be overriden by --instance-id flag.
+Commands are executed on the currently selected Kafka instance that can be overridden by --instance-id flag.
 '''
 
 [kafka.topic.cmd.example]

--- a/pkg/localize/locales/en/cmd/topic.en.toml
+++ b/pkg/localize/locales/en/cmd/topic.en.toml
@@ -5,7 +5,11 @@ one = 'topic'
 one = 'Create, describe, update, list and delete topics'
 
 [kafka.topic.cmd.longDescription]
-one = 'Create, describe, update, list and delete topics for the current Kafka instance.'
+one = '''
+Create, describe, update, list and delete topics for the current Kafka instance.
+
+Commands are executed on the currently selected Kafka instance that can be overriden by --instance-id flag.
+'''
 
 [kafka.topic.cmd.example]
 one = '''


### PR DESCRIPTION
Number of  independent developers provided us feedback that documentation missing clarification what commands are used with instance and what are used for management. I have done this by adding documentation to top level cli objects.

Issue #901 