### PR TITLE
feat: add wildcard alias for ACL resource name

### DIFF
--- a/docs/commands/rhoas_kafka_acl_delete.adoc
+++ b/docs/commands/rhoas_kafka_acl_delete.adoc
@@ -19,7 +19,7 @@ rhoas kafka acl delete [flags]
 
 ....
 # delete an ACL for user "joe_bloggs" on all topics
-$ rhoas kafka acl delete --operation write --permission allow --topic "*" --user joe_bloggs
+$ rhoas kafka acl delete --operation write --permission allow --topic all --user joe_bloggs
 
 # delete an ACL for a service account
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -228,7 +228,7 @@ func getRequestParams(opts *options) *requestParams {
 	return &requestParams{
 		resourceType: aclutil.GetMappedResourceTypeFilterValue(opts.resourceType),
 		principal:    aclutil.FormatPrincipal(opts.principal),
-		resourceName: opts.resourceName,
+		resourceName: aclutil.GetResourceName(opts.resourceName),
 		patternType:  aclutil.GetMappedPatternTypeFilterValue(opts.patternType),
 		operation:    aclutil.GetMappedOperationFilterValue(opts.operation),
 		permission:   aclutil.GetMappedPermissionTypeFilterValue(opts.permission),

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -240,7 +240,7 @@ one = 'Delete all ACLs from a Kafka instance which match the filter criteria pro
 [kafka.acl.delete.cmd.example]
 one = '''
 # delete an ACL for user "joe_bloggs" on all topics
-$ rhoas kafka acl delete --operation write --permission allow --topic "*" --user joe_bloggs
+$ rhoas kafka acl delete --operation write --permission allow --topic all --user joe_bloggs
 
 # delete an ACL for a service account
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"


### PR DESCRIPTION
This pull request adds "all" as a valid alias for specifying all resources, which is usually an asterisk (*).

## Verification

Run the delete command, passing "all" for any resource type (topic, group, transactional-id). This will be mapped to `*`.

```shell
$ rhoas kafka acl delete --topic all --operation describe-configs --permission allow --all-accounts 
⚠ The following ACLs will be deleted from Kafka instance "enda-dev":

  PRINCIPAL      PERMISSION   OPERATION          DESCRIPTION   
 -------------- ------------ ------------------ -------------- 
  All accounts   ALLOW        DESCRIBE_CONFIGS   TOPIC is "*" 
```