### PR TITLE
refactor(kafka):use flag abstraction in kafka commads

### DIFF
--- a/docs/commands/rhoas_kafka_consumer-group_delete.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_delete.adoc
@@ -28,7 +28,7 @@ $ rhoas kafka consumer-group delete --id consumer_group_1
 == Options
 
       `--id` _string_::   The unique ID of the consumer group to delete
-  `-y`, `--yes`::         Skip confirmation to forcibly delete a consumer group
+  `-y`, `--yes`::         Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_consumer-group_describe.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_describe.adoc
@@ -28,7 +28,7 @@ $ rhoas kafka consumer-group describe --id consumer_group_1 -o json
 == Options
 
       `--id` _string_::         The unique ID of the consumer group to view
-  `-o`, `--output` _string_::   Format in which to display the consumer group (choose from: "json", "yml", "yaml")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_consumer-group_list.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_list.adoc
@@ -29,7 +29,7 @@ $ rhoas kafka consumer-group list -o json
 [discrete]
 == Options
 
-  `-o`, `--output` _string_::   Format in which to display the consumer group (choose from: "json", "yml", "yaml")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
       `--page` _int32_::        Current page number for list of consumer groups (default 1)
       `--search` _string_::     Text search to filter consumer groups by ID
       `--size` _int32_::        Maximum number of consumer groups to be returned per page (default 10)

--- a/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
+++ b/docs/commands/rhoas_kafka_consumer-group_reset-offset.adoc
@@ -47,7 +47,7 @@ $ rhoas kafka consumer-group reset-offset --id consumer_group_1 --topic my-topic
       `--partitions` _int32Slice_::   Reset consumer group offsets on specified partitions (comma-separated integers) (default [])
       `--topic` _string_::            Reset consumer group offsets on a specified topic
       `--value` _string_::            Custom offset value (required when offset is "absolute" or "timestamp")
-  `-y`, `--yes`::                     Skip confirmation to forcibly reset the offset for the consumer group
+  `-y`, `--yes`::                     Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_create.adoc
+++ b/docs/commands/rhoas_kafka_create.adoc
@@ -36,7 +36,7 @@ $ rhoas kafka create -o yaml
 == Options
 
       `--name` _string_::       Unique name of the Kafka instance
-  `-o`, `--output` _string_::   Format in which to display the Kafka instance (choose from: "json", "yml", "yaml") (default "json")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
       `--provider` _string_::   Cloud Provider ID
       `--region` _string_::     Cloud Provider Region ID
       `--use`::                 Set the new Kafka instance to the current instance (default true)

--- a/docs/commands/rhoas_kafka_describe.adoc
+++ b/docs/commands/rhoas_kafka_describe.adoc
@@ -45,7 +45,7 @@ $ rhoas kafka describe -o yaml
       `--bootstrap-server`::    If specified, only bootstrap server host of the Kafka instance will be displayed
       `--id` _string_::         Unique ID of the Kafka instance you want to view
       `--name` _string_::       Name of the Kafka instance you want to view
-  `-o`, `--output` _string_::   Format in which to display the Kafka instance (choose from: "json", "yml", "yaml") (default "json")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_topic_create.adoc
+++ b/docs/commands/rhoas_kafka_topic_create.adoc
@@ -32,7 +32,7 @@ $ rhoas kafka topic create --name topic-1
 
       `--cleanup-policy` _string_::   Determines whether log messages are deleted, compacted, or both (default "delete")
       `--name` _string_::             Topic name
-  `-o`, `--output` _string_::         Format in which to display the Kafka topic (choose from: "json", "yml", "yaml") (default "json")
+  `-o`, `--output` _string_::         Specify the output format. Choose from: "json", "yaml", "yml"
       `--partitions` _int32_::        The number of partitions in the topic (default 1)
       `--retention-bytes` _int_::     The maximum total size of a partition log segments before old log segments are deleted to free up space (default -1)
       `--retention-ms` _int_::        The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)

--- a/docs/commands/rhoas_kafka_topic_delete.adoc
+++ b/docs/commands/rhoas_kafka_topic_delete.adoc
@@ -28,7 +28,7 @@ $ rhoas kafka topic delete --name topic-1
 == Options
 
       `--name` _string_::   Topic name
-  `-y`, `--yes`::           Skip confirmation to forcibly delete a topic
+  `-y`, `--yes`::           Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_topic_describe.adoc
+++ b/docs/commands/rhoas_kafka_topic_describe.adoc
@@ -28,7 +28,7 @@ $ rhoas kafka topic describe --name topic-1
 == Options
 
       `--name` _string_::       Format in which to display the Kafka topic (choose from: "json", "yml", "yaml")
