### PR TITLE
fix!: change secret keys in cluster connect

### DIFF
--- a/pkg/cluster/connect.go
+++ b/pkg/cluster/connect.go
@@ -195,8 +195,8 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 			Namespace: namespace,
 		},
 		StringData: map[string]string{
-			"api-id":     serviceAcct.GetClientId(),
-			"api-secret": serviceAcct.GetClientSecret(),
+			"client-id":     serviceAcct.GetClientId(),
+			"client-secret": serviceAcct.GetClientSecret(),
 		},
 	}
 


### PR DESCRIPTION
FYI - we have broken entire service binding integration by changing keys. 
@rkpattnaik780 let's review this PR Monday morning and create release /,hotfix as cluster commands no longer work