### PR TITLE
fix(topic): condition should check if topic name is empty

### DIFF
--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -69,7 +69,7 @@ func NewCreateTopicCommand(f *factory.Factory) *cobra.Command {
 		Example: opts.localizer.MustLocalize("kafka.topic.create.cmd.example"),
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if !opts.IO.CanPrompt() && opts.topicName != "" {
+			if !opts.IO.CanPrompt() && opts.topicName == "" {
 				return errors.New(opts.localizer.MustLocalize("argument.error.requiredWhenNonInteractive", localize.NewEntry("Argument", "name")))
 			} else if opts.topicName == "" {
 				opts.interactive = true


### PR DESCRIPTION
The `topic create` command should be checking if the topic name is "" when in a non-TTY session.

### Verification Steps

Create a topic in a detached terminal session:

```shell
true | (setsid ./rhoas kafka topic create --name topic2) 2>&1
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer