### PR TITLE
fix: invalid i18n strings

### DIFF
--- a/pkg/cmd/registry/delete/delete.go
+++ b/pkg/cmd/registry/delete/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -77,8 +78,8 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("registry.cmd.delete.flag.name.description"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.common.flag.id"))
-	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, opts.localizer.MustLocalize("registry.common.flag.yes"))
+	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.delete.flag.id"))
+	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, opts.localizer.MustLocalize("registry.delete.flag.yes"))
 
 	return cmd
 }

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -78,7 +78,7 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("registry.cmd.describe.flag.name.description"))
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.common.flag.id"))
+	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("registry.describe.flag.id"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -135,11 +135,15 @@ one = 'could not set the current Service Registry instance as default: {{.ErrorM
 description = 'Error message when no Service Registry is set'
 one = 'no Service Registry instance is currently set, use the "--id" flag or set the current instance with the "rhoas service-registry use" command'
  
-[registry.common.flag.id]
+[registry.delete.flag.id]
 description = 'Description for the --id flag'
 one = 'Unique ID of the Service Registry instance you want to delete (if not provided, the current Service Registry instance will be deleted)'
 
-[registry.common.flag.yes]
+[registry.describe.flag.id]
+description = 'Description for the --id flag'
+one = 'Unique ID of the Service Registry instance (if not provided, the current Service Registry instance will be used)'
+
+[registry.delete.flag.yes]
 description = 'Description for the --yes flag'
 one = 'Skip confirmation to forcibly delete this Service Registry instance'
 


### PR DESCRIPTION
Fixed invalid keys assigned as common key.


Verification:

```
rhoas service-registry delete -h 
rhoas service-registry describe -h 
```