### PR TITLE
chore(github): add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@redhat-developer/app-services-cli-maintainers


### PR DESCRIPTION
Added a CODEOWNERS file to assign reviewers automatically. 

We can customize this if needed, but I don't think we should assign individuals to specific areas.