### PR TITLE
 fix!: replace positional use with explicity --name flag

### DIFF
--- a/docs/commands/rhoas_kafka_use.adoc
+++ b/docs/commands/rhoas_kafka_use.adoc
@@ -9,10 +9,10 @@ Set the current Apache Kafka instance
 == Synopsis
 
 Select an Apache Kafka instance and set it as the current instance.
+You can specify a Apache Kafka instance by --name or --id.
 
-When you set the Kafka instance to be used, it is set as the current instance for all "rhoas kafka" commands.
+When you set the Kafka instance to be used, it is set as the current instance for all rhoas kafka topics and rhoas kafka consumer-group commands.
 
-When an ID is not specified in other Kafka commands, the current Kafka instance is used.
 
 
 ....

--- a/docs/commands/rhoas_kafka_use.adoc
+++ b/docs/commands/rhoas_kafka_use.adoc
@@ -31,7 +31,8 @@ $ rhoas kafka use --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg,
 [discrete]
 == Options
 
-      `--id` _string_::   Unique ID of the Kafka instance you want to set as the current instance
+      `--id` _string_::     Unique ID of the Kafka instance you want to set as the current instance
+      `--name` _string_::   Name of the Kafka instance you want to set as the current instance
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/kafka/use/use.go
+++ b/pkg/cmd/kafka/use/use.go
@@ -47,14 +47,12 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 		Short:   opts.localizer.MustLocalize("kafka.use.cmd.shortDescription"),
 		Long:    opts.localizer.MustLocalize("kafka.use.cmd.longDescription"),
 		Example: opts.localizer.MustLocalize("kafka.use.cmd.example"),
-		Args:    cobra.RangeArgs(0, 1),
+		Args:    cobra.NoArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return cmdutil.FilterValidKafkas(f, toComplete)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.name = args[0]
-			} else if opts.id == "" {
+			if opts.id == "" && opts.name == "" {
 				if !opts.IO.CanPrompt() {
 					return errors.New(opts.localizer.MustLocalize("kafka.use.error.idOrNameRequired"))
 				}
@@ -70,7 +68,7 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.use.flag.id"))
-
+	cmd.Flags().StringVar(&opts.id, "name", "", opts.localizer.MustLocalize("kafka.use.flag.name"))
 	return cmd
 }
 

--- a/pkg/cmd/kafka/use/use.go
+++ b/pkg/cmd/kafka/use/use.go
@@ -68,7 +68,7 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.use.flag.id"))
-	cmd.Flags().StringVar(&opts.id, "name", "", opts.localizer.MustLocalize("kafka.use.flag.name"))
+	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.use.flag.name"))
 	return cmd
 }
 

--- a/pkg/cmd/registry/use/use.go
+++ b/pkg/cmd/registry/use/use.go
@@ -61,7 +61,7 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.use.flag.id"))
-	cmd.Flags().StringVar(&opts.id, "name", "", opts.localizer.MustLocalize("registry.use.flag.name"))
+	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("registry.use.flag.name"))
 
 	return cmd
 }

--- a/pkg/cmd/registry/use/use.go
+++ b/pkg/cmd/registry/use/use.go
@@ -43,11 +43,9 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 		Short:   f.Localizer.MustLocalize("registry.cmd.use.shortDescription"),
 		Long:    f.Localizer.MustLocalize("registry.cmd.use.longDescription"),
 		Example: f.Localizer.MustLocalize("registry.cmd.use.example"),
-		Args:    cobra.RangeArgs(0, 1),
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.name = args[0]
-			} else if opts.id == "" {
+			if opts.id == "" && opts.name == "" {
 				if !opts.IO.CanPrompt() {
 					return errors.New(opts.localizer.MustLocalize("registry.use.error.idOrNameRequired"))
 				}
@@ -63,6 +61,7 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.use.flag.id"))
+	cmd.Flags().StringVar(&opts.id, "name", "", opts.localizer.MustLocalize("registry.use.flag.name"))
 
 	return cmd
 }

--- a/pkg/localize/locales/en/cmd/kafka_use.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_use.en.toml
@@ -10,10 +10,10 @@ one = "Set the current Apache Kafka instance"
 description = "Long description for command"
 one = '''
 Select an Apache Kafka instance and set it as the current instance.
+You can specify a Apache Kafka instance by --name or --id.
 
-When you set the Kafka instance to be used, it is set as the current instance for all "rhoas kafka" commands.
+When you set the Kafka instance to be used, it is set as the current instance for all rhoas kafka topics and rhoas kafka consumer-group commands.
 
-When an ID is not specified in other Kafka commands, the current Kafka instance is used.
 '''
 
 [kafka.use.cmd.example]

--- a/pkg/localize/locales/en/cmd/kafka_use.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_use.en.toml
@@ -27,6 +27,11 @@ $ rhoas kafka use --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg,
 description = 'Description for the --id flag'
 one = 'Unique ID of the Kafka instance you want to set as the current instance'
 
+[kafka.use.flag.name]
+description = 'Description for the --name flag'
+one = 'Name of the Kafka instance you want to set as the current instance'
+
+
 [kafka.use.error.saveError]
 description = 'Error message when current Kafka could not be saved in config'
 one = 'could not set "{{.Name}}" as the current Kafka instance'

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -89,7 +89,7 @@ one = '''
 Select a Service Registry instance to use with all instance-specific commands.
 You can specify a Service Registry instance by --name or --id.
 
-When you set the Service Registry instance to be used, it is set as the current instance for all rhoas service-registry artifacts commands.
+When you set the Service Registry instance to be used, it is set as the current instance for all rhoas service-registry artifact commands.
 '''
 
 [registry.cmd.use.example]

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -87,6 +87,9 @@ one = 'Use a Service Registry instance'
 [registry.cmd.use.longDescription]
 one = ''' 
 Select a Service Registry instance to use with all instance-specific commands.
+You can specify a Service Registry instance by --name or --id.
+
+When you set the Service Registry instance to be used, it is set as the current instance for all rhoas service-registry artifacts commands.
 '''
 
 [registry.cmd.use.example]

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -168,6 +168,10 @@ one = 'No Service Registry instances were found.'
 description = 'Description for the --id flag'
 one = 'Unique ID of the Service Registry instance you want to set as the current instance'
 
+[registry.use.flag.name]
+description = 'Description for the --name flag'
+one = 'Name the Service Registry instance you want to set as the current instance'
+
 [registry.use.error.saveError]
 description = 'Error message when current Service Registry could not be saved in config'
 one = 'could not set "{{.Name}}" as the current Service Registry instance'


### PR DESCRIPTION
Context and discussion #927 
## Verification

rhoas kafka use (will print help)
rhoas kafka use --name=yourkafka
rhoas kafka use --id=id