### PR TITLE
fix: remove ACL preview from delete command

### DIFF
--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -9,7 +9,7 @@ import (
 const (
 	ErrorSymbol     = "\u274c"
 	checkMarkSymbol = "\u2714\ufe0f"
-	warningSymbol   = "\u26A0"
+	infoSymbol      = "\u2139"
 )
 
 // Emoji accepts two arguments, emoji sequence code, and fallback string, for the cases when emoji isn't supported.
@@ -21,18 +21,30 @@ func Emoji(emoji string, fallback string) string {
 	return fallback
 }
 
-// SuccessPrefix returns check mark emoji prefix
-func SuccessPrefix() string {
-	return color.Success(Emoji(checkMarkSymbol, ""))
-}
-
 // ErrorPrefix returns cross mark emoji prefix or default "Error:"
 func ErrorPrefix() string {
 	return Emoji(ErrorSymbol, "Error:")
 }
 
-// Warning returns an emoji icon indicating a warning
-// Ref: https://emojipedia.org/warning/
-func Warning() string {
-	return Emoji(warningSymbol, "")
+// SuccessPrefix returns check mark emoji prefix
+func SuccessPrefix() string {
+	emoji := rightPadPrefixIcon(checkMarkSymbol)
+
+	return color.Success(emoji)
+}
+
+// InfoPrefix returns an emoji indicating an info message
+func InfoPrefix() string {
+	emoji := rightPadPrefixIcon(infoSymbol)
+	return color.Info(emoji)
+}
+
+// Add a space after a prefix icon
+func rightPadPrefixIcon(emojiCode string) string {
+	fallback := ""
+	emoji := Emoji(emojiCode, fallback)
+	if emoji != fallback {
+		emoji += " "
+	}
+	return emoji
 }

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -253,7 +253,10 @@ $ rhoas kafka acl delete --operation all --permission any --group "group-1" --al
 one = 'The following ACLs will be deleted from Kafka instance "{{.Name}}":'
 
 [kafka.acl.delete.input.confirmDeleteMessage]
-one = 'Are you sure you want to delete these ACLs?'
+one = 'All ACLs matching the criteria provided will be deleted from the Kafka instance "{{.Name}}". Are you sure you want to proceed?'
+
+[kafka.acl.delete.noACLsDeleted]
+one = 'No ACLs match the specified criteria'
 
 [kafka.acl.delete.successMessage]
 one = 'Deleted {{.Count}} ACL from Kafka instance "{{.Name}}"'


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps

1. Run `acl delete` - it will no longer have the preview of ACLs which would be deleted as this list could be inaccurate.

Example:

```shell
% ./rhoas kafka acl delete --topic "*" --permission allow --operation create --all-accounts 
? All ACLs matching the criteria provided will be deleted from the Kafka instance "enda-dev". Are you sure you want to proceed? Yes

⣽ Deleting ACLs from Kafka instance "enda-dev" 
✔️  Deleted 1 ACL from Kafka instance "enda-dev"
ephelan@ephelan-mac app-services-cli % ./rhoas kafka acl delete --topic "*" --permission allow --operation create --all-accounts -y

⣽ Deleting ACLs from Kafka instance "enda-dev" 
ℹ  Nothing to delete - no ACLs matching that match the criteria specified
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer