### PR TITLE
refactor: use make to create fixed size list

### DIFF
--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -157,7 +157,7 @@ func runList(opts *options) error {
 }
 
 func mapResponseItemsToRows(artifacts []registryinstanceclient.SearchedArtifact) []artifactRow {
-	rows := []artifactRow{}
+	rows := make([]artifactRow, len(artifacts))
 
 	for i := range artifacts {
 		k := (artifacts)[i]

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -170,7 +170,7 @@ func mapResponseItemsToRows(artifacts []registryinstanceclient.SearchedArtifact)
 			State:     k.GetState(),
 		}
 
-		rows = append(rows, row)
+		rows[i] = row
 	}
 
 	return rows


### PR DESCRIPTION
Closes #911 

**Verification Steps**

- [ ] Run export RHOAS_DEV=true to enable this hidden feature.
- [ ] Create a Service Registry instance, or skip this if you already have one.
- [ ] Run rhoas `service-registry artifact list` it should provide list of Service Registry artifacts

Type of change

- [ ] Other: code refactoring