### PR TITLE
fix(kafka topic create): erroneous flag validation

### DIFF
--- a/pkg/cmd/kafka/topic/create/create.go
+++ b/pkg/cmd/kafka/topic/create/create.go
@@ -73,8 +73,10 @@ func NewCreateTopicCommand(f *factory.Factory) *cobra.Command {
 				opts.interactive = true
 			}
 
-			if err = flag.ValidateOutput(opts.outputFormat); err != nil {
-				return err
+			if opts.outputFormat != "" {
+				if err = flag.ValidateOutput(opts.outputFormat); err != nil {
+					return err
+				}
 			}
 
 			// check that a valid --cleanup-policy flag value is used

--- a/pkg/cmd/kafka/use/use.go
+++ b/pkg/cmd/kafka/use/use.go
@@ -3,8 +3,10 @@ package use
 import (
 	"context"
 	"fmt"
+
 	"github.com/redhat-developer/app-services-cli/pkg/icon"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/kafka/cmdutil"
@@ -65,8 +67,10 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.use.flag.id"))
-	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.use.flag.name"))
+	flags := flagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.id, "id", "", opts.localizer.MustLocalize("kafka.use.flag.id"))
+	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("kafka.use.flag.name"))
 
 	if err := kafkacmdutil.RegisterNameFlagCompletionFunc(cmd, f); err != nil {
 		opts.Logger.Debug(opts.localizer.MustLocalize("kafka.common.error.load.completions.name.flag"), err)


### PR DESCRIPTION
Quick fix for `rhoas kafka topic create` that wasn't allowing user to create topic with default flag.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. `rhoas kafka topic create --name topic_1`
2. This should successfully create the topic

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer