### PR TITLE
fix!: remove --output flag from update commands

### DIFF
--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -44,7 +44,6 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest 
 
       `--id` _string_::               The unique ID of the consumer group to reset-offset
       `--offset` _string_::           Offset type (choose from: "earliest", "latest", "absolute", "timestamp")
-  `-o`, `--output` _string_::         Format in which to display reset offset result (choose from: "json", "yml", "yaml")
       `--partitions` _int32Slice_::   Partitions on which to reset the consumer group offset (comma-separated integers) (default [])
       `--topic` _string_::            Select topic for which consumer group offsets are to be reset
       `--value` _string_::            Custom offset value (required when offset is "absolute" or "timestamp")

--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -29,7 +29,6 @@ $ rhoas kafka topic update --name topic-1 --retention-ms -1
 
       `--cleanup-policy` _string_::    Determines whether log messages are deleted, compacted, or both
       `--name` _string_::              Topic name
-  `-o`, `--output` _string_::          Format in which to display the Kafka topic (choose from: "json", "yml", "yaml")
       `--partitions` _string_::        The number of partitions in the topic
       `--retention-bytes` _string_::   The maximum total size of a partition log segments before old log segments are deleted to free up space
       `--retention-ms` _string_::      The period of time in milliseconds the broker will retain a partition log before deleting it

--- a/docs/commands/rhoas_kafka_topic_update.adoc
+++ b/docs/commands/rhoas_kafka_topic_update.adoc
@@ -29,7 +29,7 @@ $ rhoas kafka topic update --name topic-1 --retention-ms -1
 
       `--cleanup-policy` _string_::    Determines whether log messages are deleted, compacted, or both
       `--name` _string_::              Topic name
-  `-o`, `--output` _string_::          Format in which to display the Kafka topic (choose from: "json", "yml", "yaml") (default "json")
+  `-o`, `--output` _string_::          Format in which to display the Kafka topic (choose from: "json", "yml", "yaml")
       `--partitions` _string_::        The number of partitions in the topic
       `--retention-bytes` _string_::   The maximum total size of a partition log segments before old log segments are deleted to free up space
       `--retention-ms` _string_::      The period of time in milliseconds the broker will retain a partition log before deleting it

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -36,11 +36,10 @@ $ rhoas kafka update
 [discrete]
 == Options
 
-      `--id` _string_::         Unique ID of the Kafka instance you want to update
-      `--name` _string_::       Name of the Kafka instance you want to update
-  `-o`, `--output` _string_::   Format in which to display the Kafka instance (choose from: "json", "yml", "yaml") (default "json")
-      `--owner` _string_::      ID of the user you want to set as the owner of this Kafka instance
-  `-y`, `--yes`::               Forcibly update the Kafka instance without confirmation
+      `--id` _string_::      Unique ID of the Kafka instance you want to update
+      `--name` _string_::    Name of the Kafka instance you want to update
+      `--owner` _string_::   ID of the user you want to set as the owner of this Kafka instance
+  `-y`, `--yes`::            Forcibly update the Kafka instance without confirmation
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_artifact_update.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_update.adoc
@@ -48,7 +48,6 @@ rhoas service-registry artifact update --artifact-id=my-artifact --group my-grou
   `-g`, `--group` _string_::       Artifact group (default "default")
       `--instance-id` _string_::   ID of the Service Registry instance to be used. By default, uses the currently selected instance
       `--name` _string_::          Custom name of the artifact
-  `-o`, `--output` _string_::      Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
       `--version` _string_::       Custom version of the artifact (for example 1.0.0)
 
 [discrete]

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -9,7 +9,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
@@ -29,7 +28,6 @@ type options struct {
 	offset      string
 	topic       string
 	partitions  []int32
-	output      string
 
 	IO         *iostreams.IOStreams
 	Config     config.IConfig
@@ -59,11 +57,6 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		Example: opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.cmd.example"),
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-
-			if opts.output != "" && !flagutil.IsValidInput(opts.output, flagutil.ValidOutputFormats...) {
-				return flag.InvalidValueError("output", opts.output, flagutil.ValidOutputFormats...)
-			}
-
 			validator = consumergroup.Validator{
 				Localizer: opts.localizer,
 			}

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -2,8 +2,9 @@ package resetoffset
 
 import (
 	"context"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"net/http"
+
+	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/internal/config"
@@ -12,7 +13,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
-	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -37,12 +37,6 @@ type options struct {
 	Logger     logging.Logger
 	localizer  localize.Localizer
 	Context    context.Context
-}
-
-type updatedConsumerRow struct {
-	Topic     string `json:"groupId,omitempty" header:"Topic"`
-	Partition int32  `json:"active_members,omitempty" header:"Partition"`
-	Offset    int32  `json:"lag,omitempty" header:"Offset"`
 }
 
 var validator consumergroup.Validator
@@ -109,7 +103,6 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.offset, "offset", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.offset"))
 	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.topic"))
 	cmd.Flags().Int32SliceVar(&opts.partitions, "partitions", []int32{}, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.partitions"))
-	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.output"))
 
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("offset")
@@ -227,7 +220,7 @@ func runCmd(opts *options) error {
 		}
 	}
 
-	updatedConsumers, httpRes, err := a.Execute()
+	_, httpRes, err := a.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
@@ -262,32 +255,5 @@ func runCmd(opts *options) error {
 		localize.NewEntry("InstanceName", kafkaInstance.GetName())),
 	)
 
-	switch opts.output {
-	case "":
-		opts.Logger.Info("")
-		consumers := updatedConsumers.GetItems()
-		rows := mapResetOffsetResultToTableFormat(consumers)
-		dump.Table(opts.IO.Out, rows)
-	default:
-		return dump.Formatted(opts.IO.Out, opts.output, updatedConsumers)
-	}
-
 	return nil
-
-}
-
-func mapResetOffsetResultToTableFormat(consumers []kafkainstanceclient.ConsumerGroupResetOffsetResultItem) []updatedConsumerRow {
-	rows := make([]updatedConsumerRow, len(consumers))
-
-	for i, t := range consumers {
-
-		row := updatedConsumerRow{
-			Topic:     t.GetTopic(),
-			Partition: t.GetPartition(),
-			Offset:    t.GetOffset(),
-		}
-		rows[i] = row
-	}
-
-	return rows
 }

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -155,7 +155,7 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", dump.EmptyFormat, opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
 	cmd.Flags().StringVar(&opts.retentionMsStr, "retention-ms", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
 	cmd.Flags().StringVar(&opts.retentionBytesStr, "retention-bytes", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
 	cmd.Flags().StringVar(&opts.cleanupPolicy, "cleanup-policy", "", opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
@@ -275,7 +275,7 @@ func runCmd(opts *options) error {
 	updateTopicReq = updateTopicReq.UpdateTopicInput(*topicSettings)
 
 	// update the topic
-	response, httpRes, err := updateTopicReq.Execute()
+	_, httpRes, err = updateTopicReq.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
@@ -304,14 +304,7 @@ func runCmd(opts *options) error {
 	}
 
 	opts.Logger.Info(opts.localizer.MustLocalize("kafka.topic.update.log.info.topicUpdated", topicNameTmplPair, kafkaNameTmplPair))
-
-	stdout := opts.IO.Out
-	switch opts.outputFormat {
-	case dump.EmptyFormat:
-		return nil
-	default:
-		return dump.Formatted(stdout, opts.outputFormat, response)
-	}
+	return nil
 }
 
 func runInteractivePrompt(opts *options) (err error) {

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -37,7 +37,6 @@ type options struct {
 	retentionMsStr    string
 	retentionBytesStr string
 	kafkaID           string
-	outputFormat      string
 	interactive       bool
 	cleanupPolicy     string
 
@@ -96,12 +95,6 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 					}
 				}
 
-			}
-
-			if opts.outputFormat != "" {
-				if err = flag.ValidateOutput(opts.outputFormat); err != nil {
-					return err
-				}
 			}
 
 			// check if the partition flag is set

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
@@ -273,7 +272,7 @@ func runCmd(opts *options) error {
 	updateTopicReq = updateTopicReq.UpdateTopicInput(*topicSettings)
 
 	// update the topic
-	response, httpRes, err := updateTopicReq.Execute()
+	_, httpRes, err = updateTopicReq.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
@@ -302,7 +301,8 @@ func runCmd(opts *options) error {
 	}
 
 	opts.Logger.Info(opts.localizer.MustLocalize("kafka.topic.update.log.info.topicUpdated", topicNameTmplPair, kafkaNameTmplPair))
-	return dump.Formatted(opts.IO.Out, opts.outputFormat, response)
+
+	return nil
 }
 
 func runInteractivePrompt(opts *options) (err error) {

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
@@ -155,7 +154,6 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", dump.EmptyFormat, opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
 	cmd.Flags().StringVar(&opts.retentionMsStr, "retention-ms", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
 	cmd.Flags().StringVar(&opts.retentionBytesStr, "retention-bytes", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
 	cmd.Flags().StringVar(&opts.cleanupPolicy, "cleanup-policy", "", opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -16,7 +16,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/auth/token"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
@@ -35,8 +34,6 @@ type options struct {
 	id          string
 	owner       string
 	skipConfirm bool
-
-	outputFormat string
 
 	interactive    bool
 	userIsOrgAdmin bool
@@ -92,11 +89,6 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 			}
 			if opts.owner == "" {
 				opts.interactive = true
-			}
-
-			validOutputFormats := flagutil.ValidOutputFormats
-			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
-				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
 			if opts.name != "" && opts.id != "" {

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -19,7 +19,6 @@ import (
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
-	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
@@ -119,7 +118,6 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", dump.JSONFormat, opts.localizer.MustLocalize("kafka.common.flag.output.description"))
 	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.update.flag.id"))
 	cmd.Flags().StringVar(&opts.owner, "owner", "", opts.localizer.MustLocalize("kafka.update.flag.owner"))
 	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.update.flag.yes"))
@@ -217,7 +215,7 @@ func run(opts *options) error {
 	opts.logger.Info()
 	opts.logger.Info(opts.localizer.MustLocalize("kafka.update.log.info.updateSuccess", localize.NewEntry("Name", response.GetName())))
 
-	return dump.Formatted(opts.IO.Out, opts.outputFormat, response)
+	return nil
 }
 
 func promptOwnerSelect(localizer localize.Localizer, users []rbac.Principal) (string, error) {

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
-	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
@@ -92,7 +91,6 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", opts.localizer.MustLocalize("artifact.common.file.location"))
 
 	cmd.Flags().StringVar(&opts.artifact, "artifact-id", "", opts.localizer.MustLocalize("artifact.common.id"))
@@ -152,11 +150,11 @@ func runUpdate(opts *options) error {
 	}
 
 	request = request.Body(specifiedFile)
-	metadata, _, err := request.Execute()
-	if err != nil {
+	if _, _, err = request.Execute(); err != nil {
 		return err
 	}
+
 	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.updated"))
 
-	return dump.Formatted(opts.IO.Out, opts.outputFormat, metadata)
+	return nil
 }

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -7,7 +7,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 
@@ -27,8 +26,7 @@ type options struct {
 
 	file string
 
-	registryID   string
-	outputFormat string
+	registryID string
 
 	version     string
 	name        string
@@ -60,11 +58,6 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 		Example: f.Localizer.MustLocalize("artifact.cmd.update.example"),
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			validOutputFormats := flagutil.ValidOutputFormats
-			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {
-				return flag.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
-			}
-
 			if opts.artifact == "" {
 				return opts.localizer.MustLocalizeError("artifact.common.error.artifact.id.required")
 			}

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -702,7 +702,7 @@ one = 'Topic "{{.Name}}" already has {{.Count}} partitions.'
 one = 'Nothing to update'
 
 [kafka.topic.update.log.info.topicUpdated]
-one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated. Run "rhoas kafka describe --name {{.TopicName}} to view configuration details."'
+one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated. Run "rhoas kafka topic describe --name {{.TopicName}} to view its configuration."'
 
 [kafka.topic.update.input.retentionMs.message]
 description = 'Message for the Retention period input'

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -702,7 +702,7 @@ one = 'Topic "{{.Name}}" already has {{.Count}} partitions.'
 one = 'Nothing to update'
 
 [kafka.topic.update.log.info.topicUpdated]
-one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated'
+one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated. Run "rhoas kafka describe --name {{.TopicName}} to view configuration details."'
 
 [kafka.topic.update.input.retentionMs.message]
 description = 'Message for the Retention period input'

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -702,7 +702,7 @@ one = 'Topic "{{.Name}}" already has {{.Count}} partitions.'
 one = 'Nothing to update'
 
 [kafka.topic.update.log.info.topicUpdated]
-one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated. Run "rhoas kafka topic describe --name {{.TopicName}} to view its configuration."'
+one = 'Topic "{{.TopicName}}" in Kafka instance "{{.InstanceName}}" has been updated. Run "rhoas kafka topic describe --name {{.TopicName}}" to view its configuration.'
 
 [kafka.topic.update.input.retentionMs.message]
 description = 'Message for the Retention period input'

--- a/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
+++ b/pkg/localize/locales/en/cmd/kafka_consumergroup_reset_offset.toml
@@ -52,7 +52,7 @@ one = 'Are you sure you want to reset the offset for consumer group "{{.ID}}"?'
 one = 'You have chosen not to reset the consumer group offset.'
 
 [kafka.consumerGroup.resetOffset.log.info.successful]
-one = 'Offset has been reset for members of consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}"'
+one = 'Offset has been reset for members of consumer group with ID "{{.ConsumerGroupID}}" in the Kafka instance "{{.InstanceName}}". Run "rhoas kafka consumer-group describe --id {{.ConsumerGroupID}}" to view its current state.'
 
 [kafka.consumerGroup.resetOffset.error.valueRequired]
 one = 'value is required  when "{{.Offset}}" offset is used'

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -52,7 +52,7 @@ one = 'Nothing to update: user "{{.Owner}}" is already the owner of the Kafka in
 one = 'Updating Kafka instance "{{.Name}}"...'
 
 [kafka.update.log.info.updateSuccess]
-one = 'Kafka instance "{{.Name}}" has been updated:'
+one = 'Kafka instance "{{.Name}}" has been updated. Run "rhoas kafka describe --name {{.Name}}" to view its configuration.'
 
 [kafka.update.log.info.loadingUsers]
 one = 'Loading users...'


### PR DESCRIPTION
Closes #1092 

### Verification Steps

1. Run `rhoas kafka update`, `rhoas kafka topic update`, `rhoas kafka consumer-group reset-offset`. All will no longer show any JSON output.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer