### PR TITLE
refactor: added an iso8601 validator library to validate value provided for timestamp input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1
 	github.com/redhat-developer/service-binding-operator v0.9.0
+	github.com/relvacode/iso8601 v1.1.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1 h1:Rm3+MK+F5
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1/go.mod h1:mAGBawK2y/8Qlj34Szdw+3MSniU+JB/A9gbF3gyZ6Yc=
 github.com/redhat-developer/service-binding-operator v0.9.0 h1:CS+eEtzu/PtWuyvYQFQpZXd6ukSuFtN+U0EKKtTsvlA=
 github.com/redhat-developer/service-binding-operator v0.9.0/go.mod h1:D415gZQiz5Q8zyRbmrNrlieb6Xp73oFtCb+nCuTL6GA=
+github.com/relvacode/iso8601 v1.1.0 h1:2nV8sp0eOjpoKQ2vD3xSDygsjAx37NHG2UlZiCkDH4I=
+github.com/relvacode/iso8601 v1.1.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/kafka/consumergroup/validators.go
+++ b/pkg/kafka/consumergroup/validators.go
@@ -1,15 +1,14 @@
 package consumergroup
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
-)
 
-var timestampOffsetRegExp = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2})$`)
+	"github.com/relvacode/iso8601"
+)
 
 type Validator struct {
 	Localizer localize.Localizer
@@ -27,18 +26,16 @@ func (v *Validator) ValidateOffset(offset string) error {
 }
 
 // ValidateOffsetValue validates value for timestamp and absolute offset
-// value for absolute offset should be integer and timestamp should be in format "yyyy-MM-dd'T'HH:mm:ssz"
+// value for absolute offset should be integer and timestamp should be in ISO 8601 format
 func (v *Validator) ValidateOffsetValue(offset string, value string) error {
 	offsetValueTmplPair := localize.NewEntry("Value", value)
 	switch offset {
 	case OffsetTimestamp:
-		matched := timestampOffsetRegExp.MatchString(value)
-		if !matched {
+		if _, parseErr := iso8601.ParseString(value); parseErr != nil {
 			return v.Localizer.MustLocalizeError("kafka.consumerGroup.resetOffset.error.invalidTimestampOffset", offsetValueTmplPair)
 		}
 	case OffsetAbsolute:
 		if _, parseErr := strconv.Atoi(value); parseErr != nil {
-			offsetValueTmplPair := localize.NewEntry("Value", value)
 			return v.Localizer.MustLocalizeError("kafka.consumerGroup.resetOffset.error.invalidAbsoluteOffset", offsetValueTmplPair)
 		}
 	}

--- a/pkg/kafka/consumergroup/validators_test.go
+++ b/pkg/kafka/consumergroup/validators_test.go
@@ -137,10 +137,10 @@ func TestValidateOffsetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Should throw an error when value for timestamp offset is not in format 'yyyy-MM-dd'T'HH:mm:ssz'",
+			name: "Should throw an error when value for timestamp offset is not in ISO 8601 format",
 			args: args{
 				offset: "timestamp",
-				value:  "2016-06-23T09:07:21",
+				value:  "2016-06-23TZ09:07:21",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Closes #1147 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run `rhoas kafka consumer-group reset-offset --id CONSUMER_GROUP --topic TOPIC  --offset absolute --value DATE_TIME_VALUE`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Other: code refactoring

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer