### PR TITLE
fix: remove space after prefix from root error

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"os"
+	"strings"
+
+	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
 	"github.com/redhat-developer/app-services-cli/pkg/doc"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -54,7 +56,7 @@ func main() {
 		}
 		return
 	}
-	cmdFactory.Logger.Error(wrapErrorf(err, localizer))
+	cmdFactory.Logger.Error(rootError(err, localizer))
 	build.CheckForUpdate(context.Background(), cmdFactory.Logger, localizer)
 	os.Exit(1)
 }
@@ -112,6 +114,18 @@ func initConfig(f *factory.Factory) error {
 	return nil
 }
 
-func wrapErrorf(err error, localizer localize.Localizer) error {
-	return fmt.Errorf("%v %w. %v", icon.ErrorPrefix(), err, localizer.MustLocalize("common.log.error.verboseModeHint"))
+// rootError creates the root error which is printed to the console
+// it wraps the error which has been returned from subcommands with a prefix
+func rootError(err error, localizer localize.Localizer) error {
+	prefix := icon.ErrorPrefix()
+	errMessage := err.Error()
+	if prefix == icon.CrossMark {
+		errMessage = firstCharToUpper(errMessage)
+	}
+	return fmt.Errorf("%v %v. %v", icon.ErrorPrefix(), errMessage, localizer.MustLocalize("common.log.error.verboseModeHint"))
+}
+
+// Ensure that the first character in the string is capitalized
+func firstCharToUpper(message string) string {
+	return strings.ToUpper(message[:1]) + message[1:]
 }

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -113,5 +113,5 @@ func initConfig(f *factory.Factory) error {
 }
 
 func wrapErrorf(err error, localizer localize.Localizer) error {
-	return fmt.Errorf("%v  %w. %v", icon.Error(), err, localizer.MustLocalize("common.log.error.verboseModeHint"))
+	return fmt.Errorf("%v %w. %v", icon.ErrorPrefix(), err, localizer.MustLocalize("common.log.error.verboseModeHint"))
 }

--- a/pkg/auth/login/login.go
+++ b/pkg/auth/login/login.go
@@ -53,7 +53,7 @@ func (a *AuthorizationCodeGrant) Execute(ctx context.Context, ssoCfg *SSOConfig,
 	if err := a.loginMAS(ctx, masSSOCfg); err != nil {
 		return err
 	}
-	a.Logger.Info(icon.Success(), a.Localizer.MustLocalize("login.log.info.loggedIn"))
+	a.Logger.Info(icon.SuccessPrefix(), a.Localizer.MustLocalize("login.log.info.loggedIn"))
 	a.Logger.Debug(a.Localizer.MustLocalize("login.log.info.loggedInMAS", localize.NewEntry("Host", masSSOHost)))
 
 	return nil

--- a/pkg/cluster/kcManager.go
+++ b/pkg/cluster/kcManager.go
@@ -119,7 +119,7 @@ func watchForKafkaStatus(c *KubernetesCluster, crName string, namespace string) 
 								return fmt.Errorf(c.localizer.MustLocalize("cluster.kubernetes.watchForKafkaStatus.error.status"), typedCondition["message"])
 							}
 							if typedCondition["status"].(string) == "True" {
-								c.logger.Info(icon.Success(), c.localizer.MustLocalize("cluster.kubernetes.watchForKafkaStatus.log.info.success", localize.NewEntry("Name", crName), localize.NewEntry("Namespace", namespace)))
+								c.logger.Info(icon.SuccessPrefix(), c.localizer.MustLocalize("cluster.kubernetes.watchForKafkaStatus.log.info.success", localize.NewEntry("Name", crName), localize.NewEntry("Namespace", namespace)))
 
 								w.Stop()
 								return nil

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -264,7 +264,7 @@ func (c *KubernetesCluster) createTokenSecretIfNeeded(ctx context.Context, names
 		return fmt.Errorf("%v: %w", c.localizer.MustLocalize("cluster.kubernetes.createTokenSecret.log.info.createFailed", tokenSecretNameTmplEntry), err)
 	}
 
-	c.logger.Info(icon.Success(), c.localizer.MustLocalize("cluster.kubernetes.createTokenSecret.log.info.createSuccess", tokenSecretNameTmplEntry))
+	c.logger.Info(icon.SuccessPrefix(), c.localizer.MustLocalize("cluster.kubernetes.createTokenSecret.log.info.createSuccess", tokenSecretNameTmplEntry))
 
 	return nil
 }
@@ -302,7 +302,7 @@ func (c *KubernetesCluster) createServiceAccountSecretIfNeeded(ctx context.Conte
 		return fmt.Errorf("%v: %w", c.localizer.MustLocalize("cluster.kubernetes.serviceaccountsecret.error.createError"), err)
 	}
 
-	c.logger.Info(icon.Success(), c.localizer.MustLocalize("cluster.kubernetes.createSASecret.log.info.createSuccess", localize.NewEntry("Name", createdSecret.Name)))
+	c.logger.Info(icon.SuccessPrefix(), c.localizer.MustLocalize("cluster.kubernetes.createSASecret.log.info.createSuccess", localize.NewEntry("Name", createdSecret.Name)))
 
 	return nil
 }

--- a/pkg/cluster/serviceBinding.go
+++ b/pkg/cluster/serviceBinding.go
@@ -103,7 +103,7 @@ func ExecuteServiceBinding(logger logging.Logger, localizer localize.Localizer, 
 		return err
 	}
 
-	logger.Info(icon.Success(), fmt.Sprintf(localizer.MustLocalize("cluster.serviceBinding.bindingSuccess"), options.ServiceName, options.AppName))
+	logger.Info(icon.SuccessPrefix(), fmt.Sprintf(localizer.MustLocalize("cluster.serviceBinding.bindingSuccess"), options.ServiceName, options.AppName))
 	return nil
 }
 

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -257,7 +257,7 @@ func runCmd(opts *Options) error {
 
 	defer httpRes.Body.Close()
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize(
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize(
 		"kafka.consumerGroup.resetOffset.log.info.successful",
 		localize.NewEntry("ConsumerGroupID", opts.id),
 		localize.NewEntry("InstanceName", kafkaInstance.GetName())),

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -242,7 +242,7 @@ func runCreate(opts *Options) error {
 		}
 		s.Stop()
 		opts.Logger.Info("\n")
-		opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("kafka.create.info.successSync", nameTemplateEntry))
+		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("kafka.create.info.successSync", nameTemplateEntry))
 	}
 
 	switch opts.outputFormat {
@@ -256,7 +256,7 @@ func runCreate(opts *Options) error {
 
 	if !opts.wait {
 		opts.Logger.Info()
-		opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("kafka.create.info.successAsync", nameTemplateEntry))
+		opts.Logger.Info(opts.localizer.MustLocalize("kafka.create.info.successAsync", nameTemplateEntry))
 	}
 
 	return nil

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
@@ -147,7 +146,7 @@ func runDelete(opts *options) error {
 		return err
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("kafka.delete.log.info.deleteSuccess", localize.NewEntry("Name", kafkaName)))
+	opts.Logger.Info(opts.localizer.MustLocalize("kafka.delete.log.info.deleting", localize.NewEntry("Name", kafkaName)))
 
 	currentKafka := cfg.Services.Kafka
 	// this is not the current cluster, our work here is done

--- a/pkg/cmd/kafka/use/use.go
+++ b/pkg/cmd/kafka/use/use.go
@@ -125,7 +125,7 @@ func runUse(opts *Options) error {
 		return fmt.Errorf("%v: %w", saveErrMsg, err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("kafka.use.log.info.useSuccess", nameTmplEntry))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("kafka.use.log.info.useSuccess", nameTmplEntry))
 
 	return nil
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -202,9 +202,9 @@ func runLogin(opts *Options) (err error) {
 	opts.Logger.Info("")
 
 	if !ok {
-		opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("login.log.info.loginSuccessNoUsername"))
+		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccessNoUsername"))
 	} else {
-		opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("login.log.info.loginSuccess", localize.NewEntry("Username", username)))
+		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccess", localize.NewEntry("Username", username)))
 	}
 
 	// debug mode checks this for a version update also.

--- a/pkg/cmd/logout/logout.go
+++ b/pkg/cmd/logout/logout.go
@@ -57,7 +57,7 @@ func runLogout(opts *Options) error {
 		return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("logout.error.unableToLogout"), err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("logout.log.info.logoutSuccess"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("logout.log.info.logoutSuccess"))
 
 	return nil
 }

--- a/pkg/cmd/registry/artifact/crud/get/get.go
+++ b/pkg/cmd/registry/artifact/crud/get/get.go
@@ -130,6 +130,6 @@ func runGet(opts *Options) error {
 		fmt.Fprintf(os.Stdout, "%v\n", string(fileContent))
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("artifact.common.message.fetched.successfully"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("artifact.common.message.fetched.successfully"))
 	return nil
 }

--- a/pkg/cmd/registry/artifact/download/download.go
+++ b/pkg/cmd/registry/artifact/download/download.go
@@ -141,6 +141,6 @@ func runGet(opts *Options) error {
 		fmt.Fprintf(os.Stdout, "%v\n", string(fileContent))
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("artifact.common.message.fetched.successfully"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("artifact.common.message.fetched.successfully"))
 	return nil
 }

--- a/pkg/cmd/registry/artifact/metadata/get.go
+++ b/pkg/cmd/registry/artifact/metadata/get.go
@@ -108,7 +108,7 @@ func runGet(opts *GetOptions) error {
 		return registryinstanceerror.TransformError(err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("artifact.common.message.artifact.metadata.fetched"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("artifact.common.message.artifact.metadata.fetched"))
 
 	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
 

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -150,7 +150,7 @@ func runSet(opts *SetOptions) error {
 		return registryinstanceerror.TransformError(err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("artifact.common.message.artifact.metadata.updated"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("artifact.common.message.artifact.metadata.updated"))
 	return nil
 }
 

--- a/pkg/cmd/registry/artifact/versions/versions.go
+++ b/pkg/cmd/registry/artifact/versions/versions.go
@@ -108,7 +108,7 @@ func runGet(opts *Options) error {
 		return registryinstanceerror.TransformError(err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("artifact.common.message.artifact.versions.fetched"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("artifact.common.message.artifact.versions.fetched"))
 
 	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
 

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -137,7 +137,7 @@ func runCreate(opts *Options) error {
 		return err
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
 
 	dump.PrintDataInFormat(opts.outputFormat, response, opts.IO.Out)
 

--- a/pkg/cmd/registry/delete/delete.go
+++ b/pkg/cmd/registry/delete/delete.go
@@ -142,7 +142,7 @@ func runDelete(opts *options) error {
 		return err
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("registry.delete.log.info.deleteSuccess", localize.NewEntry("Name", registryName)))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("registry.delete.log.info.deleteSuccess", localize.NewEntry("Name", registryName)))
 
 	currentContextRegistry := cfg.Services.ServiceRegistry
 	// this is not the current cluster, our work here is done

--- a/pkg/cmd/registry/use/use.go
+++ b/pkg/cmd/registry/use/use.go
@@ -118,7 +118,7 @@ func runUse(opts *Options) error {
 		return fmt.Errorf("%v: %w", saveErrMsg, err)
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("registry.use.log.info.useSuccess", nameTmplEntry))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("registry.use.log.info.useSuccess", nameTmplEntry))
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/create/create.go
+++ b/pkg/cmd/serviceaccount/create/create.go
@@ -138,7 +138,7 @@ func runCreate(opts *Options) error {
 		return err
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("serviceAccount.create.log.info.createdSuccessfully", localize.NewEntry("ID", serviceacct.GetId()), localize.NewEntry("Name", serviceacct.GetName())))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("serviceAccount.create.log.info.createdSuccessfully", localize.NewEntry("ID", serviceacct.GetId()), localize.NewEntry("Name", serviceacct.GetName())))
 
 	creds := &credentials.Credentials{
 		ClientID:     serviceacct.GetClientId(),

--- a/pkg/cmd/serviceaccount/delete/delete.go
+++ b/pkg/cmd/serviceaccount/delete/delete.go
@@ -136,7 +136,7 @@ func deleteServiceAccount(opts *Options) error {
 		}
 	}
 
-	opts.Logger.Info(icon.Success(), opts.localizer.MustLocalize("serviceAccount.delete.log.info.deleteSuccess"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("serviceAccount.delete.log.info.deleteSuccess"))
 
 	return nil
 }

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -11,12 +11,12 @@ func Emoji(emoji string, fallback string) string {
 	return fallback
 }
 
-// Success returns check mark emoji
-func Success() string {
+// SuccessPrefix returns check mark emoji prefix
+func SuccessPrefix() string {
 	return Emoji("\u2714\ufe0f", "")
 }
 
-// Error returns cross mark emoji
-func Error() string {
+// ErrorPrefix returns cross mark emoji prefix or default "Error:"
+func ErrorPrefix() string {
 	return Emoji("\u274c", "Error:")
 }

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -2,6 +2,11 @@ package icon
 
 import "runtime"
 
+const (
+	CrossMark = "\u274c"
+	CheckMark = "\u2714\ufe0f"
+)
+
 // Emoji accepts two arguments, emoji sequence code, and fallback string, for the cases when emoji isn't supported.
 // If the running program's operating system target isn't Windows, then a function returns emoji, in other case fall back string.
 func Emoji(emoji string, fallback string) string {
@@ -13,10 +18,10 @@ func Emoji(emoji string, fallback string) string {
 
 // SuccessPrefix returns check mark emoji prefix
 func SuccessPrefix() string {
-	return Emoji("\u2714\ufe0f", "")
+	return Emoji(CheckMark, "")
 }
 
 // ErrorPrefix returns cross mark emoji prefix or default "Error:"
 func ErrorPrefix() string {
-	return Emoji("\u274c", "Error:")
+	return Emoji(CrossMark, "Error:")
 }

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -384,7 +384,7 @@ one = 'The name you entered does not match the name of the Kafka instance that y
 description = 'Debug message when deleting Kafka'
 one = 'Deleting Kafka instance'
 
-[kafka.delete.log.info.deleteSuccess]
+[kafka.delete.log.info.deleting]
 description = 'Info message when instance was deleted'
 one = 'Kafka instance "{{.Name}}" is being deleted'
 


### PR DESCRIPTION
Follow up to the great work done in #1046 

Three things are covered here:

- Renamed methods
- Removed the extra space between the Error prefix and message
- Detect if an emoji is used, and if so it capitalizes the first character if the message.

### Verification Steps

Windows:

```shell
$ rhoas kafka topic list
Error: not logged in to identity.api.openshift.com. 
```

Linux:

```shell
$ rhoas kafka topic list
❌ Not logged in to identity.api.openshift.com.
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer