### PR TITLE
feat(cluster connect): create service registry connection

### DIFF
--- a/docs/commands/rhoas_cluster_connect.adoc
+++ b/docs/commands/rhoas_cluster_connect.adoc
@@ -40,12 +40,14 @@ $ rhoas cluster connect
 [discrete]
 == Options
 
-      `--ignore-context`::         Ignore currently selected services and ask to select each service separately
-      `--kubeconfig` _string_::    Location of the kubeconfig file
-  `-n`, `--namespace` _string_::   Custom Kubernetes namespace (if not set current namespace will be used)
-      `--token` _string_::         Provide an offline token to be used by the operator (to get a token, visit https://console.redhat.com/openshift/token)
+      `--ignore-context`::          Ignore currently selected services and ask to select each service separately
+      `--kubeconfig` _string_::     Location of the kubeconfig file
+  `-n`, `--namespace` _string_::    Custom Kubernetes namespace (if not set current namespace will be used)
+      `--service-name` _string_::   ID of service to connect to
+      `--service-type` _string_::   Service name to connect to
+      `--token` _string_::          Provide an offline token to be used by the operator (to get a token, visit https://console.redhat.com/openshift/token)
 
-  `-y`, `--yes`::                  Forcibly create a binding without confirmation
+  `-y`, `--yes`::                   Forcibly create a binding without confirmation
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -11,6 +11,8 @@ type ConnectArguments struct {
 	SelectedKafka           string
 	SelectedRegistry        string
 	Namespace               string
+	SelectedService         string
+	SelectedServiceID       string
 }
 
 // Cluster defines methods used to interact with a cluster

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -9,6 +9,7 @@ type ConnectArguments struct {
 	ForceCreationWithoutAsk bool
 	IgnoreContext           bool
 	SelectedKafka           string
+	SelectedRegistry        string
 	Namespace               string
 }
 

--- a/pkg/cluster/kafka/ManagedKafkaConnection.go
+++ b/pkg/cluster/kafka/ManagedKafkaConnection.go
@@ -1,4 +1,4 @@
-package cluster
+package kafka
 
 // We should use dependency once repo is public
 

--- a/pkg/cluster/kafka/kcManager.go
+++ b/pkg/cluster/kafka/kcManager.go
@@ -1,0 +1,52 @@
+package kafka
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	AKCGroup   = "rhoas.redhat.com"
+	AKCVersion = "v1alpha1"
+)
+
+var AKCRMeta = metav1.TypeMeta{
+	Kind:       "KafkaConnection",
+	APIVersion: AKCGroup + "/" + AKCVersion,
+}
+
+var AKCResource = schema.GroupVersionResource{
+	Group:    AKCGroup,
+	Version:  AKCVersion,
+	Resource: "kafkaconnections",
+}
+
+var tokenSecretName = "rh-cloud-services-accesstoken-cli"
+
+/*  #nosec */
+var serviceAccountSecretName = "rh-cloud-services-service-account"
+
+func GetKafkaConnectionsAPIURL(namespace string) string {
+	return fmt.Sprintf("/apis/rhoas.redhat.com/v1alpha1/namespaces/%v/kafkaconnections", namespace)
+}
+
+func CreateKCObject(crName string, namespace string, kafkaID string) *KafkaConnection {
+	kafkaConnectionCR := &KafkaConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+		},
+		TypeMeta: AKCRMeta,
+		Spec: KafkaConnectionSpec{
+			KafkaID:               kafkaID,
+			AccessTokenSecretName: tokenSecretName,
+			Credentials: CredentialsSpec{
+				SecretName: serviceAccountSecretName,
+			},
+		},
+	}
+
+	return kafkaConnectionCR
+}

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -9,15 +9,16 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/kafka"
 	registryPkg "github.com/redhat-developer/app-services-cli/pkg/cluster/serviceregistry"
+	kafkaUtil "github.com/redhat-developer/app-services-cli/pkg/kafka"
+	"github.com/redhat-developer/app-services-cli/pkg/kafka/kafkaerr"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 	srsmgmtv1 "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
 
-	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/kafka/kafkaerr"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
 	"k8s.io/client-go/dynamic"
@@ -122,24 +123,12 @@ func (c *KubernetesCluster) CurrentNamespace() (string, error) {
 	return namespace, err
 }
 
+// nolint:funlen
 // Connect connects a remote Kafka instance to the Kubernetes cluster
 func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArguments) error {
-	api := c.connection.API()
-	kafkaInstance, _, err := api.Kafka().GetKafkaById(ctx, cmdOptions.SelectedKafka).Execute()
-	if kas.IsErr(err, kas.ErrorNotFound) {
-		return kafkaerr.NotFoundByIDError(cmdOptions.SelectedKafka)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	registryInstance, _, err := serviceregistry.GetServiceRegistryByID(ctx, api.ServiceRegistryMgmt(), cmdOptions.SelectedRegistry)
-	if err != nil {
-		return err
-	}
 
 	var currentNamespace string
+	var err error
 	if cmdOptions.Namespace != "" {
 		currentNamespace = cmdOptions.Namespace
 	} else {
@@ -153,9 +142,9 @@ func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArgu
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.log.info.statusMessage"))
 
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.statusInfo",
-		localize.NewEntry("InstanceName", color.Info(kafkaInstance.GetName())),
+		localize.NewEntry("InstanceName", color.Info("random name")),
 		localize.NewEntry("Namespace", color.Info(currentNamespace)),
-		localize.NewEntry("RegistryInstanceName", color.Info(registryInstance.GetName())),
+		localize.NewEntry("RegistryInstanceName", color.Info("random-name")),
 		localize.NewEntry("ServiceAccountSecretName", color.Info(serviceAccountSecretName))))
 
 	if cmdOptions.ForceCreationWithoutAsk == false {
@@ -174,11 +163,6 @@ func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArgu
 		}
 	}
 
-	err = CheckIfConnectionsExist(ctx, c, currentNamespace, &kafkaInstance)
-	if err != nil {
-		return err
-	}
-
 	// Token with auth for operator to pick
 	err = c.createTokenSecretIfNeeded(ctx, currentNamespace, cmdOptions)
 	if err != nil {
@@ -190,12 +174,87 @@ func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArgu
 		return err
 	}
 
-	err = c.createKafkaConnectionCustomResource(ctx, currentNamespace, &kafkaInstance)
+	switch cmdOptions.SelectedService {
+	case "kafka":
+		err = c.checkAndCreateKafkaConnectionCustomResource(ctx, currentNamespace, cmdOptions.SelectedServiceID)
+		if err != nil {
+			return err
+		}
+	case "service-registry":
+		err = c.checkAndCreateServiceRegistryConnectionCustomResource(ctx, currentNamespace, cmdOptions.SelectedServiceID)
+		if err != nil {
+			return err
+		}
+	case "":
+		var selectedKafkaInstance string
+		var selectedRegistryInstance string
+
+		cfg, err := c.config.Load()
+		if err != nil {
+			return err
+		}
+
+		if cfg.Services.Kafka == nil || cmdOptions.IgnoreContext {
+			// nolint
+			selectedKafka, err := kafkaUtil.InteractiveSelect(c.connection, c.logger)
+			if err != nil {
+				return err
+			}
+			if selectedKafka == nil {
+				return nil
+			}
+			selectedKafkaInstance = selectedKafka.GetId()
+		} else {
+			selectedKafkaInstance = cfg.Services.Kafka.ClusterID
+		}
+
+		err = c.checkAndCreateKafkaConnectionCustomResource(ctx, currentNamespace, selectedKafkaInstance)
+		if err != nil {
+			return err
+		}
+
+		if cfg.Services.ServiceRegistry == nil || cmdOptions.IgnoreContext {
+			// nolint
+			selectedServiceRegistry, err := serviceregistry.InteractiveSelect(c.connection, c.logger)
+			if err != nil {
+				return err
+			}
+			if selectedServiceRegistry == nil {
+				return nil
+			}
+			selectedRegistryInstance = selectedServiceRegistry.GetId()
+		} else {
+			selectedRegistryInstance = cfg.Services.ServiceRegistry.InstanceID
+		}
+
+		err = c.checkAndCreateServiceRegistryConnectionCustomResource(ctx, currentNamespace, selectedRegistryInstance)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (c *KubernetesCluster) checkAndCreateKafkaConnectionCustomResource(ctx context.Context, namespace string, kafkaID string) error {
+
+	api := c.connection.API()
+
+	kafkaInstance, _, err := api.Kafka().GetKafkaById(ctx, kafkaID).Execute()
+	if kas.IsErr(err, kas.ErrorNotFound) {
+		return kafkaerr.NotFoundByIDError(kafkaID)
+	}
+
+	if err != nil {
+		return err
+	}
+	err = CheckIfKafkaConnectionExists(ctx, c, namespace, kafkaInstance.GetName())
 	if err != nil {
 		return err
 	}
 
-	err = c.createServiceRegistryCustomResource(ctx, currentNamespace, registryInstance)
+	err = c.createKafkaConnectionCustomResource(ctx, namespace, &kafkaInstance)
 	if err != nil {
 		return err
 	}
@@ -228,6 +287,28 @@ func (c *KubernetesCluster) createKafkaConnectionCustomResource(ctx context.Cont
 	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.createKafkaCR.log.info.customResourceCreated", localize.NewEntry("Name", crName)))
 
 	return watchForKafkaStatus(c, crName, namespace)
+}
+
+func (c *KubernetesCluster) checkAndCreateServiceRegistryConnectionCustomResource(ctx context.Context, namespace string, registryID string) error {
+
+	api := c.connection.API()
+
+	registryInstance, _, err := serviceregistry.GetServiceRegistryByID(ctx, api.ServiceRegistryMgmt(), registryID)
+	if err != nil {
+		return err
+	}
+
+	err = CheckIfRegistryConnectionExists(ctx, c, namespace, registryInstance.GetName())
+	if err != nil {
+		return err
+	}
+
+	err = c.createServiceRegistryCustomResource(ctx, namespace, registryInstance)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // createServiceRegistryCustomResource creates a new "ServiceRegistryConnection" CR

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -237,7 +237,7 @@ func (c *KubernetesCluster) createServiceRegistryCustomResource(ctx context.Cont
 
 	crJSON, err := json.Marshal(serviceRegistryCR)
 	if err != nil {
-		return fmt.Errorf("%v: %w", c.localizer.MustLocalize("cluster.kubernetes.createKafkaCR.error.marshalError"), err)
+		return fmt.Errorf("%v: %w", c.localizer.MustLocalize("cluster.kubernetes.createRegistryCR.error.marshalError"), err)
 	}
 
 	data := c.clientset.RESTClient().
@@ -250,10 +250,10 @@ func (c *KubernetesCluster) createServiceRegistryCustomResource(ctx context.Cont
 		return data.Error()
 	}
 
-	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.createKafkaCR.log.info.customResourceCreated", localize.NewEntry("Name", crName)))
+	c.logger.Info(c.localizer.MustLocalize("cluster.kubernetes.createRegistryCR.log.info.customResourceCreated", localize.NewEntry("Name", crName)))
 	// c.logger.Info("KafkaConnection resource some-registry-name has been created'")
 
-	return watchForKafkaStatus(c, crName, namespace)
+	return watchForServiceRegistryStatus(c, crName, namespace)
 }
 
 // IsRhoasOperatorAvailableOnCluster checks the cluster to see if a KafkaConnection CRD is installed

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cluster/kafka"
+	registryPkg "github.com/redhat-developer/app-services-cli/pkg/cluster/serviceregistry"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 	srsmgmtv1 "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
@@ -206,7 +208,7 @@ func (c *KubernetesCluster) createKafkaConnectionCustomResource(ctx context.Cont
 	crName := kafkaInstance.GetName()
 	kafkaID := kafkaInstance.GetId()
 
-	kafkaConnectionCR := createKCObject(crName, namespace, kafkaID)
+	kafkaConnectionCR := kafka.CreateKCObject(crName, namespace, kafkaID)
 
 	crJSON, err := json.Marshal(kafkaConnectionCR)
 	if err != nil {
@@ -215,7 +217,7 @@ func (c *KubernetesCluster) createKafkaConnectionCustomResource(ctx context.Cont
 
 	data := c.clientset.RESTClient().
 		Post().
-		AbsPath(getKafkaConnectionsAPIURL(namespace)).
+		AbsPath(kafka.GetKafkaConnectionsAPIURL(namespace)).
 		Body(crJSON).
 		Do(ctx)
 
@@ -233,7 +235,7 @@ func (c *KubernetesCluster) createServiceRegistryCustomResource(ctx context.Cont
 	crName := registryInstance.GetName()
 	registryId := registryInstance.GetId()
 
-	serviceRegistryCR := createSRObject(crName, namespace, registryId)
+	serviceRegistryCR := registryPkg.CreateSRObject(crName, namespace, registryId)
 
 	crJSON, err := json.Marshal(serviceRegistryCR)
 	if err != nil {
@@ -242,7 +244,7 @@ func (c *KubernetesCluster) createServiceRegistryCustomResource(ctx context.Cont
 
 	data := c.clientset.RESTClient().
 		Post().
-		AbsPath(getServiceRegistryAPIURL(namespace)).
+		AbsPath(registryPkg.GetServiceRegistryAPIURL(namespace)).
 		Body(crJSON).
 		Do(ctx)
 

--- a/pkg/cluster/serviceBinding.go
+++ b/pkg/cluster/serviceBinding.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/redhat-developer/app-services-cli/pkg/cluster/kafka"
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
@@ -91,7 +92,7 @@ func ExecuteServiceBinding(logger logging.Logger, localizer localize.Localizer, 
 	}
 
 	// Check KafkaConnection
-	_, err = clients.dynamicClient.Resource(AKCResource).Namespace(ns).Get(context.TODO(), options.ServiceName, metav1.GetOptions{})
+	_, err = clients.dynamicClient.Resource(kafka.AKCResource).Namespace(ns).Get(context.TODO(), options.ServiceName, metav1.GetOptions{})
 	if err != nil {
 		return errors.New(localizer.MustLocalize("cluster.serviceBinding.serviceMissing.message"))
 	}
@@ -110,9 +111,9 @@ func performBinding(options *ServiceBindingOptions, ns string, clients *Kubernet
 	serviceRef := v1alpha1.Service{
 		NamespacedRef: v1alpha1.NamespacedRef{
 			Ref: v1alpha1.Ref{
-				Group:    AKCResource.Group,
-				Version:  AKCResource.Version,
-				Resource: AKCResource.Resource,
+				Group:    kafka.AKCResource.Group,
+				Version:  kafka.AKCResource.Version,
+				Resource: kafka.AKCResource.Resource,
 				Name:     options.ServiceName,
 			},
 		},

--- a/pkg/cluster/serviceregistry/ServiceRegistryConnection.go
+++ b/pkg/cluster/serviceregistry/ServiceRegistryConnection.go
@@ -1,0 +1,51 @@
+package serviceregistry
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceRegsitryConnectionSpec contains credentials and connection parameters to  Kafka
+type ServiceRegsitryConnectionSpec struct {
+	AccessTokenSecretName string          `json:"accessTokenSecretName,omitempty"`
+	ServiceRegistryId     string          `json:"serviceRegistryId,omitempty"`
+	Credentials           CredentialsSpec `json:"credentials"`
+}
+
+// BootstrapServerSpec contains server host information that can be used to connecto the  Kafka
+type BootstrapServerSpec struct {
+	// Host full host to  Kafka Service including port
+	Host string `json:"host,omitempty"`
+}
+
+// CredentialsSpec specification containing various formats of credentials
+type CredentialsSpec struct {
+	// Reference to secret name that needs to be fetched
+	SecretName string `json:"serviceAccountSecretName,omitempty"`
+}
+
+// ServiceRegsitryConnectionStatus defines the observed state of ServiceRegsitryConnection
+type ServiceRegsitryConnectionStatus struct {
+	CreatedBy       string              `json:"createdBy,omitempty"`
+	Message         string              `json:"message,omitempty"`
+	Updated         string              `json:"updated,omitempty"`
+	BootstrapServer BootstrapServerSpec `json:"bootstrapServer"`
+	RegistryUrl     string              `json:"registryUrl"`
+	// Reference to secret name that needs to be fetched
+	ServiceAccountSecretName string `json:"ServiceAccountSecretName,omitempty"`
+}
+
+// ServiceRegsitryConnection schema
+type ServiceRegsitryConnection struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ServiceRegsitryConnectionSpec   `json:"spec,omitempty"`
+	Status ServiceRegsitryConnectionStatus `json:"status,omitempty"`
+}
+
+// ServiceRegsitryConnectionList contains a list of ServiceRegsitryConnection
+type ServiceRegsitryConnectionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ServiceRegsitryConnection `json:"items"`
+}

--- a/pkg/cluster/serviceregistry/srManager.go
+++ b/pkg/cluster/serviceregistry/srManager.go
@@ -1,0 +1,52 @@
+package serviceregistry
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	SRCGroup   = "rhoas.redhat.com"
+	SRCVersion = "v1alpha1"
+)
+
+var RegistryResourceMeta = metav1.TypeMeta{
+	Kind:       "ServiceRegistryConnection",
+	APIVersion: SRCGroup + "/" + SRCVersion,
+}
+
+var tokenSecretName = "rh-cloud-services-accesstoken-cli"
+
+/*  #nosec */
+var serviceAccountSecretName = "rh-cloud-services-service-account"
+
+var SRCResource = schema.GroupVersionResource{
+	Group:    SRCGroup,
+	Version:  SRCVersion,
+	Resource: "serviceregistryconnections",
+}
+
+func GetServiceRegistryAPIURL(namespace string) string {
+	return fmt.Sprintf("/apis/rhoas.redhat.com/v1alpha1/namespaces/%v/serviceregistryconnections", namespace)
+}
+
+func CreateSRObject(crName string, namespace string, registryID string) *ServiceRegsitryConnection {
+	serviceRegistryCR := &ServiceRegsitryConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: namespace,
+		},
+		TypeMeta: RegistryResourceMeta,
+		Spec: ServiceRegsitryConnectionSpec{
+			ServiceRegistryId:     registryID,
+			AccessTokenSecretName: tokenSecretName,
+			Credentials: CredentialsSpec{
+				SecretName: serviceAccountSecretName,
+			},
+		},
+	}
+
+	return serviceRegistryCR
+}

--- a/pkg/cmd/cluster/connect/connect.go
+++ b/pkg/cmd/cluster/connect/connect.go
@@ -99,7 +99,7 @@ func runConnect(opts *Options) error {
 
 	if cfg.Services.ServiceRegistry == nil || opts.ignoreContext {
 		// nolint
-		selectedServiceRegistry, err := serviceregistry.InteractiveSelect(connection, logger)
+		selectedServiceRegistry, err := serviceregistry.InteractiveSelect(connection, opts.Logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/localize/locales/en/cluster_kubernetes.en.toml
+++ b/pkg/localize/locales/en/cluster_kubernetes.en.toml
@@ -9,6 +9,7 @@ one = '''
 Connection Details:
 
 Apache Kafka instance:  {{.InstanceName}}
+Service Registry Name:  {{.RegistryInstanceName}}
 Kubernetes Namespace:   {{.Namespace}}
 Service Account Secret: {{.ServiceAccountSecretName}}
 '''

--- a/pkg/localize/locales/en/cluster_kubernetes.en.toml
+++ b/pkg/localize/locales/en/cluster_kubernetes.en.toml
@@ -122,3 +122,6 @@ one = 'Service account secret already exist.'
 
 [cluster.kubernetes.checkIfConnectionExist.existError]
 one = 'KafkaConnection already exist'
+
+[cluster.kubernetes.checkIfServiceRegistryConnectionExist.existError]
+one = 'ServiceRegistryConnection already exist'

--- a/pkg/localize/locales/en/cluster_kubernetes.en.toml
+++ b/pkg/localize/locales/en/cluster_kubernetes.en.toml
@@ -95,7 +95,7 @@ Created ServiceRegistryConnection can be already injected to your application.
 To bind you need to have Service Binding Operator installed:
 https://github.com/redhat-developer/service-binding-operator
 
-You can bind KafkaConnection to your application by executing "rhoas cluster bind" 
+You can bind ServiceRegistryConnection to your application by executing "rhoas cluster bind" 
 or directly in the OpenShift Console topology view.
 '''
 

--- a/pkg/localize/locales/en/cluster_kubernetes.en.toml
+++ b/pkg/localize/locales/en/cluster_kubernetes.en.toml
@@ -29,15 +29,29 @@ one = 'Cancelling cluster connection'
 [cluster.kubernetes.createKafkaCR.error.marshalError]
 one = 'could not marshal KafkaConnection to JSON object'
 
+[cluster.kubernetes.createRegistryCR.error.marshalError]
+one = 'could not marshal ServiceRegsitryConnection to JSON object'
+
 [cluster.kubernetes.createKafkaCR.log.info.customResourceCreated]
 one = 'KafkaConnection resource "{{.Name}}" has been created'
+
+[cluster.kubernetes.createRegistryCR.log.info.customResourceCreated]
+one = 'ServiceRegistryConnection resource "{{.Name}}" has been created'
 
 [cluster.kubernetes.watchForKafkaStatus.error.format]
 one = '''invalid result from operator. Status object is not compatible with expected result from CLI.
 '''
 
+[cluster.kubernetes.watchForRegistryStatus.error.format]
+one = '''invalid result from operator. Status object is not compatible with expected result from CLI.
+'''
+
 [cluster.kubernetes.watchForKafkaStatus.error.status]
 one = '''error when processing KafkaConnection: %v
+'''
+
+[cluster.kubernetes.watchForRegistryStatus.error.status]
+one = '''error when processing ServiceRegistryConnection: %v
 '''
 
 [cluster.kubernetes.watchForKafkaStatus.log.info.success]
@@ -49,6 +63,15 @@ oc get kafkaconnection -o=yaml -n {{.Namespace}} {{.Name}}
 
 '''
 
+[cluster.kubernetes.watchForRegistryStatus.log.info.success]
+one = '''
+ServiceRegistryConnection successfully installed on your cluster.
+To view it execute:
+
+oc get src -o=yaml -n {{.Namespace}} {{.Name}}
+
+'''
+
 [cluster.kubernetes.watchForKafkaStatus.error.timeout]
 one = '''process of watching KafkaConnection timed out'''
 
@@ -56,6 +79,18 @@ one = '''process of watching KafkaConnection timed out'''
 one = '''
 Waiting for status from KafkaConnection resource.
 Created KafkaConnection can be already injected to your application.
+
+To bind you need to have Service Binding Operator installed:
+https://github.com/redhat-developer/service-binding-operator
+
+You can bind KafkaConnection to your application by executing "rhoas cluster bind" 
+or directly in the OpenShift Console topology view.
+'''
+
+[cluster.kubernetes.watchForRegistryStatus.log.info.wait]
+one = '''
+Waiting for status from ServiceRegistryConnection resource.
+Created ServiceRegistryConnection can be already injected to your application.
 
 To bind you need to have Service Binding Operator installed:
 https://github.com/redhat-developer/service-binding-operator

--- a/pkg/localize/locales/en/cmd/cluster_common.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster_common.en.toml
@@ -14,3 +14,9 @@ one = 'Custom Kubernetes namespace (if not set current namespace will be used)'
 
 [cluster.common.flag.ignoreContext.description]
 one = 'Ignore currently selected services and ask to select each service separately'
+
+[cluster.common.flag.serviceName.description]
+one = 'Service name to connect to'
+
+[cluster.common.flag.serviceId.description]
+one = 'ID of service to connect to'


### PR DESCRIPTION
`rhoas cluster connect` should create a serviceregistry connection along with KafkaConnection. 

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run `rhoas kafka use --name <name of kafka instance>`.
2. Run `rhoas service-registry use --id <id of registry instance>`.
3. Running the cluster connect command should create connections from context.
```
./rhoas cluster connect
```
4. Running the cluster connect command with `ignore-context` flag should prompt for values.
5. ```
./rhoas cluster connect --ignore-context
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer