### PR TITLE
Upgrade SBO to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.4.0
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1
-	github.com/redhat-developer/service-binding-operator v0.9.0
+	github.com/redhat-developer/service-binding-operator v1.0.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,8 @@ github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1 h1:xRq5X
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1/go.mod h1:Z/gr/snlpsqYg4vftmcx97vCR3qMQJhALGelDHx4pMA=
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1 h1:Rm3+MK+F5rm3GCVbHeNNnDyIEl3gwfC8gKDXAOnH16s=
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.3.1/go.mod h1:mAGBawK2y/8Qlj34Szdw+3MSniU+JB/A9gbF3gyZ6Yc=
-github.com/redhat-developer/service-binding-operator v0.9.0 h1:CS+eEtzu/PtWuyvYQFQpZXd6ukSuFtN+U0EKKtTsvlA=
-github.com/redhat-developer/service-binding-operator v0.9.0/go.mod h1:D415gZQiz5Q8zyRbmrNrlieb6Xp73oFtCb+nCuTL6GA=
+github.com/redhat-developer/service-binding-operator v1.0.0 h1:scogXBufgdNcavyqUKThhpgp0HKmm01Xt6YEV1viE18=
+github.com/redhat-developer/service-binding-operator v1.0.0/go.mod h1:pODWh91lgIyjf2n9ZqWYb1EBrLTmvKnjusKw0eG4vcE=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
Recently SBO [v1.0.0](https://github.com/redhat-developer/service-binding-operator/releases/tag/v1.0.0) has been released.

This PR updates the Go dependency for SBO to the same version `v1.0.0`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Other (please specify): Upgrade Go dependency for SBO

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer