### PR TITLE
feat: display registry status in status cmd

### DIFF
--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	kafkaSvcName = "kafka"
+	kafkaSvcName    = "kafka"
+	registrySvcName = "registry"
 )
 
-var validServices = []string{kafkaSvcName}
+var validServices = []string{kafkaSvcName, registrySvcName}
 
 type Options struct {
 	IO         *iostreams.IOStreams

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -9,6 +9,7 @@ import (
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/profile"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 
@@ -25,10 +26,10 @@ import (
 
 const (
 	kafkaSvcName    = "kafka"
-	registrySvcName = "registry"
+	registrySvcName = "service-registry"
 )
 
-var validServices = []string{kafkaSvcName, registrySvcName}
+var validServices = []string{kafkaSvcName}
 
 type Options struct {
 	IO         *iostreams.IOStreams
@@ -42,6 +43,11 @@ type Options struct {
 }
 
 func NewStatusCommand(f *factory.Factory) *cobra.Command {
+
+	if profile.DevModeEnabled() {
+		validServices = append(validServices, registrySvcName)
+	}
+
 	opts := &Options{
 		IO:         f.IOStreams,
 		Config:     f.Config,

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka/kafkaerr"
+	"github.com/redhat-developer/app-services-cli/pkg/profile"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
@@ -24,7 +25,7 @@ const tagTitle = "title"
 
 type Status struct {
 	Kafka    *KafkaStatus    `json:"kafka,omitempty" title:"Kafka"`
-	Registry *RegistryStatus `json:"registry,omitempty" title:"Registry"`
+	Registry *RegistryStatus `json:"registry,omitempty" title:"Service Registry"`
 }
 
 type KafkaStatus struct {
@@ -85,7 +86,7 @@ func Get(ctx context.Context, opts *Options) (status *Status, ok bool, err error
 		}
 	}
 
-	if stringInSlice("registry", opts.Services) {
+	if profile.DevModeEnabled() && stringInSlice("service-registry", opts.Services) {
 		registryCfg := cfg.Services.ServiceRegistry
 		if registryCfg != nil && registryCfg.InstanceID != "" {
 			// nolint:govet


### PR DESCRIPTION
`rhoas status` should display the status of registry command if selected.

Closes #902

![Screenshot from 2021-08-19 14-07-55](https://user-images.githubusercontent.com/23582438/130036974-9c7392fa-407d-426a-b8bc-5fa9d92908d6.png)

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Select a service registry using the `service-registry` use command.
```
./rhoas service-registry use --id 195
```
2. Run the `rhoas status` command, you should be able to see the status of registry along with kafka instance.
3. To see the status of registry specifically, run `./rhoas status registry`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer