### PR TITLE
Add `search` flag to `rhoas service-registry list`

### DIFF
--- a/docs/commands/rhoas_service-registry_list.adoc
+++ b/docs/commands/rhoas_service-registry_list.adoc
@@ -32,6 +32,7 @@ rhoas service-registry list
       `--limit` _int32_::       The maximum number of Service Registry instances to be returned (default 100)
   `-o`, `--output` _string_::   Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml")
       `--page` _int32_::        Display the Service Registry instances from the specified page number (default 1)
+      `--search` _string_::     Text search to filter the Service Registry instances by name
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_list.adoc
+++ b/docs/commands/rhoas_service-registry_list.adoc
@@ -32,7 +32,7 @@ rhoas service-registry list
       `--limit` _int32_::       The maximum number of Service Registry instances to be returned (default 100)
   `-o`, `--output` _string_::   Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml")
       `--page` _int32_::        Display the Service Registry instances from the specified page number (default 1)
-      `--search` _string_::     Text search to filter the Service Registry instances by name
+      `--search` _string_::     Text search to filter the Service Registry instances by name or status
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -81,6 +81,7 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
 	cmd.Flags().Int32VarP(&opts.page, "page", "", cmdutil.ConvertPageValueToInt32(build.DefaultPageNumber), opts.localizer.MustLocalize("registry.list.flag.page"))
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, opts.localizer.MustLocalize("registry.list.flag.limit"))
+	cmd.Flags().StringVar(&opts.search, "search", "", opts.localizer.MustLocalize("registry.list.flag.search"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 

--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -158,7 +158,7 @@ func mapResponseItemsToRows(registries *[]srsmgmtv1.Registry, selectedId string)
 
 func buildQuery(search string) string {
 	queryString := fmt.Sprintf(
-		"name=%v",
+		"name like %%%[1]v%% or status like %%%[1]v%%",
 		search,
 	)
 

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -180,7 +180,7 @@ one = 'The maximum number of Service Registry instances to be returned'
 
 [registry.list.flag.search]
 description = 'Description for the --search flag'
-one = 'Text search to filter the Service Registry instances by name'
+one = 'Text search to filter the Service Registry instances by name or status'
 
 [registry.list.log.debug.filteringList]
 description = 'Debug message when filtering the list of Service Registry instances'


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes https://github.com/redhat-developer/app-services-cli/issues/1165

Regarding building the `search` parameter for API call I followed it the same way as `rhoas kafka list` does. I make a like query for all possible fields (`name`, `status`)  in search parameter. Hope that's alright!

### Verification Steps
Run `rhoas service-registry list --search my-registry`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer