### PR TITLE
fix: remove double-login messages

### DIFF
--- a/pkg/auth/login/login.go
+++ b/pkg/auth/login/login.go
@@ -47,13 +47,13 @@ func (a *AuthorizationCodeGrant) Execute(ctx context.Context, ssoCfg *SSOConfig,
 
 	masSSOHost := masSSOCfg.AuthURL.Host
 
-	a.Logger.Info(a.Localizer.MustLocalize("login.log.info.loggingInMAS", localize.NewEntry("Host", masSSOHost)))
+	a.Logger.Debug(a.Localizer.MustLocalize("login.log.info.loggingInMAS", localize.NewEntry("Host", masSSOHost)))
 	// log in to MAS-SSO
 	if err := a.loginMAS(ctx, masSSOCfg); err != nil {
 		return err
 	}
 	a.Logger.Info(a.Localizer.MustLocalize("login.log.info.loggedIn"))
-	a.Logger.Info(a.Localizer.MustLocalize("login.log.info.loggedInMAS", localize.NewEntry("Host", masSSOHost)))
+	a.Logger.Debug(a.Localizer.MustLocalize("login.log.info.loggedInMAS", localize.NewEntry("Host", masSSOHost)))
 
 	return nil
 }
@@ -96,7 +96,7 @@ func (a *AuthorizationCodeGrant) loginSSO(ctx context.Context, cfg *SSOConfig) e
 	pkceCodeChallenge := pkce.CreateChallenge(pkceCodeVerifier)
 	authCodeURL := oauthConfig.AuthCodeURL(state, *pkce.GetAuthCodeURLOptions(pkceCodeChallenge)...)
 	a.Logger.Debug("Opening Authorization URL:", authCodeURL)
-	a.Logger.Info()
+	a.Logger.Debug()
 
 	// create a localhost server to handle redirects and exchange tokens securely
 	sm := http.NewServeMux()
@@ -183,7 +183,7 @@ func (a *AuthorizationCodeGrant) loginMAS(ctx context.Context, cfg *SSOConfig) e
 
 	authCodeURL := oauthConfig.AuthCodeURL(state, *pkce.GetAuthCodeURLOptions(pkceCodeChallenge)...)
 	a.Logger.Debug("Opening Authorization URL:", authCodeURL)
-	a.Logger.Info()
+	a.Logger.Debug()
 
 	sm := http.NewServeMux()
 	server := http.Server{

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -168,7 +168,7 @@ func runLogin(opts *Options) (err error) {
 
 		if err = loginExec.Execute(ctx, ssoCfg, masSsoCfg); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				return errors.New(opts.localizer.MustLocalize("login.error.context.deadline.exceeded"))
+				return opts.localizer.MustLocalizeError("login.error.context.deadline.exceeded")
 			}
 
 			return err


### PR DESCRIPTION
### Verification Steps

Log in, and you will not see the messages related to MAS-SSO unless you pass the `-v` flag.

```shell
$ rhoas login
Logging in...
Logged in successfully
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer