### PR TITLE
fix: remove invalid CR from the connect command

### DIFF
--- a/pkg/cluster/kcManager.go
+++ b/pkg/cluster/kcManager.go
@@ -85,15 +85,6 @@ func getKafkaConnectionsAPIURL(namespace string) string {
 func watchForKafkaStatus(c *KubernetesCluster, crName string, namespace string) error {
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.watchForKafkaStatus.log.info.wait"))
 
-	templateEntries := []*localize.TemplateEntry{
-		localize.NewEntry("Name", crName),
-		localize.NewEntry("Namespace", namespace),
-		localize.NewEntry("Group", AKCGroup),
-		localize.NewEntry("Version", AKCVersion),
-		localize.NewEntry("Kind", AKCRMeta.Kind),
-	}
-	fmt.Fprint(c.io.Out, c.localizer.MustLocalize("cluster.kubernetes.watchForKafkaStatus.binding", templateEntries...))
-
 	w, err := c.dynamicClient.Resource(AKCResource).Namespace(namespace).Watch(context.TODO(), metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", crName).String(),
 	})

--- a/pkg/localize/locales/en/cluster_kubernetes.en.toml
+++ b/pkg/localize/locales/en/cluster_kubernetes.en.toml
@@ -58,34 +58,10 @@ Created KafkaConnection can be already injected to your application.
 
 To bind you need to have Service Binding Operator installed:
 https://github.com/redhat-developer/service-binding-operator
+
+You can bind KafkaConnection to your application by executing "rhoas cluster bind" 
+or directly in the OpenShift Console topology view.
 '''
-
-[cluster.kubernetes.watchForKafkaStatus.binding]
-one = '''
-cat <<EOF | kubectl apply -f - 
-apiVersion: binding.operators.coreos.com/v1alpha1
-kind: ServiceBinding
-metadata:
-  name: kafka-config
-  namespace: {{.Namespace}}
-spec:
-  application:
-    group: apps
-    name: name-of-your-application
-    resource: deployments
-    version: v1
-    
-  bindAsFiles: true
-  services:
-  - group: {{.Group}}
-    version: {{.Version}}
-    kind: {{.Kind}}
-    name: {{.Name}}
-EOF
-
-'''
-
-
 
 [cluster.kubernetes.serviceaccountsecret.error.createError]
 one = 'could not create Service Account secret'


### PR DESCRIPTION
We no longer need to print CR as bind command provides this feature