### PR TITLE
refactor(login): add visual spinner to login command

### DIFF
--- a/pkg/auth/login/login.go
+++ b/pkg/auth/login/login.go
@@ -3,7 +3,6 @@ package login
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"log"
 	"net/http"
 	"net/url"
@@ -40,8 +39,6 @@ type SSOConfig struct {
 // enabling the user to log in to SSO and MAS-SSO in succession
 // https://tools.ietf.org/html/rfc6749#section-4.1
 func (a *AuthorizationCodeGrant) Execute(ctx context.Context, ssoCfg *SSOConfig, masSSOCfg *SSOConfig) error {
-	// log in to SSO
-	a.Logger.Info(a.Localizer.MustLocalize("login.log.info.loggingIn"))
 	if err := a.loginSSO(ctx, ssoCfg); err != nil {
 		return err
 	}
@@ -53,7 +50,6 @@ func (a *AuthorizationCodeGrant) Execute(ctx context.Context, ssoCfg *SSOConfig,
 	if err := a.loginMAS(ctx, masSSOCfg); err != nil {
 		return err
 	}
-	a.Logger.Info(icon.SuccessPrefix(), a.Localizer.MustLocalize("login.log.info.loggedIn"))
 	a.Logger.Debug(a.Localizer.MustLocalize("login.log.info.loggedInMAS", localize.NewEntry("Host", masSSOHost)))
 
 	return nil

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -3,11 +3,13 @@ package create
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"net/http"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/redhat-developer/app-services-cli/pkg/icon"
+	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
 
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
@@ -209,8 +211,8 @@ func runCreate(opts *options) error {
 
 	if opts.wait {
 		opts.Logger.Debug("--wait flag is enabled, waiting for Kafka to finish creating")
-		s := opts.IO.NewSpinner()
-		s.Suffix = fmt.Sprintf(" %v", opts.localizer.MustLocalize("kafka.create.log.info.creatingKafka", nameTemplateEntry))
+		s := spinner.New(opts.IO.ErrOut, opts.localizer)
+		s.SetLocalizedSuffix("kafka.create.log.info.creatingKafka", nameTemplateEntry)
 		s.Start()
 
 		// when there is a SIGINT, display a message informing the user that this does not cancel the creation
@@ -235,11 +237,11 @@ func runCreate(opts *options) error {
 			defer httpRes.Body.Close()
 			opts.Logger.Debug("Checking Kafka status:", response.GetStatus())
 
-			s.Suffix = createSpinnerSuffix(opts.localizer, response.GetName(), response.GetStatus())
+			s.SetSuffix(createSpinnerSuffix(opts.localizer, response.GetName(), response.GetStatus()))
 
 		}
 		s.Stop()
-		opts.Logger.Info("\n")
+		opts.Logger.Info()
 		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("kafka.create.info.successSync", nameTemplateEntry))
 	}
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -237,7 +237,10 @@ func runCreate(opts *options) error {
 			defer httpRes.Body.Close()
 			opts.Logger.Debug("Checking Kafka status:", response.GetStatus())
 
-			s.SetSuffix(createSpinnerSuffix(opts.localizer, response.GetName(), response.GetStatus()))
+			s.SetLocalizedSuffix("kafka.create.log.info.creationInProgress",
+				localize.NewEntry("Name", response.GetName()),
+				localize.NewEntry("Status", color.Info(response.GetStatus())),
+			)
 
 		}
 		s.Stop()
@@ -345,10 +348,4 @@ func promptKafkaPayload(opts *options) (payload *kafkamgmtclient.KafkaRequestPay
 	}
 
 	return payload, nil
-}
-
-func createSpinnerSuffix(localizer localize.Localizer, name string, status string) string {
-	return " " + localizer.MustLocalize("kafka.create.log.info.creationInProgress",
-		localize.NewEntry("Name", name),
-		localize.NewEntry("Status", color.Info(status)))
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -174,6 +174,8 @@ func runLogin(opts *options) (err error) {
 		defer cancel()
 
 		if err = loginExec.Execute(ctx, ssoCfg, masSsoCfg); err != nil {
+			spinner.Stop()
+			opts.Logger.Info()
 			if errors.Is(err, context.DeadlineExceeded) {
 				return opts.localizer.MustLocalizeError("login.error.context.deadline.exceeded")
 			}
@@ -184,6 +186,8 @@ func runLogin(opts *options) (err error) {
 
 	if opts.offlineToken != "" {
 		if err = loginWithOfflineToken(opts); err != nil {
+			spinner.Stop()
+			opts.Logger.Info()
 			return err
 		}
 	}

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net/http"
+	"net/url"
+
 	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"golang.org/x/oauth2"
-	"net/http"
-	"net/url"
 
 	"github.com/redhat-developer/app-services-cli/pkg/auth/login"
 	"github.com/redhat-developer/app-services-cli/pkg/auth/token"
@@ -21,6 +22,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
 
 	"github.com/spf13/cobra"
 )
@@ -137,6 +139,10 @@ func runLogin(opts *options) (err error) {
 	}
 	opts.masAuthURL = masAuthURL.String()
 
+	// log in to SSO
+	spinner := spinner.New(opts.IO.ErrOut, opts.localizer)
+	spinner.SetLocalizedSuffix("login.log.info.loggingIn")
+	spinner.Start()
 	if opts.offlineToken == "" {
 		tr := createTransport(opts.insecureSkipTLSVerify)
 		httpClient := oauth2.NewClient(opts.Context, nil)
@@ -181,6 +187,7 @@ func runLogin(opts *options) (err error) {
 			return err
 		}
 	}
+	spinner.Stop()
 
 	cfg, err := opts.Config.Load()
 	if err != nil {
@@ -199,8 +206,8 @@ func runLogin(opts *options) (err error) {
 	}
 
 	username, ok := token.GetUsername(cfg.AccessToken)
-	opts.Logger.Info("")
 
+	opts.Logger.Info()
 	if !ok {
 		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccessNoUsername"))
 	} else {

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -3,9 +3,7 @@ package iostreams
 import (
 	"io"
 	"os"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
 )
@@ -88,11 +86,6 @@ func (s *IOStreams) IsSSHSession() bool {
 	_, hasTTY := os.LookupEnv("SSH_TTY")
 
 	return hasClient || hasTTY
-}
-
-// NewSpinner returns a new spinner progress bar to be used in synchronous commands
-func (s *IOStreams) NewSpinner() *spinner.Spinner {
-	return spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithWriter(s.ErrOut))
 }
 
 func isTerminal(f *os.File) bool {

--- a/pkg/ioutil/spinner/spinner.go
+++ b/pkg/ioutil/spinner/spinner.go
@@ -1,0 +1,50 @@
+package spinner
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+)
+
+type Spinner struct {
+	writer    io.Writer
+	spinner   *spinner.Spinner
+	localizer localize.Localizer
+}
+
+// New create a new Spinner instance
+func New(w io.Writer, localizer localize.Localizer) *Spinner {
+	return &Spinner{
+		writer:    w,
+		localizer: localizer,
+		spinner: spinner.New(
+			spinner.CharSets[11],
+			100*time.Millisecond,
+			spinner.WithWriter(w),
+		),
+	}
+}
+
+// SetSuffix sets the spinner suffix message
+func (s *Spinner) SetSuffix(suffix string) {
+	s.spinner.Suffix = " " + suffix
+}
+
+// SetLocalizedSuffix sets the spinner suffix from an i18n ID
+func (s *Spinner) SetLocalizedSuffix(id string, entries ...*localize.TemplateEntry) {
+	s.SetSuffix(s.localizer.MustLocalize(id, entries...))
+}
+
+// Start starts the spinner
+func (s *Spinner) Start() {
+	s.spinner.Start()
+}
+
+// Stop stops the spinner
+func (s *Spinner) Stop() {
+	s.spinner.Stop()
+	fmt.Fprintln(s.writer)
+}


### PR DESCRIPTION
Closes #1094 

This pull request primarily adds a visual spinner to the login command. I've also added a custom `spinner` package which abstracts the `github.com/briandowns/spinner` and allows you to pass the localized ID directly and it will localize the message.

### Verification Steps

Run `rhoas login` and watch the command prompt during each phase as it starts a spinner and will stop it after you have logged in.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Refactor

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer