### PR TITLE
feat(kafka acl): add base and list command

### DIFF
--- a/docs/commands/rhoas_kafka.adoc
+++ b/docs/commands/rhoas_kafka.adoc
@@ -52,6 +52,13 @@ ifdef::pantheonenv[]
 endif::[]
 
 ifdef::env-github,env-browser[]
+* link:rhoas_kafka_acl.adoc#rhoas-kafka-acl[rhoas kafka acl]	 - Kafka ACL management for users and service accounts
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-acl_{context}[rhoas kafka acl]	 - Kafka ACL management for users and service accounts
+endif::[]
+
+ifdef::env-github,env-browser[]
 * link:rhoas_kafka_consumer-group.adoc#rhoas-kafka-consumer-group[rhoas kafka consumer-group]	 - Describe, list, and delete consumer groups for the current Apache Kafka instance
 endif::[]
 ifdef::pantheonenv[]

--- a/docs/commands/rhoas_kafka_acl.adoc
+++ b/docs/commands/rhoas_kafka_acl.adoc
@@ -1,0 +1,48 @@
+ifdef::env-github,env-browser[:context: cmd]
+[id='ref-rhoas-kafka-acl_{context}']
+= rhoas kafka acl
+
+[role="_abstract"]
+Kafka ACL management for users and service accounts
+
+[discrete]
+== Synopsis
+
+Set of commands that will let you manage resources
+By default, every users and service account have limited access to their Kafka instance (Only DESCRIBE permission is enabled for TOPIC, ACL, and GROUP).
+
+
+[discrete]
+== Examples
+
+....
+
+## List ACL rules for a Kafka instance
+rhoas kafka acl list
+
+....
+
+[discrete]
+== Options inherited from parent commands
+
+  `-h`, `--help`::      Show help for a command
+  `-v`, `--verbose`::   Enable verbose mode
+
+[discrete]
+== See also
+
+
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka.adoc#rhoas-kafka[rhoas kafka]	 - Create, view, use, and manage your Kafka instances
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka_{context}[rhoas kafka]	 - Create, view, use, and manage your Kafka instances
+endif::[]
+
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka_acl_list.adoc#rhoas-kafka-acl-list[rhoas kafka acl list]	 - List all Kafka ACL rules.
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-acl-list_{context}[rhoas kafka acl list]	 - List all Kafka ACL rules.
+endif::[]
+

--- a/docs/commands/rhoas_kafka_acl.adoc
+++ b/docs/commands/rhoas_kafka_acl.adoc
@@ -8,7 +8,7 @@ Kafka ACL management for users and service accounts
 [discrete]
 == Synopsis
 
-Set of commands that will let you manage resources
+Set of commands that will let you manage Kafka ACLs.
 By default, every users and service account have limited access to their Kafka instance (Only DESCRIBE permission is enabled for TOPIC, ACL, and GROUP).
 
 
@@ -16,7 +16,6 @@ By default, every users and service account have limited access to their Kafka i
 == Examples
 
 ....
-
 ## List ACL rules for a Kafka instance
 rhoas kafka acl list
 

--- a/docs/commands/rhoas_kafka_acl_list.adoc
+++ b/docs/commands/rhoas_kafka_acl_list.adoc
@@ -1,0 +1,52 @@
+ifdef::env-github,env-browser[:context: cmd]
+[id='ref-rhoas-kafka-acl-list_{context}']
+= rhoas kafka acl list
+
+[role="_abstract"]
+List all Kafka ACL rules.
+
+[discrete]
+== Synopsis
+
+This command will display list of Kafka ACL rules
+
+The instances are displayed by default in a table, but can also be displayed as JSON or YAML.
+
+
+....
+rhoas kafka acl list [flags]
+....
+
+[discrete]
+== Examples
+
+....
+## Display Kafka ACL rules for the instance
+rhoas kafka acl list
+
+....
+
+[discrete]
+== Options
+
+  `-o`, `--output` _string_::   Format in which to display the Kafka ACL rules (choose from: "json", "yml", "yaml")
+      `--page` _int32_::        Current page number for list of Kafka ACL rules (default 1)
+      `--size` _int32_::        Maximum number of items to be returned per page (default 10)
+
+[discrete]
+== Options inherited from parent commands
+
+  `-h`, `--help`::      Show help for a command
+  `-v`, `--verbose`::   Enable verbose mode
+
+[discrete]
+== See also
+
+
+ifdef::env-github,env-browser[]
+* link:rhoas_kafka_acl.adoc#rhoas-kafka-acl[rhoas kafka acl]	 - Kafka ACL management for users and service accounts
+endif::[]
+ifdef::pantheonenv[]
+* link:{path}#ref-rhoas-kafka-acl_{context}[rhoas kafka acl]	 - Kafka ACL management for users and service accounts
+endif::[]
+

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -11,7 +11,7 @@ Reset partition offsets for a consumer group
 Reset the offset for consumers in a consumer group reading from a given topic.
 
 Reset to the earliest or latest offset. Or base the reset on a specific offset value or timestamp.
-You can also choose partitions to reset offsets from
+You can also choose partitions to reset offsets from.
 
 
 ....
@@ -34,7 +34,7 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset absolut
 # reset partition offsets for a consumer group to a timestamp
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset timestamp --value "2016-06-23T09:07:21-07:00"
 
-# reset partition offsets by specifying partitions for a consumer group
+# reset specific partition offsets for a consumer group
 $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --offset latest --topic my-topic --partitions 0,1
 
 ....

--- a/pkg/cmd/kafka/acl/acl.go
+++ b/pkg/cmd/kafka/acl/acl.go
@@ -1,0 +1,24 @@
+package acl
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/list"
+	"github.com/spf13/cobra"
+)
+
+// NewAclCommand creates a new command sub-group for Kafka ACL operations
+func NewAclCommand(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "acl",
+		Short:   f.Localizer.MustLocalize("kafka.acl.cmd.shortDescription"),
+		Long:    f.Localizer.MustLocalize("kafka.acl.cmd.longDescription"),
+		Example: f.Localizer.MustLocalize("kafka.acl.cmd.example"),
+		Args:    cobra.ExactArgs(1),
+	}
+
+	cmd.AddCommand(
+		list.NewListACLCommand(f),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/kafka/acl/list/list.go
+++ b/pkg/cmd/kafka/acl/list/list.go
@@ -1,0 +1,172 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/redhat-developer/app-services-cli/internal/build"
+	"github.com/redhat-developer/app-services-cli/internal/config"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+	"github.com/spf13/cobra"
+
+	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
+)
+
+type options struct {
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     logging.Logger
+	IO         *iostreams.IOStreams
+	localizer  localize.Localizer
+	Context    context.Context
+
+	page    int32
+	size    int32
+	kafkaID string
+	output  string
+}
+
+type permissionsRow struct {
+	Principal   string `json:"principal,omitempty" header:"Principal"`
+	Permission  string `json:"permission,omitempty" header:"permission"`
+	Description string `json:"description,omitempty" header:"description"`
+}
+
+// NewListACLCommand creates a new command to list Kafka ACL rules
+func NewListACLCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		IO:         f.IOStreams,
+		localizer:  f.Localizer,
+		Context:    f.Context,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   f.Localizer.MustLocalize("kafka.acl.list.cmd.shortDescription"),
+		Long:    f.Localizer.MustLocalize("kafka.acl.list.cmd.longDescription"),
+		Example: f.Localizer.MustLocalize("kafka.acl.list.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !cfg.HasKafka() {
+				return opts.localizer.MustLocalizeError("kafka.acl.common.error.noKafkaSelected")
+			}
+
+			opts.kafkaID = cfg.Services.Kafka.ClusterID
+
+			return runList(opts)
+		},
+	}
+
+	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.acl.list.flag.page.description"))
+	cmd.Flags().Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.acl.list.flag.size.description"))
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.acl.list.flag.output.description"))
+
+	return cmd
+}
+
+func runList(opts *options) (err error) {
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	api, kafkaInstance, err := conn.API().KafkaAdmin(opts.kafkaID)
+	if err != nil {
+		return err
+	}
+
+	req := api.AclsApi.GetAcls(opts.Context)
+
+	req.Page(float32(opts.page))
+
+	permissionsData, httpRes, err := req.Execute()
+	if httpRes != nil {
+		defer httpRes.Body.Close()
+	}
+
+	if err != nil {
+		if httpRes == nil {
+			return err
+		}
+
+		operationTmplPair := localize.NewEntry("Operation", "list")
+
+		switch httpRes.StatusCode {
+		case http.StatusUnauthorized:
+			return opts.localizer.MustLocalizeError("kafka.acl.common.error.unauthorized", operationTmplPair)
+		case http.StatusForbidden:
+			return opts.localizer.MustLocalizeError("kafka.acl.common.error.forbidden", operationTmplPair)
+		case http.StatusInternalServerError:
+			return opts.localizer.MustLocalizeError("kafka.acl.common.error.internalServerError")
+		case http.StatusServiceUnavailable:
+			return opts.localizer.MustLocalizeError("kafka.acl.common.error.unableToConnectToKafka", localize.NewEntry("Name", kafkaInstance.GetName()))
+		default:
+			return err
+		}
+	}
+
+	switch opts.output {
+	case dump.EmptyFormat:
+		opts.Logger.Info("")
+		permissions := permissionsData.GetItems()
+		rows := mapPermissionListResultsToTableFormat(permissions, opts.localizer)
+		dump.Table(opts.IO.Out, rows)
+	default:
+		return dump.Formatted(opts.IO.Out, opts.output, permissionsData)
+	}
+
+	return nil
+}
+
+func mapPermissionListResultsToTableFormat(permissions []kafkainstanceclient.AclBinding, localizer localize.Localizer) []permissionsRow {
+
+	rows := make([]permissionsRow, len(permissions))
+
+	for i, p := range permissions {
+
+		description := buildDescription(p.PatternType, localizer)
+		row := permissionsRow{
+			Principal:   formatPrincipal(p.GetPrincipal(), localizer),
+			Permission:  fmt.Sprintf("%s | %s", p.GetPermission(), p.GetOperation()),
+			Description: fmt.Sprintf("%s %s \"%s\"", p.GetResourceType(), description, p.GetResourceName()),
+		}
+		rows[i] = row
+	}
+	return rows
+}
+
+func formatPrincipal(principal string, localizer localize.Localizer) string {
+	s := strings.Split(principal, ":")[1]
+
+	if s == "*" {
+		return localizer.MustLocalize("kafka.acl.list.allAccounts")
+	}
+
+	return s
+}
+
+func buildDescription(patternType kafkainstanceclient.AclPatternType, localizer localize.Localizer) string {
+	if patternType == kafkainstanceclient.ACLPATTERNTYPE_LITERAL {
+		return localizer.MustLocalize("kafka.acl.list.is")
+	}
+
+	return localizer.MustLocalize("kafka.acl.list.startsWith")
+}

--- a/pkg/cmd/kafka/acl/list/list.go
+++ b/pkg/cmd/kafka/acl/list/list.go
@@ -97,6 +97,8 @@ func runList(opts *options) (err error) {
 
 	req.Page(float32(opts.page))
 
+	req.Size(float32(opts.size))
+
 	permissionsData, httpRes, err := req.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()

--- a/pkg/cmd/kafka/acl/list/list.go
+++ b/pkg/cmd/kafka/acl/list/list.go
@@ -95,9 +95,9 @@ func runList(opts *options) (err error) {
 
 	req := api.AclsApi.GetAcls(opts.Context)
 
-	req.Page(float32(opts.page))
+	req = req.Page(float32(opts.page))
 
-	req.Size(float32(opts.size))
+	req = req.Size(float32(opts.size))
 
 	permissionsData, httpRes, err := req.Execute()
 	if httpRes != nil {

--- a/pkg/cmd/kafka/kafka.go
+++ b/pkg/cmd/kafka/kafka.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/describe"
@@ -35,6 +36,7 @@ func NewKafkaCommand(f *factory.Factory) *cobra.Command {
 		topic.NewTopicCommand(f),
 		consumergroup.NewConsumerGroupCommand(f),
 		update.NewUpdateCommand(f),
+		acl.NewAclCommand(f),
 	)
 
 	return cmd

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -1,0 +1,71 @@
+[kafka.acl.cmd.shortDescription]
+one = 'Kafka ACL management for users and service accounts'
+
+[kafka.acl.cmd.longDescription]
+one = '''
+Set of commands that will let you manage resources
+By default, every users and service account have limited access to their Kafka instance (Only DESCRIBE permission is enabled for TOPIC, ACL, and GROUP).
+'''
+
+[kafka.acl.cmd.example]
+one = '''
+
+## List ACL rules for a Kafka instance
+rhoas kafka acl list
+'''
+
+
+[kafka.acl.common.error.unauthorized]
+one = 'you are unauthorized to {{.Operation}} these Kafka ACL rules'
+
+[kafka.acl.common.error.forbidden]
+one = 'you are forbidden to {{.Operation}} this consumer group'
+
+[kafka.acl.common.error.internalServerError]
+one = 'internal server error'
+
+[kafka.acl.common.error.unableToConnectToKafka]
+one = 'unable to connect to Kafka instance "{{.Name}}"'
+
+[kafka.acl.common.error.noKafkaSelected]
+one = 'no Kafka instance is currently selected, run "rhoas kafka use" to set the current instance'
+
+
+
+[kafka.acl.list.cmd.shortDescription]
+one = 'List all Kafka ACL rules.'
+
+[kafka.acl.list.cmd.longDescription]
+one = '''
+This command will display list of Kafka ACL rules
+
+The instances are displayed by default in a table, but can also be displayed as JSON or YAML.
+'''
+
+[kafka.acl.list.cmd.example]
+one = '''
+## Display Kafka ACL rules for the instance
+rhoas kafka acl list
+'''
+
+
+[kafka.acl.list.flag.output.description]
+description = "Description for --output flag"
+one = 'Format in which to display the Kafka ACL rules (choose from: "json", "yml", "yaml")'
+
+[kafka.acl.list.flag.page.description]
+description = 'Description for the --page flag'
+one = 'Current page number for list of Kafka ACL rules'
+
+[kafka.acl.list.flag.size.description]
+description = 'Description for the --size flag'
+one = 'Maximum number of items to be returned per page'
+
+[kafka.acl.list.allAccounts]
+one = 'All accounts'
+
+[kafka.acl.list.is]
+one = 'is'
+
+[kafka.acl.list.startsWith]
+one = 'starts with'

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -3,13 +3,12 @@ one = 'Kafka ACL management for users and service accounts'
 
 [kafka.acl.cmd.longDescription]
 one = '''
-Set of commands that will let you manage resources
+Set of commands that will let you manage Kafka ACLs.
 By default, every users and service account have limited access to their Kafka instance (Only DESCRIBE permission is enabled for TOPIC, ACL, and GROUP).
 '''
 
 [kafka.acl.cmd.example]
 one = '''
-
 ## List ACL rules for a Kafka instance
 rhoas kafka acl list
 '''


### PR DESCRIPTION
This PR adds `rhoas kafka acl list` command to list all the Kafka ACL rules for a given instance.

Closes #1172

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. `rhoas kafka -h` should display `acl` in list of sub commands
2. `rhoas kafka acl list` should display ACL rules for the selected Kafka instance.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [X] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer