### PR TITLE
fix: fixed NPR when validating Kafka name

### DIFF
--- a/pkg/kafka/kafka_util.go
+++ b/pkg/kafka/kafka_util.go
@@ -106,7 +106,9 @@ func (v *Validator) ValidateNameIsAvailable(val interface{}) error {
 	api := connection.API()
 
 	_, httpRes, err := GetKafkaByName(context.Background(), api.Kafka(), name)
-	defer httpRes.Body.Close()
+	if httpRes != nil {
+		defer httpRes.Body.Close()
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I've been testing rhoas CLI and found the following NPR. Here is the fix.

❯ ./rhoas kafka create
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x248874d]

goroutine 1 [running]:
github.com/redhat-developer/app-services-cli/pkg/kafka.(*Validator).ValidateNameIsAvailable(0xc0008d0168, 0x2616a40, 0xc0003bb560, 0x0, 0x0)
	/Users/allyse/Dev/app-services-cli/pkg/kafka/kafka_util.go:109 +0x12d
github.com/AlecAivazis/survey/v2.Ask(0xc00072b3d0, 0x1, 0x1, 0x25bd7c0, 0xc0006a0100, 0xc0001e9408, 0x2, 0x2, 0x0, 0x0)
	/Users/allyse/go/pkg/mod/github.com/!alec!aivazis/survey/v2@v2.3.1/survey.go:329 +0x402
github.com/AlecAivazis/survey/v2.AskOne(...)
	/Users/allyse/go/pkg/mod/github.com/!alec!aivazis/survey/v2@v2.3.1/survey.go:251
github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create.promptKafkaPayload(0xc00023bb00, 0x0, 0x0, 0x0)
	/Users/allyse/Dev/app-services-cli/pkg/cmd/kafka/create/create.go:291 +0x3f1
github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create.runCreate(0xc00023bb00, 0x0, 0x0)
	/Users/allyse/Dev/app-services-cli/pkg/cmd/kafka/create/create.go:156 +0x189e
github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create.NewCreateCommand.func1(0xc000630500, 0x385c928, 0x0, 0x0, 0x0, 0x0)
	/Users/allyse/Dev/app-services-cli/pkg/cmd/kafka/create/create.go:109 +0x167
github.com/spf13/cobra.(*Command).execute(0xc000630500, 0x385c928, 0x0, 0x0, 0xc000630500, 0x385c928)
	/Users/allyse/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc00040f180, 0x2b7c628, 0x3, 0xc00040f180)
	/Users/allyse/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/allyse/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/allyse/Dev/app-services-cli/cmd/rhoas/main.go:49 +0x2aa