### PR TITLE
refactor(consumer-group): rename unconsumed to unassigned

### DIFF
--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -168,7 +168,7 @@ func mapConsumerGroupDescribeToTableFormat(consumers []kafkainstanceclient.Consu
 		}
 
 		if consumer.GetMemberId() == "" {
-			row.MemberID = color.Italic("unconsumed")
+			row.MemberID = color.Italic("unassigned")
 		}
 
 		rows = append(rows, row)
@@ -189,9 +189,9 @@ func printConsumerGroupDetails(w io.Writer, consumerGroupData kafkainstanceclien
 
 	activeMembersCount := cgutil.GetActiveConsumersCount(consumers)
 	partitionsWithLagCount := cgutil.GetPartitionsWithLag(consumers)
-	unconsumedPartitions := cgutil.GetUnconsumedPartitions(consumers)
+	unassignedPartitions := cgutil.GetUnassignedPartitions(consumers)
 
-	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unconsumedPartitions")), unconsumedPartitions)
+	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unassignedPartitions")), unassignedPartitions)
 	fmt.Fprintln(w, "")
 
 	rows := mapConsumerGroupDescribeToTableFormat(consumers)

--- a/pkg/kafka/consumergroup/util.go
+++ b/pkg/kafka/consumergroup/util.go
@@ -24,11 +24,11 @@ func GetActiveConsumersCount(consumers []kafkainstanceclient.Consumer) (count in
 	return count
 }
 
-func GetUnconsumedPartitions(consumers []kafkainstanceclient.Consumer) (unconsumedPartitions int) {
+func GetUnassignedPartitions(consumers []kafkainstanceclient.Consumer) (unassignedPartitions int) {
 	for _, c := range consumers {
 		if c.GetMemberId() == "" {
-			unconsumedPartitions++
+			unassignedPartitions++
 		}
 	}
-	return unconsumedPartitions
+	return unassignedPartitions
 }

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_describe.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_describe.en.toml
@@ -27,5 +27,5 @@ one = 'ACTIVE MEMBERS:'
 [kafka.consumerGroup.describe.output.partitionsWithLag]
 one = 'PARTITIONS WITH LAG:'
 
-[kafka.consumerGroup.describe.output.unconsumedPartitions]
-one = 'UNCONSUMED PARTITIONS:'
+[kafka.consumerGroup.describe.output.unassignedPartitions]
+one = 'UNASSIGNED PARTITIONS:'


### PR DESCRIPTION
Change unconsumed partition to unassigned partition.

![Screenshot from 2021-08-19 16-20-01](https://user-images.githubusercontent.com/23582438/130057602-9c5c515c-4dd3-4e82-9a8c-61435c75ca97.png)


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run `consumer-group describe` for a consumer group with inactive member(s).
```
./rhoas kafka consumer-group describe --id my-group
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer