### PR TITLE
feat(kafka acl grant-access): add --all-accounts flag

### DIFF
--- a/.cases/kafka-acl-grant-permissions.sh
+++ b/.cases/kafka-acl-grant-permissions.sh
@@ -44,7 +44,7 @@ rhoas kafka acl grant-access --producer --user test_user --topic-prefix test_
 
 rhoas kafka acl grant-access --producer --user test_user --topic test_topic
 
-rhoas kafka acl grant-access --producer --user all --topic all
+rhoas kafka acl grant-access --producer --all-accounts --topic all
 
 rhoas kafka acl grant-access --consumer --service-account test_prefix --topic-prefix test_ 
 

--- a/docs/commands/rhoas_kafka_acl_grant-access.adoc
+++ b/docs/commands/rhoas_kafka_acl_grant-access.adoc
@@ -47,6 +47,7 @@ rhoas kafka acl grant-access [flags]
 [discrete]
 == Options
 
+      `--all-accounts`::               Set the ACL principal to match all accounts (wildcard). Cannot be used in conjunction with --service-account or --user
       `--consumer`::                   Add ACL rules that grant the specified principal access to consume messages from topics
       `--group` _string_::             Consumer group ID to define ACL rules for
       `--group-prefix` _string_::      Prefix name for groups to be selected

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -108,8 +108,6 @@
 	[kafka.acl.common.startsWith]
 	one = 'starts with'
 
-[kafka.acl.list]
-
 	[kafka.acl.list.cmd.example]
 	one = '''
 	# Display Kafka ACL rules for the Kafka instance


### PR DESCRIPTION
`--all-accounts` flag to grant permissions to all users and service accounts (substitute for `--user "*"` and `--service-account "*"`).

Closes #1197 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. The following command should grant access to all users for consuming messages from topic "my-topic"
```
rhoas kafka acl grant-permissions --consumer --all-accounts --topic my-topic --group my-group
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer