### PR TITLE
fix(cluster connect): display service account credentials

### DIFF
--- a/pkg/cluster/connect.go
+++ b/pkg/cluster/connect.go
@@ -208,7 +208,6 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.createSASecret.log.info.createSuccess",
 		localize.NewEntry("Name", createdSecret.Name),
 		localize.NewEntry("ClientID", serviceAcct.GetClientId()),
-		localize.NewEntry("ClientSecret", serviceAcct.GetClientSecret()),
 	))
 
 	return nil

--- a/pkg/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster.en.toml
@@ -292,14 +292,12 @@ one = '''
 Service Account Secret "{{.Name}}" created successfully
 
 Client ID:     {{.ClientID}}
-Client Secret: {{.ClientSecret}}
 
-Make a copy of the client ID and secret to store in a safe place. Credentials won't appear again after closing the terminal.
+Make a copy of the client ID to store in a safe place. Credentials won't appear again after closing the terminal.
 
-Execute the following command to grant access to the service-account using rhoas cli
+Execute the following command to grant access to the service account using rhoas cli:
 
-rhoas kafka acl grant-access --producer --consumer --service-account {{.ClientID}} --topic "*" --group "*"
-
+  $ rhoas kafka acl grant-access --producer --consumer --service-account {{.ClientID}} --topic "*" --group "*"
 '''
 
 [cluster.kubernetes.createTokenSecret.log.info.createFailed]


### PR DESCRIPTION
* Output client id and client secret of generated service account.
* Missing i18n key error

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Execute cluster connect command
```
./rhoas cluster connect --service-type kafka --service-name rama-test-2 
```
2. It should display the command required to grant permissions to the generated service account.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer