### PR TITLE
style: error strings should not be capitalized

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -112,5 +112,5 @@ func initConfig(f *factory.Factory) error {
 }
 
 func wrapErrorf(err error, localizer localize.Localizer) error {
-	return fmt.Errorf("error: %w. %v", err, localizer.MustLocalize("common.log.error.verboseModeHint"))
+	return fmt.Errorf("Error: %w. %v", err, localizer.MustLocalize("common.log.error.verboseModeHint"))
 }

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -112,5 +112,5 @@ func initConfig(f *factory.Factory) error {
 }
 
 func wrapErrorf(err error, localizer localize.Localizer) error {
-	return fmt.Errorf("Error: %w. %v", err, localizer.MustLocalize("common.log.error.verboseModeHint"))
+	return fmt.Errorf("error: %w. %v", err, localizer.MustLocalize("common.log.error.verboseModeHint"))
 }

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -67,7 +67,7 @@ EDITOR="code -w" rhoas service-registry artifact metadata-set --artifact-id=my-a
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.name == "" && opts.description == "" && !opts.IO.CanPrompt() {
-				return errors.New("Editor mode cannot be started in non-interactive mode. Please use --name and --description flags")
+				return errors.New("editor mode cannot be started in non-interactive mode. Please use --name and --description flags")
 			}
 
 			if opts.artifact == "" {

--- a/pkg/connection/builder.go
+++ b/pkg/connection/builder.go
@@ -162,7 +162,7 @@ func (b *Builder) BuildContext(ctx context.Context) (connection *KeycloakConnect
 	}
 
 	if b.config == nil {
-		return nil, fmt.Errorf("Missing IConfig")
+		return nil, fmt.Errorf("missing IConfig")
 	}
 
 	if b.logger == nil {

--- a/pkg/connection/keycloak_connection.go
+++ b/pkg/connection/keycloak_connection.go
@@ -240,16 +240,16 @@ func (c *KeycloakConnection) API() *api.API {
 		// nolint
 		switch status {
 		case "provisioning", "accepted":
-			err = fmt.Errorf(`Service Registry instance "%v" is not ready yet`, instance.GetName())
+			err = fmt.Errorf(`service registry instance "%v" is not ready yet`, instance.GetName())
 			return nil, nil, err
 		case "failed":
-			err = fmt.Errorf(`Service Registry instance "%v" has failed`, instance.GetName())
+			err = fmt.Errorf(`service registry instance "%v" has failed`, instance.GetName())
 			return nil, nil, err
 		case "deprovision":
-			err = fmt.Errorf(`Service Registry instance "%v" is being deprovisioned`, instance.GetName())
+			err = fmt.Errorf(`service registry instance "%v" is being deprovisioned`, instance.GetName())
 			return nil, nil, err
 		case "deleting":
-			err = fmt.Errorf(`Service Registry instance "%v" is being deleted`, instance.GetName())
+			err = fmt.Errorf(`service registry instance "%v" is being deleted`, instance.GetName())
 			return nil, nil, err
 		}
 

--- a/pkg/serviceregistry/api.go
+++ b/pkg/serviceregistry/api.go
@@ -26,7 +26,7 @@ func GetServiceRegistryByName(ctx context.Context, api srsmgmtv1.RegistriesApi, 
 	}
 
 	if registryList.GetTotal() == 0 {
-		return nil, nil, fmt.Errorf(`Instance "%v" not found`, name)
+		return nil, nil, fmt.Errorf(`instance "%v" not found`, name)
 	}
 
 	items := registryList.GetItems()


### PR DESCRIPTION
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation

https://github.com/golang/go/wiki/CodeReviewComments#error-strings