### PR TITLE
chore: change beta to alpha label for commands

### DIFF
--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -11,7 +11,7 @@ var DevPreviewEnv string = "RHOAS_DEV"
 
 // ApplyDevPreviewLabel adds visual element displayed in help
 func ApplyDevPreviewLabel(cmd *cobra.Command) {
-	cmd.Short = "[beta] " + cmd.Short
+	cmd.Short = "[alpha] " + cmd.Short
 	cmd.Long += "\nThis command is available as part of the developer preview\n"
 
 	for _, child := range cmd.Commands() {


### PR DESCRIPTION
rhoas service-registry and subcommands will now print different label (alpha)