### PR TITLE
fix(topic): only return error on http.StatusOK

### DIFF
--- a/pkg/kafka/topic/validators.go
+++ b/pkg/kafka/topic/validators.go
@@ -142,7 +142,7 @@ func (v *Validator) ValidateMessageRetentionSize(val interface{}) error {
 
 // ValidateNameIsAvailable checks if a topic with the given name already exists
 func (v *Validator) ValidateNameIsAvailable(val interface{}) error {
-	name, _ := val.(string)
+	name := fmt.Sprintf("%v", val)
 
 	conn, err := v.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
@@ -154,15 +154,12 @@ func (v *Validator) ValidateNameIsAvailable(val interface{}) error {
 		return err
 	}
 
-	_, httpRes, err := api.TopicsApi.GetTopic(context.Background(), name).Execute()
-	defer httpRes.Body.Close()
-	if err != nil {
-		return err
-	}
+	_, httpRes, _ := api.TopicsApi.GetTopic(context.Background(), name).Execute()
 
 	if httpRes != nil && httpRes.StatusCode == http.StatusOK {
 		return errors.New(v.Localizer.MustLocalize("kafka.topic.create.error.conflictError", localize.NewEntry("TopicName", name), localize.NewEntry("InstanceName", kafkaInstance.GetName())))
 	}
+	defer httpRes.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
The topic name validator should only be returning an error
when this topic name already exists.

Closes #1003 

### Verification Steps

1. Run `rhoas kafka create`
2. Enter a name in the interactive prompt.
3. It should proceed past this stage.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer