### PR TITLE
metadata commands

### DIFF
--- a/pkg/cmd/registry/artifact/artifacts.go
+++ b/pkg/cmd/registry/artifact/artifacts.go
@@ -68,7 +68,8 @@ rhoas service-registry artifact versions --artifact-id=my-artifact --group=my-gr
 		update.NewUpdateCommand(f),
 
 		// Misc
-		metadata.NewMetadataCommand(f),
+		metadata.NewGetMetadataCommand(f),
+		metadata.NewSetMetadataCommand(f),
 		versions.NewVersionsCommand(f),
 		download.NewDownloadCommand(f),
 	)

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -33,7 +33,7 @@ type Options struct {
 	artifactType string
 
 	version     string
-	title       string
+	name        string
 	description string
 
 	registryID   string
@@ -135,7 +135,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
 	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
 
 	cmd.Flags().StringVar(&opts.version, "version", "", "Custom version of the artifact (for example 1.0.0)")
-	cmd.Flags().StringVar(&opts.title, "title", "", "Custom title of the artifact")
+	cmd.Flags().StringVar(&opts.name, "name", "", "Custom name of the artifact")
 	cmd.Flags().StringVar(&opts.description, "description", "", "Custom description of the artifact")
 
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", "Type of artifact. Choose from:  "+util.GetAllowedArtifactTypeEnumValuesAsString())
@@ -193,8 +193,8 @@ func runCreate(opts *Options) error {
 		request = request.XRegistryVersion(opts.version)
 	}
 
-	if opts.title != "" {
-		request = request.XRegistryName(opts.title)
+	if opts.name != "" {
+		request = request.XRegistryName(opts.name)
 	}
 
 	if opts.description != "" {

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -33,7 +33,7 @@ type Options struct {
 	outputFormat string
 
 	version     string
-	title       string
+	name        string
 	description string
 
 	IO         *iostreams.IOStreams
@@ -115,7 +115,7 @@ rhoas service-registry artifact update --artifact-id=my-artifact --group my-grou
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
 
 	cmd.Flags().StringVar(&opts.version, "version", "", "Custom version of the artifact (for example 1.0.0)")
-	cmd.Flags().StringVar(&opts.title, "title", "", "Custom title of the artifact")
+	cmd.Flags().StringVar(&opts.name, "name", "", "Custom name of the artifact")
 	cmd.Flags().StringVar(&opts.description, "description", "", "Custom description of the artifact")
 
 	flagutil.EnableOutputFlagCompletion(cmd)
@@ -159,8 +159,8 @@ func runUpdate(opts *Options) error {
 	if opts.version != "" {
 		request = request.XRegistryVersion(opts.version)
 	}
-	if opts.title != "" {
-		request = request.XRegistryName(opts.title)
+	if opts.name != "" {
+		request = request.XRegistryName(opts.name)
 	}
 
 	if opts.description != "" {

--- a/pkg/cmd/registry/artifact/metadata/get.go
+++ b/pkg/cmd/registry/artifact/metadata/get.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
@@ -18,7 +19,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 )
 
-type Options struct {
+type GetOptions struct {
 	artifact     string
 	group        string
 	outputFormat string
@@ -32,9 +33,9 @@ type Options struct {
 	localizer  localize.Localizer
 }
 
-// NewMetadataCommand creates a new command for fetching metadata for registry artifacts.
-func NewMetadataCommand(f *factory.Factory) *cobra.Command {
-	opts := &Options{
+// NewGetMetadataCommand creates a new command for fetching metadata for registry artifacts.
+func NewGetMetadataCommand(f *factory.Factory) *cobra.Command {
+	opts := &GetOptions{
 		Config:     f.Config,
 		Connection: f.Connection,
 		IO:         f.IOStreams,
@@ -43,7 +44,7 @@ func NewMetadataCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "metadata",
+		Use:   "metadata-get",
 		Short: "Get artifact metadata",
 		Long: `
 Gets the metadata for an artifact in the service registry. 
@@ -90,7 +91,7 @@ rhoas service-registry artifact metadata --artifact-id=my-artifact --group mygro
 	return cmd
 }
 
-func runGet(opts *Options) error {
+func runGet(opts *GetOptions) error {
 	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
 		return err

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -58,8 +58,11 @@ Editable metadata includes fields like name and description
 ##  Update the metadata for an artifact
 rhoas service-registry artifact metadata-set --artifact-id=my-artifact --group=my-group --name=my-name --description=my-description
 
-##  Update the metadata for an artifact using your editor
-rhoas service-registry artifact metadata-set --artifact-id=my-artifact --group=my-group
+##  Update the metadata for an artifact using your default editor ($EDITOR)
+rhoas service-registry artifact metadata-set --artifact-id=my-artifact
+
+##  Update the metadata for an artifact using visual studio code
+EDITOR="code -w" rhoas service-registry artifact metadata-set --artifact-id=my-artifact
 		`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -143,7 +146,7 @@ func runSet(opts *SetOptions) error {
 			editableMedata.Description = &opts.description
 		}
 	} else {
-		opts.Logger.Info("Running edito to let you edit metadata. Please close editor to continue...")
+		opts.Logger.Info("Running editor with editable metadata. Please save contents and close editor to continue...")
 		editableMedata, err = runEditor(editableMedata)
 		if err != nil {
 			return err

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -1,0 +1,173 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/editor"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry/registryinstanceerror"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+)
+
+type SetOptions struct {
+	artifact     string
+	group        string
+	outputFormat string
+
+	registryID string
+
+	name        string
+	description string
+
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Logger     logging.Logger
+	Connection factory.ConnectionFunc
+	localizer  localize.Localizer
+}
+
+// NewSetMetadataCommand creates a new command for updating metadata for registry artifacts.
+func NewSetMetadataCommand(f *factory.Factory) *cobra.Command {
+	opts := &SetOptions{
+		Config:     f.Config,
+		Connection: f.Connection,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Logger:     f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "metadata-set",
+		Short: "Update artifact metadata",
+		Long: `
+Updates the metadata for an artifact in the service registry. 
+Editable metadata includes fields like name and description
+`,
+		Example: `
+##  Update the metadata for an artifact
+rhoas service-registry artifact metadata-set
+		`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.artifact == "" {
+				return errors.New("artifact id is required. Please specify artifact by using --artifact-id flag")
+			}
+
+			if opts.registryID != "" {
+				return runSet(opts)
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasServiceRegistry() {
+				return errors.New("no service registry selected. Please specify registry by using --instance-id flag")
+			}
+
+			opts.registryID = cfg.Services.ServiceRegistry.InstanceID
+			return runSet(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.artifact, "artifact-id", "a", "", "Id of the artifact")
+	cmd.Flags().StringVarP(&opts.group, "group", "g", util.DefaultArtifactGroup, "Artifact group")
+	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", "Id of the registry to be used. By default uses currently selected registry")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format (json, yaml, yml)")
+
+	cmd.Flags().StringVar(&opts.name, "name", "", "Custom name of the artifact")
+	cmd.Flags().StringVar(&opts.description, "description", "", "Custom description of the artifact")
+
+	flagutil.EnableOutputFlagCompletion(cmd)
+
+	return cmd
+}
+
+func runSet(opts *SetOptions) error {
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.group == util.DefaultArtifactGroup {
+		opts.Logger.Info("Group was not specified. Using 'default' artifacts group.")
+		opts.group = util.DefaultArtifactGroup
+	}
+
+	opts.Logger.Info("Fetching current artifact metadata")
+
+	ctx := context.Background()
+	request := dataAPI.MetadataApi.GetArtifactMetaData(ctx, opts.group, opts.artifact)
+	currentMetadata, _, err := request.Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	editableMedata := &registryinstanceclient.EditableMetaData{
+		Name:        currentMetadata.Name,
+		Description: currentMetadata.Description,
+		Labels:      currentMetadata.Labels,
+		Properties:  currentMetadata.Properties,
+	}
+
+	if opts.name != "" || opts.description != "" {
+		if opts.name != "" {
+			editableMedata.Name = &opts.name
+		}
+
+		if opts.description != "" {
+			editableMedata.Description = &opts.description
+		}
+	} else {
+		// TODO check interactive mode
+		opts.Logger.Info("Running interactive mode to let you edit metadata")
+		editableMedata, err = runEditor(editableMedata)
+		if err != nil {
+			return err
+		}
+	}
+
+	opts.Logger.Info("Updating artifact metadata")
+
+	editRequest := dataAPI.MetadataApi.UpdateArtifactMetaData(ctx, opts.group, opts.artifact)
+	_, err = editRequest.EditableMetaData(*editableMedata).Execute()
+	if err != nil {
+		return registryinstanceerror.TransformError(err)
+	}
+
+	opts.Logger.Info("Successfully updated artifact metadata")
+	return nil
+}
+
+func runEditor(currentMetadata *registryinstanceclient.EditableMetaData) (*registryinstanceclient.EditableMetaData, error) {
+	metadataJson, err := json.Marshal(currentMetadata)
+	editor := editor.New(metadataJson, "metadata.json")
+	output, err := editor.Run()
+	if err != nil {
+		return nil, err
+	}
+	var resultData registryinstanceclient.EditableMetaData
+	err = json.Unmarshal(output, &resultData)
+
+	if err != nil {
+		return nil, err
+	}
+	return &resultData, nil
+}

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -56,7 +56,10 @@ Editable metadata includes fields like name and description
 `,
 		Example: `
 ##  Update the metadata for an artifact
-rhoas service-registry artifact metadata-set
+rhoas service-registry artifact metadata-set --artifact-id=my-artifact --group=my-group --name=my-name --description=my-description
+
+##  Update the metadata for an artifact using your editor
+rhoas service-registry artifact metadata-set --artifact-id=my-artifact --group=my-group
 		`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -38,6 +38,7 @@ func (e *Editor) Run() ([]byte, error) {
 	defer os.Remove(path)
 
 	args := []string{shell, shellCommandFlag, fmt.Sprintf("%s %s", editor, path)}
+	// #nosec 204
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -1,0 +1,56 @@
+package editor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type Editor struct {
+	content  []byte
+	filename string
+}
+
+func New(content []byte, filename string) *Editor {
+	return &Editor{
+		content:  content,
+		filename: filename,
+	}
+}
+
+func (e *Editor) Run() ([]byte, error) {
+	shell := defaultShell
+	if os.Getenv("SHELL") != "" {
+		shell = os.Getenv("SHELL")
+	}
+	editor := defaultEditor
+	if os.Getenv("EDITOR") != "" {
+		editor = os.Getenv("EDITOR")
+	}
+
+	path := filepath.Join(os.TempDir(), e.filename)
+	err := ioutil.WriteFile(path, e.content, 0600)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(path)
+
+	args := []string{shell, shellCommandFlag, fmt.Sprintf("%s %s", editor, path)}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err = cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return content, nil
+}

--- a/pkg/editor/linux.go
+++ b/pkg/editor/linux.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package editor
+
+const (
+	defaultShell     = "sh"
+	shellCommandFlag = "-c"
+	defaultEditor    = "vi"
+)

--- a/pkg/editor/windows.go
+++ b/pkg/editor/windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package editor
+
+const (
+	defaultShell     = "cmd"
+	shellCommandFlag = "/C"
+	defaultEditor    = "notepad"
+)


### PR DESCRIPTION
Added new command to edit metadata.
Bonus point - added small utility to open editor in interactive mode (same as in kubernetes)

Interactive mode - opens your system editor and lets you edit values
```
rhoas service-registry artifact metadata-set --artifact-id=test 
```

Explicit mode:

```
rhoas service-registry artifact metadata-set --artifact-id=test --name=test --description=test
```


Verify if changes were applied

```
 rhoas service-registry artifact metadata-get --artifact-id=test
 ```
