### PR TITLE
fix: fixed the problem with a verbose flag

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -49,6 +49,8 @@ func main() {
 	}
 
 	err = rootCmd.Execute()
+	cmdFactory.Logger.SetDebug(debug.Enabled())
+
 	if err == nil {
 		if debug.Enabled() {
 			build.CheckForUpdate(cmdFactory.Context, cmdFactory.Logger, localizer)

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -49,7 +49,6 @@ func main() {
 	}
 
 	err = rootCmd.Execute()
-	cmdFactory.Logger.SetDebug(debug.Enabled())
 
 	if err == nil {
 		if debug.Enabled() {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/internal/config"
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/debug"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/httputil"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
@@ -28,10 +27,6 @@ func New(localizer localize.Localizer) *Factory {
 
 	loggerBuilder := logging.NewStdLoggerBuilder()
 	loggerBuilder = loggerBuilder.Streams(io.Out, io.ErrOut)
-
-	debugEnabled := debug.Enabled()
-	loggerBuilder = loggerBuilder.Debug(debugEnabled)
-
 	logger, _ = loggerBuilder.Build()
 
 	ctx := context.Background()

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"flag"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/debug"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
 
@@ -29,6 +30,9 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 		Short:         f.Localizer.MustLocalize("root.cmd.shortDescription"),
 		Long:          f.Localizer.MustLocalize("root.cmd.longDescription"),
 		Example:       f.Localizer.MustLocalize("root.cmd.example"),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			f.Logger.SetDebug(debug.Enabled())
+		},
 	}
 	fs := cmd.PersistentFlags()
 	arguments.AddDebugFlag(fs)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -7,6 +7,9 @@ type Logger interface {
 	// InfoEnabled returns true if the information level is enabled.
 	InfoEnabled() bool
 
+	// SetDebug sets/unsets the debug level for the logger
+	SetDebug(b bool)
+
 	// Debug sends to the log a debug message formatted using the fmt.Sprintf function and the
 	// given format and arguments.
 	Debug(args ...interface{})

--- a/pkg/logging/std_logger.go
+++ b/pkg/logging/std_logger.go
@@ -87,6 +87,11 @@ func (b *StdLoggerBuilder) Build() (logger *StdLogger, err error) {
 	return
 }
 
+// SetDebug sets/unsets the debug level for the logger
+func (l *StdLogger) SetDebug(b bool) {
+	l.debugEnabled = b
+}
+
 // DebugEnabled returns true iff the debug level is enabled.
 func (l *StdLogger) DebugEnabled() bool {
 	return l.debugEnabled


### PR DESCRIPTION
I've added a new SetDebug() function to the Logger interface and implemented it in the StdLoggerBuilder. Also, I've moved debug.Enabled() out of default.go file to the main.go and placed it after the command line arguments definition, so the verbose flag will be properly read and set.

Closes #1034 