### PR TITLE
fix: added a Parse function for the command-line arguments

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"flag"
+	"os"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
 
@@ -41,6 +42,7 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 	cmd.Version = version
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	fs.Parse(os.Args[1:])
 
 	// Child commands
 	cmd.AddCommand(login.NewLoginCmd(f))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -42,7 +42,7 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 	cmd.Version = version
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	fs.Parse(os.Args[1:])
+	_ = fs.Parse(os.Args[1:])
 
 	// Child commands
 	cmd.AddCommand(login.NewLoginCmd(f))


### PR DESCRIPTION
This is a potential fix for #1034  . Seems like that we have to run a Parse() function, at least it started working in my local copy. @wtrocki , @craicoverflow what do you think?