-  `-o`, `--output` _string_::   Format in which to display the Kafka topic (choose from: "json", "yml", "yaml") (default "json")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_topic_list.adoc
+++ b/docs/commands/rhoas_kafka_topic_list.adoc
@@ -30,7 +30,7 @@ $ rhoas kafka topic list -o json
 [discrete]
 == Options
 
-  `-o`, `--output` _string_::   Format in which to display the Kafka topic (choose from: "json", "yml", "yaml")
+  `-o`, `--output` _string_::   Specify the output format. Choose from: "json", "yaml", "yml"
       `--page` _int32_::        Current page number for list of topics (default 1)
       `--search` _string_::     Text search to filter the Kafka topics by name
       `--size` _int32_::        Maximum number of items to be returned per page (default 10)

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -39,7 +39,7 @@ $ rhoas kafka update
       `--id` _string_::      Unique ID of the Kafka instance you want to update
       `--name` _string_::    Name of the Kafka instance you want to update
       `--owner` _string_::   ID of the user you want to set as the owner of this Kafka instance
-  `-y`, `--yes`::            Forcibly update the Kafka instance without confirmation
+  `-y`, `--yes`::            Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/kafka/consumergroup/delete/delete.go
+++ b/pkg/cmd/kafka/consumergroup/delete/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
@@ -67,8 +68,10 @@ func NewDeleteConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.consumerGroup.delete.flag.yes.description"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "delete")))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddYes(&opts.skipConfirm)
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "delete")))
 	_ = cmd.MarkFlagRequired("id")
 
 	// flag based completions for ID

--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sort"
 
-	cgutil "github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
+
+	cgutil "github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -88,8 +89,10 @@ func NewDescribeConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.output.description"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "view")))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddOutput(&opts.outputFormat)
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "view")))
 	_ = cmd.MarkFlagRequired("id")
 
 	// flag based completions for ID

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -92,11 +92,13 @@ func NewListConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.output.description"))
-	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.topic.description"))
-	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.search"))
-	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.page"))
-	cmd.Flags().Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.size"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddOutput(&opts.output)
+	flags.StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.topic.description"))
+	flags.StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.search"))
+	flags.Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.page"))
+	flags.Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.consumerGroup.list.flag.size"))
 
 	_ = cmd.RegisterFlagCompletionFunc("topic", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)

