### PR TITLE
fix: detect and  handle API error code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,7 @@
       "args": [
         "kafka",
         "create",
-        "my-kafka-instance"
+        "--name=my-kafka-instance"
       ]
     },
     {

--- a/pkg/api/kas/error.go
+++ b/pkg/api/kas/error.go
@@ -48,6 +48,9 @@ const (
 	// Invalid Search Query
 	ErrorFailedToParseSearch ServiceErrorCode = 23
 
+	// Only one eval instance is allowed
+	OneEvalInstanceAllowed ServiceErrorCode = 24
+
 	// Failed to create service account
 	ErrorFailedToCreateServiceAccount ServiceErrorCode = 110
 

--- a/pkg/cluster/kubernetes_cluster.go
+++ b/pkg/cluster/kubernetes_cluster.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
@@ -122,7 +123,7 @@ func (c *KubernetesCluster) CurrentNamespace() (string, error) {
 func (c *KubernetesCluster) Connect(ctx context.Context, cmdOptions *ConnectArguments) error {
 	api := c.connection.API()
 	kafkaInstance, _, err := api.Kafka().GetKafkaById(ctx, cmdOptions.SelectedKafka).Execute()
-	if kas.IsErr(err, kas.ErrorNotFound) {
+	if kas.IsErr(err, kas.ErrorCode7) {
 		return kafkaerr.NotFoundByIDError(cmdOptions.SelectedKafka)
 	}
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
 
@@ -187,6 +188,10 @@ func runCreate(opts *options) error {
 
 	if httpRes.StatusCode == http.StatusBadRequest {
 		return opts.localizer.MustLocalizeError("kafka.create.error.conflictError", localize.NewEntry("Name", payload.Name))
+	}
+
+	if kas.IsErr(err, kas.OneEvalInstanceAllowed) {
+		return opts.localizer.MustLocalizeError("kafka.create.error.oneinstance")
 	}
 
 	if err != nil {

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
 
@@ -190,7 +189,7 @@ func runCreate(opts *options) error {
 		return opts.localizer.MustLocalizeError("kafka.create.error.conflictError", localize.NewEntry("Name", payload.Name))
 	}
 
-	if kas.IsErr(err, kas.OneEvalInstanceAllowed) {
+	if httpRes.StatusCode == http.StatusTooManyRequests {
 		return opts.localizer.MustLocalizeError("kafka.create.error.oneinstance")
 	}
 

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -208,7 +208,7 @@ func run(opts *options) error {
 	s.Stop()
 
 	if err != nil {
-		if apiError, ok := kas.GetAPIError(err); ok {
+		if apiError := kas.GetAPIError(err); apiError != nil {
 			return errors.New(apiError.GetReason())
 		}
 		return err

--- a/pkg/connection/keycloak_connection.go
+++ b/pkg/connection/keycloak_connection.go
@@ -205,7 +205,7 @@ func (c *KeycloakConnection) API() *api.API {
 
 		kafkaInstance, resp, err := kafkaAPI.GetKafkaById(context.Background(), kafkaID).Execute()
 		defer resp.Body.Close()
-		if kas.IsErr(err, kas.ErrorNotFound) {
+		if kas.IsErr(err, kas.ErrorCode7) {
 			return nil, nil, kafkaerr.NotFoundByIDError(kafkaID)
 		} else if err != nil {
 			return nil, nil, fmt.Errorf("%w", err)

--- a/pkg/kafka/api.go
+++ b/pkg/kafka/api.go
@@ -14,7 +14,7 @@ func GetKafkaByID(ctx context.Context, api kafkamgmtclient.DefaultApi, id string
 	r := api.GetKafkaById(ctx, id)
 
 	kafkaReq, httpResponse, err := r.Execute()
-	if kas.IsErr(err, kas.ErrorNotFound) {
+	if kas.IsErr(err, kas.ErrorCode7) {
 		return nil, httpResponse, kafkaerr.NotFoundByIDError(id)
 	}
 

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -305,7 +305,7 @@ one = 'name is required. Run "rhoas kafka create --name <name>"'
 one = 'Kafka instance "{{.Name}}" already exists'
 
 [kafka.create.error.oneinstance]
-one = 'Unable to create new Kafka instance. Only one instance is allowed with an eval account'
+one = 'unable to create new Kafka instance. Only one instance is allowed with an eval account'
 
 [kafka.delete.cmd.shortDescription]
 description = "Short description for command"

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -305,7 +305,7 @@ one = 'name is required. Run "rhoas kafka create --name <name>"'
 one = 'Kafka instance "{{.Name}}" already exists'
 
 [kafka.create.error.oneinstance]
-one = 'Cannot create new instance. Only one instance allowed in eval account'
+one = 'Unable to create new Kafka instance. Only one instance is allowed with an eval account'
 
 [kafka.delete.cmd.shortDescription]
 description = "Short description for command"

--- a/pkg/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka.en.toml
@@ -304,6 +304,9 @@ one = 'name is required. Run "rhoas kafka create --name <name>"'
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'
 
+[kafka.create.error.oneinstance]
+one = 'Cannot create new instance. Only one instance allowed in eval account'
+
 [kafka.delete.cmd.shortDescription]
 description = "Short description for command"
 one = "Delete an Apache Kafka instance"

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -68,7 +68,7 @@ func Get(ctx context.Context, opts *Options) (status *Status, ok bool, err error
 			// nolint:govet
 			kafkaStatus, err := getKafkaStatus(ctx, api.Kafka(), kafkaCfg.ClusterID)
 			if err != nil {
-				if kas.IsErr(err, kas.ErrorNotFound) {
+				if kas.IsErr(err, kas.ErrorCode7) {
 					err = kafkaerr.NotFoundByIDError(kafkaCfg.ClusterID)
 					opts.Logger.Error(err)
 					opts.Logger.Info(`Run "rhoas kafka use" to use another Kafka instance.`)
@@ -193,7 +193,7 @@ func createDivider(n int) string {
 
 func getKafkaStatus(ctx context.Context, api kafkamgmtclient.DefaultApi, id string) (status *KafkaStatus, err error) {
 	kafkaResponse, _, err := api.GetKafkaById(ctx, id).Execute()
-	if kas.IsErr(err, kas.ErrorNotFound) {
+	if kas.IsErr(err, kas.ErrorCode7) {
 		return nil, kafkaerr.NotFoundByIDError(id)
 	}
 	if err != nil {


### PR DESCRIPTION
Closes #1136 

### Verification Steps

Try to create two Kafka instances. There is an accurate error shown based on the error code:

```shell
$ rhoas kafka create --name "enda2"
❌ Unable to create new Kafka instance. Only one instance is allowed with an eval account. Run the command in verbose mode using the -v flag to see more information
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer