### PR TITLE
fix!: remove positional arguments for artifact commands

### DIFF
--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -35,7 +35,10 @@ This set of commands provide create, read, update, and delete operations for sch
 rhoas service-registry artifact create --artifact-id=my-artifact --group=my-group artifact.json
 
 ## Get artifact content
-rhoas service-registry artifact get --artifact-id=my-artifact --group=my-group file.json 
+rhoas service-registry artifact get --artifact-id=my-artifact --group=my-group --file-location=artifact.json
+
+## Get artifact content by hash
+rhoas service-registry artifact download --hash=cab4...al9 --file-location=artifact.json
 
 ## Delete artifact
 rhoas service-registry artifact delete --artifact-id=my-artifact

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -126,7 +126,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 	}
 
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
-	cmd.Flags().StringVarP(&opts.file, "file", "", "", "File location of the artifact")
+	cmd.Flags().StringVar(&opts.file, "file", "", "File location of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
 	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -126,10 +126,10 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 	}
 
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
-	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
+	cmd.Flags().StringVarP(&opts.file, "file", "", "", "File location of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", "Type of artifact. Choose from:  "+util.GetAllowedArtifactTypeEnumValuesAsString())
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 

--- a/pkg/cmd/registry/artifact/crud/delete/delete.go
+++ b/pkg/cmd/registry/artifact/crud/delete/delete.go
@@ -52,28 +52,21 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		Long: `
 Deletes single or all artifacts in a given group. 
 
-Delete command works in two modes:
-
-	- When --artifact-id argument is missing delete will delete all artifacts in the group
-	- When --artifact-id is specified delete deletes only single artifact and its version
-
+When called without arguments delete will delete all artifacts in the group
+When --artifact-id is specified delete deletes only single artifact and its version
 When --group parameter is missing the command will use "default" group.
 		`,
 		Example: `
 ## Delete all artifacts in the group "default"
-rhoas service-registry artifact delete 
+rhoas service-registry artifact delete
 
 ## Delete artifact in the group "default" with name "my-artifact"
-rhoas service-registry artifact delete my-artifact
+rhoas service-registry artifact delete --artifact-id=my-artifact
 		`,
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !opts.IO.CanPrompt() && !opts.force {
 				return flag.RequiredWhenNonInteractiveError("yes")
-			}
-
-			if len(args) > 0 {
-				opts.artifact = args[0]
 			}
 
 			if opts.registryID != "" {
@@ -96,7 +89,7 @@ rhoas service-registry artifact delete my-artifact
 
 	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, "Delete without prompt")
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -49,37 +49,29 @@ func NewGetCommand(f *factory.Factory) *cobra.Command {
 		Use:   "get",
 		Short: "Get artifact by id and group",
 		Long: `Get artifact by specifying id and group.
-Command will fetch the latest artifact from the registry based on the artifactId and group.
+Command will fetch the latest artifact from the registry based on the artifact-id and group.
 
 When --version is specified command will fetch the specific version of the artifact.
-Get command will fetch artifacts based on group and artifactId and version.
+Get command will fetch artifacts based on --group and --artifact-id and --version.
 For fetching artifacts using global identifiers please use "service-registry download" command
 `,
 		Example: `
-## Get latest artifact by name
-rhoas service-registry artifact get myschema
+## Get latest artifact with name "my-artifact" and print it out to standard out
+rhoas service-registry artifact get --artifact-id=my-artifact
 
-## Get latest artifact and save its content to file
-rhoas service-registry artifact get myschema myschema.json
+## Get latest artifact with name "my-artifact" from group "my-group" and save it to artifact.json file
+rhoas service-registry artifact get --artifact-id=my-artifact --group=my-group --file-location=artifact.json
 
 ## Get latest artifact and pipe it to other command 
-rhoas service-registry artifact get myschema | grep -i 'user'
+rhoas service-registry artifact get --artifact-id=my-artifact | grep -i 'user'
 
-## Get latest artifact by specifying custom group, registry and name as flag
-rhoas service-registry artifact get --group mygroup --instance-id=myregistry --artifact-id myartifact
+## Get artifact with custom version and print it out to standard out
+rhoas service-registry artifact get --artifact-id=myartifact --version=4
 `,
-		Args: cobra.RangeArgs(0, 2),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.artifact = args[0]
-			}
-
 			if opts.artifact == "" {
-				return errors.New("artifact id is required. Please specify artifact as positional argument or by using --artifact-id flag")
-			}
-
-			if len(args) > 1 {
-				opts.outputFile = args[1]
+				return errors.New("artifact id is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if opts.registryID != "" {
@@ -92,7 +84,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service registry selected. Please specify registry by using --instance-id flag")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
@@ -101,7 +93,7 @@ rhoas service-registry artifact get --group mygroup --instance-id=myregistry --a
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVar(&opts.outputFile, "file-location", "", "Location of the output file")
 	cmd.Flags().StringVar(&opts.version, "version", "", "Version of the artifact")

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -73,23 +73,19 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 		Short: "List artifacts",
 		Long:  "List all artifacts for the group by specified output format (by default table)",
 		Example: `
-## List all artifacts for the default artifacts group
+## List all artifacts for the "default" artifacts group
 rhoas service-registry artifact list
 
-## List all artifacts with explicit group 
+## List all artifacts with "my-group" group 
 rhoas service-registry artifact list --group=my-group
 
 ## List all artifacts with limit and group
 rhoas service-registry artifact list --page=2 --limit=10
 		`,
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, flagutil.ValidOutputFormats...) {
 				return flag.InvalidValueError("output", opts.outputFormat, flagutil.ValidOutputFormats...)
-			}
-
-			if len(args) > 0 {
-				opts.group = args[0]
 			}
 
 			if opts.page < 1 || opts.limit < 1 {
@@ -116,7 +112,6 @@ rhoas service-registry artifact list --page=2 --limit=10
 	}
 
 	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
-
 	cmd.Flags().Int32VarP(&opts.page, "page", "", 1, "Page number")
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, "Page limit")
 

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -62,7 +62,7 @@ The type of the content should be compatible with the current artifact's type.
 When successful, this creates a new version of the artifact, making it the most recent (and therefore official) version of the artifact.
 
 An artifact is update using the content provided in the body of the request.  
-This content is updated under afu unique artifactId provided by user.
+This content is updated under a unique artifactId provided by user.
 		`,
 		Example: `
 ## update artifact from group and artifact-id

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -57,17 +57,19 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 Update artifact from file or directly standard input
 
 Artifacts can be typically in JSON format for most of the supported types, but may be in another format for a few (for example, PROTOBUF).
-The type of the content should be compatible with the artifact's type.
-(it would be an error to update an AVRO artifact with new OPENAPI content, for example).
+The type of the content should be compatible with the current artifact's type.
 
 When successful, this creates a new version of the artifact, making it the most recent (and therefore official) version of the artifact.
 
 An artifact is update using the content provided in the body of the request.  
-This content is updated under a unique artifactId provided by user.
+This content is updated under afu unique artifactId provided by user.
 		`,
 		Example: `
 ## update artifact from group and artifact-id
-rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifact --group my-group
+rhoas service-registry artifact update --artifact-id=my-artifact --group my-group my-artifact.json 
+
+## update artifact from group and artifact-id
+rhoas service-registry artifact update --artifact-id=my-artifact --group my-group my-artifact.json 
 `,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -106,7 +108,7 @@ rhoas service-registry artifact update my-artifact.json --artifact-id=my-artifac
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "File location of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 
 	flagutil.EnableOutputFlagCompletion(cmd)

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -66,7 +66,7 @@ func NewDownloadCommand(f *factory.Factory) *cobra.Command {
 rhoas service-registry artifact download --content-id=183282932983
 
 ## Get latest artifact by content id to specific file
-rhoas service-registry artifact download --content-id=183282932983 schema.json
+rhoas service-registry artifact download --content-id=183282932983 --file-location=schema.json
 
 ## Get latest artifact by global id
 rhoas service-registry artifact download --global-id=383282932983
@@ -76,10 +76,6 @@ rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec6
 `,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.outputFile = args[0]
-			}
-
 			if opts.registryID != "" {
 				return runGet(opts)
 			}
@@ -90,7 +86,7 @@ rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec6
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service registry selected. Please specify registry by using --instance-id flag")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
@@ -98,7 +94,7 @@ rhoas service-registry artifact download --hash=c71d239df91726fc519c6eb72d318ec6
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.hash, "hash", "", "SHA-256 hash of the artifact")
 	cmd.Flags().Int64VarP(&opts.globalId, "global-id", "", unusedFlagIdValue, "Global ID of the artifact")
 	cmd.Flags().Int64VarP(&opts.contentId, "content-id", "", unusedFlagIdValue, "ContentId of the artifact")

--- a/pkg/cmd/registry/artifact/metadata/metadata.go
+++ b/pkg/cmd/registry/artifact/metadata/metadata.go
@@ -53,17 +53,13 @@ The returned metadata includes both generated (read-only) and editable metadata 
 `,
 		Example: `
 ## Get latest artifact metadata for default group
-rhoas service-registry artifact metadata my-artifact
+rhoas service-registry artifact metadata --artifact-id=my-artifact
 
 ## Get latest artifact metadata for my-group group
-rhoas service-registry artifact metadata my-artifact --group mygroup 
+rhoas service-registry artifact metadata --artifact-id=my-artifact --group mygroup 
 		`,
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.artifact = args[0]
-			}
-
 			if opts.artifact == "" {
 				return errors.New("artifact id is required. Please specify artifact by using --artifact-id flag")
 			}
@@ -78,7 +74,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service registry selected. Please specify registry by using --instance-id flag")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
@@ -87,7 +83,7 @@ rhoas service-registry artifact metadata my-artifact --group mygroup
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
 

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -45,23 +45,20 @@ func NewVersionsCommand(f *factory.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "versions",
-		Short: "Get latest artifact versions by id and group",
-		Long:  "Get latest artifact versions by specifying group and artifacts id",
+		Short: "Get latest artifact versions by artifact-id and group",
+		Long:  "Get latest artifact versions by specifying group and artifact-id",
 		Example: `
 ## Get latest artifact versions for default group
-rhoas service-registry artifact versions my-artifact
+rhoas service-registry artifact versions --artifact-id=my-artifact
 
 ## Get latest artifact versions for my-group group
-rhoas service-registry artifact versions my-artifact --group mygroup 
+rhoas service-registry artifact versions --artifact-id=my-artifact --group mygroup 
 		`,
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.artifact = args[0]
-			}
 
 			if opts.artifact == "" {
-				return errors.New("artifact id is required. Please specify artifact as positional argument or by using --artifact-id flag")
+				return errors.New("artifact id is required. Please specify artifact by using --artifact-id flag")
 			}
 
 			if opts.registryID != "" {
@@ -74,7 +71,7 @@ rhoas service-registry artifact versions my-artifact --group mygroup
 			}
 
 			if !cfg.HasServiceRegistry() {
-				return errors.New("no service Registry selected. Use 'rhoas service-registry use' to select your registry")
+				return errors.New("no service registry selected. Please specify registry by using --instance-id flag")
 			}
 
 			opts.registryID = fmt.Sprint(cfg.Services.ServiceRegistry.InstanceID)
@@ -83,7 +80,7 @@ rhoas service-registry artifact versions my-artifact --group mygroup
 	}
 
 	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
-	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Group of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
 


### PR DESCRIPTION
1. Positionals for artifact id/name were removed 
2. Positional for file input for create command is the only positional we have
3. For file output we use flag as suggested by @craicoverflow 


## Verification

```
## Create artifact in my-group from schema.json file
rhoas service-registry artifact create --artifact-id=my-artifact --group=my-group artifact.json

## Get artifact content
rhoas service-registry artifact get --artifact-id=my-artifact --group=my-group --file-location=artifact.json

## Get artifact content by hash
rhoas service-registry artifact download --hash=cab4...al9 --file-location=artifact.json

## Delete artifact
rhoas service-registry artifact delete --artifact-id=my-artifact

## Get artifact metadata
rhoas service-registry artifact metadata --artifact-id=my-artifact --group=my-group

## Update artifact
rhoas service-registry artifact update --artifact-id=my-artifact artifact-new.json

## List Artifacts
rhoas service-registry artifact list --group=my-group --limit=10 page=1

## View artifact versions
rhoas service-registry artifact versions --artifact-id=my-artifact --group=my-group
```