### PR TITLE
fix: add name to confirmation dialog on delete

### DIFF
--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -121,7 +121,7 @@ func runDelete(opts *options) error {
 
 	if !opts.force {
 		promptConfirmName := &survey.Input{
-			Message: opts.localizer.MustLocalize("kafka.delete.input.confirmName.message"),
+			Message: opts.localizer.MustLocalize("kafka.delete.input.confirmName.message", localize.NewEntry("Name", kafkaName)),
 		}
 
 		var confirmedKafkaName string

--- a/pkg/localize/locales/en/cmd/kafka_delete.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_delete.en.toml
@@ -42,7 +42,7 @@ one = 'Skip confirmation to forcibly delete this Kafka instance'
 
 [kafka.delete.input.confirmName.message]
 description = 'Input title for Kafka name confirmation'
-one = 'Confirm the name of the instance you want to delete:'
+one = 'Confirm the name of the instance you want to delete ({{.Name}})'
 
 [kafka.delete.log.info.incorrectNameConfirmation]
 description = 'Info message when user incorrectly confirms the name'

--- a/pkg/localize/locales/en/cmd/kafka_delete.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_delete.en.toml
@@ -42,7 +42,7 @@ one = 'Skip confirmation to forcibly delete this Kafka instance'
 
 [kafka.delete.input.confirmName.message]
 description = 'Input title for Kafka name confirmation'
-one = 'Confirm the name of the instance you want to delete ({{.Name}})'
+one = 'Confirm the name of the instance you want to delete ({{.Name}}):'
 
 [kafka.delete.log.info.incorrectNameConfirmation]
 description = 'Info message when user incorrectly confirms the name'


### PR DESCRIPTION
Before
```
 rhoas kafka delete
? Confirm the name of the instance you want to delete: wtrocki
```


After
```
 rhoas kafka delete
? Confirm the name of the instance you want to delete (wtrocki) wtrocki
```