### PR TITLE
chore: add print to cluster command

### DIFF
--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -143,10 +143,10 @@ func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArgu
 	// print status
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.log.info.statusMessage"))
 
-	c.localizer.MustLocalize("cluster.kubernetes.statusInfo",
+	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.statusInfo",
 		localize.NewEntry("InstanceName", color.Info(kafkaInstance.GetName())),
 		localize.NewEntry("Namespace", color.Info(currentNamespace)),
-		localize.NewEntry("ServiceAccountSecretName", color.Info(serviceAccountSecretName)))
+		localize.NewEntry("ServiceAccountSecretName", color.Info(serviceAccountSecretName))))
 
 	if cmdOptions.ForceCreationWithoutAsk == false {
 		var shouldContinue bool


### PR DESCRIPTION
When working with bind I noticed that we do not print status anymore. 
Quick fix.

Verified already