--- a/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
+++ b/pkg/cmd/kafka/consumergroup/resetoffset/reset_offset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka/consumergroup"
@@ -92,12 +92,14 @@ func NewResetOffsetConsumerGroupCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.yes"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "reset-offset")))
-	cmd.Flags().StringVar(&opts.value, "value", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.value"))
-	cmd.Flags().StringVar(&opts.offset, "offset", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.offset"))
-	cmd.Flags().StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.topic"))
-	cmd.Flags().Int32SliceVar(&opts.partitions, "partitions", []int32{}, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.partitions"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddYes(&opts.skipConfirm)
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.consumerGroup.common.flag.id.description", localize.NewEntry("Action", "reset-offset")))
+	flags.StringVar(&opts.value, "value", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.value"))
+	flags.StringVar(&opts.offset, "offset", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.offset"))
+	flags.StringVar(&opts.topic, "topic", "", opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.topic"))
+	flags.Int32SliceVar(&opts.partitions, "partitions", []int32{}, opts.localizer.MustLocalize("kafka.consumerGroup.resetOffset.flag.partitions"))
 
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("offset")

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -11,11 +11,12 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/ioutil/spinner"
 
+	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
+
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
-	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
 	"github.com/redhat-developer/app-services-cli/pkg/ams"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
@@ -24,6 +25,7 @@ import (
 	svcstatus "github.com/redhat-developer/app-services-cli/pkg/service/status"
 
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	pkgKafka "github.com/redhat-developer/app-services-cli/pkg/kafka"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
@@ -111,12 +113,14 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.create.flag.name.description"))
-	cmd.Flags().StringVar(&opts.provider, flagutil.FlagProvider, "", opts.localizer.MustLocalize("kafka.create.flag.cloudProvider.description"))
-	cmd.Flags().StringVar(&opts.region, flagutil.FlagRegion, "", opts.localizer.MustLocalize("kafka.create.flag.cloudRegion.description"))
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.common.flag.output.description"))
-	cmd.Flags().BoolVar(&opts.autoUse, "use", true, opts.localizer.MustLocalize("kafka.create.flag.autoUse.description"))
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, opts.localizer.MustLocalize("kafka.create.flag.wait.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.create.flag.name.description"))
+	flags.StringVar(&opts.provider, flagutil.FlagProvider, "", opts.localizer.MustLocalize("kafka.create.flag.cloudProvider.description"))
+	flags.StringVar(&opts.region, flagutil.FlagRegion, "", opts.localizer.MustLocalize("kafka.create.flag.cloudRegion.description"))
+	flags.AddOutput(&opts.outputFormat)
+	flags.BoolVar(&opts.autoUse, "use", true, opts.localizer.MustLocalize("kafka.create.flag.autoUse.description"))
+	flags.BoolVarP(&opts.wait, "wait", "w", false, opts.localizer.MustLocalize("kafka.create.flag.wait.description"))
 
 	_ = cmd.RegisterFlagCompletionFunc(flagutil.FlagProvider, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return kafkacmdutil.GetCloudProviderCompletionValues(f)

--- a/pkg/cmd/kafka/delete/delete.go
+++ b/pkg/cmd/kafka/delete/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -12,14 +12,16 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka"
 
-	"github.com/redhat-developer/app-services-cli/pkg/logging"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
+	"github.com/redhat-developer/app-services-cli/pkg/logging"
+
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
-	"github.com/spf13/cobra"
 )
 
 type options struct {
@@ -80,11 +82,11 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	flagSet := flagutil.NewFlagSet(cmd, opts.localizer)
-	flagSet.AddYes(&opts.skipConfirm)
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
 
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.delete.flag.id"))
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.delete.flag.name"))
+	flags.AddYes(&opts.skipConfirm)
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.delete.flag.id"))
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.delete.flag.name"))
 
 	if err := kafkacmdutil.RegisterNameFlagCompletionFunc(cmd, f); err != nil {
 		opts.Logger.Debug(opts.localizer.MustLocalize("kafka.common.error.load.completions.name.flag"), err)

--- a/pkg/cmd/kafka/describe/describe.go
+++ b/pkg/cmd/kafka/describe/describe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
@@ -13,13 +13,14 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 
+	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
-	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
-	"github.com/spf13/cobra"
 )
 
 type options struct {
@@ -85,10 +86,12 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.common.flag.output.description"))
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.describe.flag.id"))
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.describe.flag.name"))
-	cmd.Flags().BoolVar(&opts.bootstrapServer, "bootstrap-server", false, opts.localizer.MustLocalize("kafka.describe.flag.bootstrapserver"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddOutput(&opts.outputFormat)
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.describe.flag.id"))
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.describe.flag.name"))
+	flags.BoolVar(&opts.bootstrapServer, "bootstrap-server", false, opts.localizer.MustLocalize("kafka.describe.flag.bootstrapserver"))
 
 	if err := kafkacmdutil.RegisterNameFlagCompletionFunc(cmd, f); err != nil {
 		opts.Logger.Debug(opts.localizer.MustLocalize("kafka.common.error.load.completions.name.flag"), err)

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
+
 	cmdFlagUtil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
-	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
@@ -87,12 +88,12 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	flagSet := flagutil.NewFlagSet(cmd, opts.localizer)
-	flagSet.AddOutput(&opts.outputFormat)
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
 
-	cmd.Flags().IntVar(&opts.page, "page", int(cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber)), opts.localizer.MustLocalize("kafka.list.flag.page"))
-	cmd.Flags().IntVar(&opts.limit, "limit", 100, opts.localizer.MustLocalize("kafka.list.flag.limit"))
-	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.list.flag.search"))
+	flags.AddOutput(&opts.outputFormat)
+	flags.IntVar(&opts.page, "page", int(cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber)), opts.localizer.MustLocalize("kafka.list.flag.page"))
+	flags.IntVar(&opts.limit, "limit", 100, opts.localizer.MustLocalize("kafka.list.flag.limit"))
+	flags.StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.list.flag.search"))
 
 	return cmd
 }

--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
@@ -125,12 +125,14 @@ func NewCreateTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.topicName, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
-	cmd.Flags().Int32Var(&opts.partitions, "partitions", 1, opts.localizer.MustLocalize("kafka.topic.common.input.partitions.description"))
-	cmd.Flags().IntVar(&opts.retentionMs, "retention-ms", defaultRetentionPeriodMS, opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
-	cmd.Flags().IntVar(&opts.retentionBytes, "retention-bytes", defaultRetentionSize, opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
-	cmd.Flags().StringVar(&opts.cleanupPolicy, "cleanup-policy", defaultCleanupPolicy, opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.topicName, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
+	flags.Int32Var(&opts.partitions, "partitions", 1, opts.localizer.MustLocalize("kafka.topic.common.input.partitions.description"))
+	flags.IntVar(&opts.retentionMs, "retention-ms", defaultRetentionPeriodMS, opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
+	flags.IntVar(&opts.retentionBytes, "retention-bytes", defaultRetentionSize, opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
+	flags.StringVar(&opts.cleanupPolicy, "cleanup-policy", defaultCleanupPolicy, opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
+	flags.AddOutput(&opts.outputFormat)
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 	flagutil.EnableStaticFlagCompletion(cmd, "cleanup-policy", topicutil.ValidCleanupPolicies)

--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
@@ -74,14 +75,16 @@ func NewDeleteTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.topicName, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.topicName, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
 
 	_ = cmd.MarkFlagRequired("name")
 
 	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
 	})
-	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, opts.localizer.MustLocalize("kafka.topic.delete.flag.yes.description"))
+	flags.AddYes(&opts.force)
 
 	return cmd
 }

--- a/pkg/cmd/kafka/topic/describe/describe.go
+++ b/pkg/cmd/kafka/topic/describe/describe.go
@@ -16,7 +16,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
 
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 
 	"github.com/spf13/cobra"
 )
@@ -78,9 +78,11 @@ func NewDescribeTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
 
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
+	flags.AddOutput(&opts.outputFormat)
+
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.output.description"))
 	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
 	})

--- a/pkg/cmd/kafka/topic/list/list.go
+++ b/pkg/cmd/kafka/topic/list/list.go
@@ -13,7 +13,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 
 	"github.com/spf13/cobra"
 
@@ -104,10 +104,12 @@ func NewListTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.output, "output", "o", "", opts.localizer.MustLocalize("kafka.topic.list.flag.output.description"))
-	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.topic.list.flag.search.description"))
-	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.topic.list.flag.page.description"))
-	cmd.Flags().Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.topic.list.flag.size.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.AddOutput(&opts.output)
+	flags.StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("kafka.topic.list.flag.search.description"))
+	flags.Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("kafka.topic.list.flag.page.description"))
+	flags.Int32VarP(&opts.size, "size", "", cmdutil.ConvertSizeValueToInt32(build.DefaultPageSize), opts.localizer.MustLocalize("kafka.topic.list.flag.size.description"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmd/kafka/topic/update/update.go
+++ b/pkg/cmd/kafka/topic/update/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
-	flagutil "github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil/flagutil"
 	topicutil "github.com/redhat-developer/app-services-cli/pkg/kafka/topic"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/flag"
@@ -149,12 +149,14 @@ func NewUpdateTopicCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.retentionMsStr, "retention-ms", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
-	cmd.Flags().StringVar(&opts.retentionBytesStr, "retention-bytes", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
-	cmd.Flags().StringVar(&opts.cleanupPolicy, "cleanup-policy", "", opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
-	cmd.Flags().StringVar(&opts.partitionsStr, "partitions", "", opts.localizer.MustLocalize("kafka.topic.common.input.partitions.description"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
 
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
+	flags.StringVar(&opts.retentionMsStr, "retention-ms", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionMs.description"))
+	flags.StringVar(&opts.retentionBytesStr, "retention-bytes", "", opts.localizer.MustLocalize("kafka.topic.common.input.retentionBytes.description"))
+	flags.StringVar(&opts.cleanupPolicy, "cleanup-policy", "", opts.localizer.MustLocalize("kafka.topic.common.input.cleanupPolicy.description"))
+	flags.StringVar(&opts.partitionsStr, "partitions", "", opts.localizer.MustLocalize("kafka.topic.common.input.partitions.description"))
+
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
 	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.FilterValidTopicNameArgs(f, toComplete)
 	})

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
+	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/api/kas"
@@ -26,8 +29,6 @@ import (
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
-	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
-	"github.com/spf13/cobra"
 )
 
 type options struct {
@@ -110,10 +111,12 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.update.flag.id"))
-	cmd.Flags().StringVar(&opts.owner, "owner", "", opts.localizer.MustLocalize("kafka.update.flag.owner"))
-	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("kafka.update.flag.yes"))
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.update.flag.name"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.update.flag.id"))
+	flags.StringVar(&opts.owner, "owner", "", opts.localizer.MustLocalize("kafka.update.flag.owner"))
+	flags.AddYes(&opts.skipConfirm)
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.update.flag.name"))
 
 	_ = kafkacmdutil.RegisterNameFlagCompletionFunc(cmd, f)
 	_ = flagutil.RegisterUserCompletionFunc(cmd, "owner", f.Connection)


### PR DESCRIPTION
Replace the use of `cmd.Flags()` with the new flag type 

Closes #1246 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer