### PR TITLE
chore: variable 'editor' collides with imported package name

### DIFF
--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -177,8 +177,8 @@ func runEditor(currentMetadata *registryinstanceclient.EditableMetaData) (*regis
 	if err != nil {
 		return nil, err
 	}
-	edit := editor.New(metadataJson, "metadata.json")
-	output, err := edit.Run()
+	systemEditor := editor.New(metadataJson, "metadata.json")
+	output, err := systemEditor.Run()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -177,8 +177,8 @@ func runEditor(currentMetadata *registryinstanceclient.EditableMetaData) (*regis
 	if err != nil {
 		return nil, err
 	}
-	editor := editor.New(metadataJson, "metadata.json")
-	output, err := editor.Run()
+	edit := editor.New(metadataJson, "metadata.json")
+	output, err := edit.Run()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Variable 'editor' collides with imported package name