### PR TITLE
refactor: use common output flag

### DIFF
--- a/docs/commands/rhoas_kafka_list.adoc
+++ b/docs/commands/rhoas_kafka_list.adoc
@@ -37,7 +37,7 @@ $ rhoas kafka list -o json
 == Options
 
       `--limit` _int_::         The maximum number of Kafka instances to be returned (default 100)
-  `-o`, `--output` _string_::   Format in which to display the Kafka instances (choose from: "json", "yml", "yaml")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
       `--page` _int_::          Display the Kafka instances from the specified page number (default 1)
       `--search` _string_::     Text search to filter the Kafka instances by name, owner, cloud_provider, region and status
 

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -3,9 +3,10 @@ package list
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
-	"strconv"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flags"
@@ -85,7 +86,8 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("kafkas.common.flag.output.description"))
+	flagSet := flagutil.NewFlagSet(cmd, opts.localizer)
+	flagSet.AddOutput(&opts.outputFormat)
 	cmd.Flags().IntVar(&opts.page, "page", int(cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber)), opts.localizer.MustLocalize("kafka.list.flag.page"))
 	cmd.Flags().IntVar(&opts.limit, "limit", 100, opts.localizer.MustLocalize("kafka.list.flag.limit"))
 	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.list.flag.search"))


### PR DESCRIPTION
Replace the custom `output` flag for `kafka list` with a common reusable flag.