### PR TITLE
feat: add hidden docs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ docs/check: docs/generate
 
 docs/generate:
 	rm -rf ./docs/commands/*
-	GENERATE_DOCS=true RHOAS_DEV=false go run ./cmd/rhoas
+	go run ./cmd/rhoas docs -d ./docs/commands -f adoc
 .PHONY: docs/generate
 
 docs/generate-modular-docs: docs/generate

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ docs/check: docs/generate
 
 docs/generate:
 	rm -rf ./docs/commands/*
-	go run ./cmd/rhoas docs -d ./docs/commands -f adoc
+	go run ./cmd/rhoas docs --dir ./docs/commands --file-format adoc
 .PHONY: docs/generate
 
 docs/generate-modular-docs: docs/generate

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
-	"github.com/redhat-developer/app-services-cli/pkg/doc"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/localize/goi18n"
 
@@ -19,10 +18,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/debug"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/root"
-	"github.com/spf13/cobra"
 )
-
-var generateDocs = os.Getenv("GENERATE_DOCS") == "true"
 
 func main() {
 	localizer, err := goi18n.New(nil)
@@ -44,11 +40,6 @@ func main() {
 
 	rootCmd.InitDefaultHelpCmd()
 
-	if generateDocs {
-		generateDocumentation(rootCmd)
-		os.Exit(0)
-	}
-
 	err = rootCmd.Execute()
 
 	if err == nil {
@@ -60,26 +51,6 @@ func main() {
 	cmdFactory.Logger.Errorf("%v\n", rootError(err, localizer))
 	build.CheckForUpdate(context.Background(), cmdFactory.Logger, localizer)
 	os.Exit(1)
-}
-
-/**
-* Generates documentation files
- */
-func generateDocumentation(rootCommand *cobra.Command) {
-	fmt.Fprintln(os.Stderr, "\n🛠️  Generating rhoas command-line reference documentation...")
-	filePrepender := func(filename string) string {
-		return ""
-	}
-
-	rootCommand.DisableAutoGenTag = true
-
-	linkHandler := func(s string) string { return s }
-
-	if err := doc.GenAsciidocTreeCustom(rootCommand, "./docs/commands", filePrepender, linkHandler); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	fmt.Fprintln(os.Stderr, "\n✅ Command-line reference documentation has been generated successfully")
 }
 
 func initConfig(f *factory.Factory) error {

--- a/go.sum
+++ b/go.sum
@@ -158,7 +158,9 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -636,7 +638,9 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -644,6 +648,7 @@ github.com/segmentio/ksuid v1.0.3 h1:FoResxvleQwYiPAVKe1tMUlEirodZqlqglIuFsdDntY
 github.com/segmentio/ksuid v1.0.3/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/pkg/cmd/docs/docs.go
+++ b/pkg/cmd/docs/docs.go
@@ -40,8 +40,8 @@ func NewDocsCmd(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.format, "format", "f", "md", "Output format of the generated documentation. Valid options are: 'md' (markdown), 'adoc' (Asciidoc) and 'man'")
-	cmd.Flags().StringVarP(&opts.dir, "docs", "d", "./docs", "The directory to output the generated documentation files")
+	cmd.Flags().StringVar(&opts.format, "file-format", "md", "Output format of the generated documentation. Valid options are: 'md' (markdown), 'adoc' (Asciidoc) and 'man'")
+	cmd.Flags().StringVar(&opts.dir, "dir", "./docs", "The directory to output the generated documentation files")
 
 	return cmd
 }

--- a/pkg/cmd/docs/docs.go
+++ b/pkg/cmd/docs/docs.go
@@ -1,0 +1,77 @@
+package docs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	rhoasdoc "github.com/redhat-developer/app-services-cli/pkg/doc"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+const (
+	markdown = "md"
+	asciidoc = "adoc"
+	man      = "man"
+)
+
+type options struct {
+	dir    string
+	format string
+
+	logger logging.Logger
+}
+
+// NewDocsCmd creates a new docs command
+func NewDocsCmd(f *factory.Factory) *cobra.Command {
+	opts := options{
+		logger: f.Logger,
+	}
+
+	cmd := &cobra.Command{
+		Use:    "docs",
+		Short:  "Generate documentation files in format of your choice",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCmd(cmd, &opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.format, "format", "f", "md", "Output format of the generated documentation. Valid options are: 'md' (markdown), 'adoc' (Asciidoc) and 'man'")
+	cmd.Flags().StringVarP(&opts.dir, "docs", "d", "./docs", "The directory to output the generated documentation files")
+
+	return cmd
+}
+
+func runCmd(cmd *cobra.Command, opts *options) (err error) {
+	cmd.Root().DisableAutoGenTag = true
+
+	switch opts.format {
+	case markdown:
+		err = doc.GenMarkdownTree(cmd.Root(), opts.dir)
+	case man:
+		year := time.Now().Year()
+		header := &doc.GenManHeader{
+			Title:   "rhoas",
+			Section: "1",
+			Source:  fmt.Sprintf("Copyright (c) %v Red Hat, Inc.", year),
+		}
+		err = doc.GenManTree(cmd.Root(), header, opts.dir)
+	case asciidoc:
+		filePrepender := func(filename string) string { return "" }
+		linkHandler := func(s string) string { return s }
+
+		err = rhoasdoc.GenAsciidocTreeCustom(cmd.Root(), opts.dir, filePrepender, linkHandler)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	opts.logger.Infof("Documentation successfully generated into %v", opts.dir)
+
+	return nil
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/arguments"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/debug"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/docs"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
 
@@ -57,6 +58,8 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 
 	// Registry commands
 	cmd.AddCommand(registry.NewServiceRegistryCommand(f))
+
+	cmd.AddCommand(docs.NewDocsCmd(f))
 
 	return cmd
 }


### PR DESCRIPTION
closes #1098 

this remains hidden from documentation and completions.

### Verification Steps

1. Run `rhoas docs -d ./docs/commands -f adoc` to generate documentation into the same folder as the old format.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer