### PR TITLE
refactor: check for username and preferred_username claims

### DIFF
--- a/pkg/auth/login/mas_sso_redirect_handler.go
+++ b/pkg/auth/login/mas_sso_redirect_handler.go
@@ -79,16 +79,13 @@ func (h *masRedirectPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	accessTkn, _ := token.Parse(resp.OAuth2Token.AccessToken)
-	tknClaims, _ := token.MapClaims(accessTkn)
-	userName, ok := tknClaims["preferred_username"]
-	rawUsername := "unknown"
-	if ok {
-		rawUsername = fmt.Sprintf("%v", userName)
+	userName, ok := token.GetUsername(resp.OAuth2Token.AccessToken)
+	if !ok {
+		userName = "unknown"
 	}
 
 	pageTitle := h.Localizer.MustLocalize("login.redirectPage.title")
-	pageBody := h.Localizer.MustLocalize("login.masRedirectPage.body", localize.NewEntry("Host", h.AuthURL.Host), localize.NewEntry("Username", rawUsername))
+	pageBody := h.Localizer.MustLocalize("login.masRedirectPage.body", localize.NewEntry("Host", h.AuthURL.Host), localize.NewEntry("Username", userName))
 
 	redirectPage := fmt.Sprintf(masSSOredirectHTMLPage, pageTitle, pageTitle, pageBody)
 

--- a/pkg/auth/token/token.go
+++ b/pkg/auth/token/token.go
@@ -117,12 +117,19 @@ func GetExpiry(tokenStr string, now time.Time) (expires bool,
 	return
 }
 
+// GetUsername extracts the username claim value from the JWT
 func GetUsername(tokenStr string) (username string, ok bool) {
 	accessTkn, _ := Parse(tokenStr)
 	tknClaims, _ := MapClaims(accessTkn)
-	userName, ok := tknClaims["preferred_username"]
+	u, ok := tknClaims["preferred_username"]
 	if ok {
-		username = fmt.Sprintf("%v", userName)
+		username = fmt.Sprintf("%v", u)
+		return
+	}
+	u, ok = tknClaims["username"]
+	if ok {
+		username = fmt.Sprintf("%v", u)
+		return
 	}
 
 	return username, ok

--- a/pkg/cmd/whoami/whoami.go
+++ b/pkg/cmd/whoami/whoami.go
@@ -61,11 +61,10 @@ func runCmd(opts *Options) (err error) {
 		return err
 	}
 
-	accessTkn, _ := token.Parse(cfg.AccessToken)
-
-	tknClaims, _ := token.MapClaims(accessTkn)
-
-	userName, ok := tknClaims["preferred_username"]
+	userName, ok := token.GetUsername(cfg.AccessToken)
+	if !ok {
+		userName = "unknown"
+	}
 
 	if ok {
 		fmt.Fprintln(opts.IO.Out, userName)


### PR DESCRIPTION
The "preferred_username" claim will be changed to "username" in the near future. This change ensures that both are checked.

### Verification Steps

1. Run `rhoas whoami`. It will continue to print your username.
2. Now log in using a token. Run `rhoas whoami` and you will see the same result.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Refactor

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer