### PR TITLE
fix: add proper validation for state

### DIFF
--- a/pkg/cmd/registry/artifact/state/state.go
+++ b/pkg/cmd/registry/artifact/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -53,10 +54,8 @@ func NewSetStateCommand(f *factory.Factory) *cobra.Command {
 				return f.Localizer.MustLocalizeError("artifact.common.message.artifactIdRequired")
 			}
 
-			if opts.state != "" {
-				if _, err := registryinstanceclient.NewArtifactStateFromValue(opts.state); err != nil {
-					return opts.localizer.MustLocalizeError("artifact.cmd.state.error.invalidArtifactState", localize.NewEntry("AllowedTypes", util.GetAllowedArtifactStateEnumValuesAsString()))
-				}
+			if _, err := registryinstanceclient.NewArtifactStateFromValue(opts.state); err != nil {
+				return opts.localizer.MustLocalizeError("artifact.cmd.state.error.invalidArtifactState", localize.NewEntry("AllowedTypes", util.GetAllowedArtifactStateEnumValuesAsString()))
 			}
 
 			if opts.registryID != "" {


### PR DESCRIPTION
[wtrocki@graphapi app-services-cli (state-fix ✗)]$ rhoas service-registry artifact state-set --artifact-id=test
Using default artifacts group.
❌ Invalid value '' for ArtifactState: valid values are [ENABLED DISABLED DEPRECATED]. Run the command in verbose mode using the -v flag to see more information
