### PR TITLE
feat: enable kafka update command

### DIFF
--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -94,6 +94,13 @@ ifdef::pantheonenv[]
 endif::[]
 
 ifdef::env-github,env-browser[]
+* link:rhoas_kafka_update.adoc#rhoas-kafka-update[rhoas kafka update]	 - Update configuration details of a Kafka instance.
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-update_{context}[rhoas kafka update]	 - Update configuration details of a Kafka instance.
+endif::[]
+
+ifdef::env-github,env-browser[]
 * link:rhoas_kafka_use.adoc#rhoas-kafka-use[rhoas kafka use]	 - Set the current Apache Kafka instance
 endif::[]
 ifdef::pantheonenv[]

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -1,0 +1,61 @@
+ifdef::env-github,env-browser[:context: cmd]
+[id='ref-rhoas-kafka-update_{context}']
+= rhoas kafka update
+
+[role="_abstract"]
+Update configuration details of a Kafka instance.
+
+[discrete]
+== Synopsis
+
+Update certain configuration details of a Kafka instance.
+
+Currently it is possible to update the "owner" field. The new owner 
+will have super-user privileges and will be authorized to manage this instance.
+
+
+....
+rhoas kafka update [flags]
+....
+
+[discrete]
+== Examples
+
+....
+# update the Kafka instance owner
+$ rhoas kafka update --name=my-kafka --owner=other-user
+
+# update the owner of the current Kafka instance
+$ rhoas kafka update --owner=other-user
+
+# update the current Kafka instance in interactive mode
+$ rhoas kafka update
+
+....
+
+[discrete]
+== Options
+
+      `--id` _string_::         Unique ID of the Kafka instance you want to update
+      `--name` _string_::       Name of the Kafka instance you want to update
+  `-o`, `--output` _string_::   Format in which to display the Kafka instance (choose from: "json", "yml", "yaml") (default "json")
+      `--owner` _string_::      ID of the user you want to set as the owner of this Kafka instance
+  `-y`, `--yes`::               Forcibly update the Kafka instance without confirmation
+
+[discrete]
+== Options inherited from parent commands
+
+  `-h`, `--help`::      Show help for a command
+  `-v`, `--verbose`::   Enable verbose mode
+
+[discrete]
+== See also
+
+
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka.adoc#rhoas-kafka[rhoas kafka]	 - Create, view, use, and manage your Kafka instances
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka_{context}[rhoas kafka]	 - Create, view, use, and manage your Kafka instances
+endif::[]
+

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -11,7 +11,7 @@ Update configuration details of a Kafka instance.
 Update certain configuration details of a Kafka instance.
 
 Currently it is possible to update the "owner" field. The new owner 
-will have super-user privileges and will be authorized to manage this instance.
+will be authorized to manage this instance.
 
 
 ....

--- a/pkg/auth/token/token.go
+++ b/pkg/auth/token/token.go
@@ -134,3 +134,15 @@ func GetUsername(tokenStr string) (username string, ok bool) {
 
 	return username, ok
 }
+
+// IsOrgAdmin returns the value of the `is_org_admin` claim
+func IsOrgAdmin(tokenStr string) bool {
+	accessTkn, _ := Parse(tokenStr)
+	tknClaims, _ := MapClaims(accessTkn)
+	isAdminClaim, ok := tknClaims["is_org_admin"]
+	if !ok {
+		return false
+	}
+	orgAdmin, _ := isAdminClaim.(bool)
+	return orgAdmin
+}

--- a/pkg/cmd/kafka/kafka.go
+++ b/pkg/cmd/kafka/kafka.go
@@ -5,7 +5,6 @@ package kafka
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic"
-	"github.com/redhat-developer/app-services-cli/pkg/profile"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
@@ -35,11 +34,8 @@ func NewKafkaCommand(f *factory.Factory) *cobra.Command {
 		use.NewUseCommand(f),
 		topic.NewTopicCommand(f),
 		consumergroup.NewConsumerGroupCommand(f),
+		update.NewUpdateCommand(f),
 	)
-
-	if profile.DevModeEnabled() {
-		cmd.AddCommand(update.NewUpdateCommand(f))
-	}
 
 	return cmd
 }

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -8,7 +8,7 @@ one = '''
 Update certain configuration details of a Kafka instance.
 
 Currently it is possible to update the "owner" field. The new owner 
-will have super-user privileges and will be authorized to manage this instance.
+will be authorized to manage this instance.
 '''
 
 [kafka.update.cmd.examples]
@@ -62,3 +62,6 @@ one = "Select new owner:"
 
 [kafka.update.error.loadUsersError]
 one = 'unable to load users'
+
+[kafka.update.log.info.onlyOrgAdminsCanUpdate]
+one = "Only organization administrators have the ability to update a Kafka instance."


### PR DESCRIPTION
The `rhoas kafka update` command was hidden as there needed to be some changes in the backend. This has been enabled now, so we can make this command available to users.

### Verification Steps

1. Log in as an org admin.
1. Ensure `RHOAS_DEV=false` or unset.
1. Run `rhoas kafka update`
2. You will be shown a list of users to choose from.
3. Log in as a non-admin.
4. Run `rhoas kafka update`, you should see:

```shell
$ rhoas kafka update
Only organization administrators have the ability to update a Kafka instance.
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer