### PR TITLE
refactor: support different resource types and operations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -173,6 +173,25 @@
       ]
     },
     {
+      "name": "Delete Kafka ACLs",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/rhoas",
+      "env": {},
+      "args": [
+        "kafka",
+        "acl",
+        "delete",
+        "--all-accounts",
+        "--topic",
+        "*",
+        "--operation=describe",
+        "--permission=allow",
+        "--yes"
+      ]
+    },
+    {
       "name": "List service accounts (JSON)",
       "type": "go",
       "request": "launch",

--- a/pkg/kafka/aclutil/enums.go
+++ b/pkg/kafka/aclutil/enums.go
@@ -56,11 +56,12 @@ var patternTypeMap = map[string]kafkainstanceclient.AclPatternType{
 	PatternTypePREFIX:  kafkainstanceclient.ACLPATTERNTYPE_PREFIXED,
 }
 
-var resourceTypeOperationKeyMap = map[string]string{
-	ResourceTypeCLUSTER:          "cluster",
-	ResourceTypeTOPIC:            "topic",
-	ResourceTypeGROUP:            "group",
-	ResourceTypeTRANSACTIONAL_ID: "transactional_id",
+// for backwards-compatibility, two resource types are possible
+var resourceTypeOperationKeyMap = map[string][]string{
+	ResourceTypeCLUSTER:          {"cluster", string(kafkainstanceclient.ACLRESOURCETYPE_CLUSTER)},
+	ResourceTypeTOPIC:            {"topic", string(kafkainstanceclient.ACLRESOURCETYPE_TOPIC)},
+	ResourceTypeGROUP:            {"group", string(kafkainstanceclient.ACLRESOURCETYPE_GROUP)},
+	ResourceTypeTRANSACTIONAL_ID: {"transactional_id", string(kafkainstanceclient.ACLRESOURCETYPEFILTER_TRANSACTIONAL_ID)},
 }
 
 var validOperationsResponseMap = map[string]string{
@@ -75,6 +76,16 @@ func GetOperationFilterMap() map[string]kafkainstanceclient.AclOperationFilter {
 
 func GetOperationMap() map[string]kafkainstanceclient.AclOperation {
 	return operationMap
+}
+
+// GetReversedOperationMap returns a map of operations with the SDK enums as the keys
+func GetReversedOperationMap() map[kafkainstanceclient.AclOperation]string {
+	reversedMap := make(map[kafkainstanceclient.AclOperation]string)
+	for k, v := range operationMap {
+		reversedMap[v] = k
+	}
+
+	return reversedMap
 }
 
 // GetMappedOperationFilterValue gets the mapped operation filter value
@@ -137,7 +148,16 @@ func GetMappedResourceTypeFilterValue(resourceType string) kafkainstanceclient.A
 	return resourceTypeFilterMap[resourceType]
 }
 
-// GetResourceTypeFilterKeyMap gets the mappings for ACL operations
-func GetResourceTypeFilterKeyMap() map[string]string {
-	return resourceTypeOperationKeyMap
+// getValidOperationsResponseMap returns a map of the ACL
+// resource operations to the values used in this package
+// eg: "ALTER": "alter"
+func getValidOperationsResponseMap() map[string]string {
+	reverseOperationMap := GetReversedOperationMap()
+	// The API is returning internal Kafka operations, e.g describe_configs
+	// It will change to align with the API enums, eg: DESCRIBE_CONFIGS
+	// This will provide backwards compatibility for both and can be removed in a later release
+	for op, v := range reverseOperationMap {
+		validOperationsResponseMap[string(op)] = string(v)
+	}
+	return validOperationsResponseMap
 }

--- a/pkg/kafka/aclutil/util.go
+++ b/pkg/kafka/aclutil/util.go
@@ -72,10 +72,18 @@ func GetResourceName(resourceName string) string {
 // IsValidResourceOperation checks if the operation is valid, and returns the list valid operations when invalid
 func IsValidResourceOperation(resourceType string, operation string, resourceOperationsMap map[string][]string) (bool, []string) {
 	resourceTypeMapped := resourceTypeOperationKeyMap[resourceType]
-	resourceOperations := resourceOperationsMap[resourceTypeMapped]
+	var resourceOperations []string
+	for _, v := range resourceTypeMapped {
+		var ok bool
+		resourceOperations, ok = resourceOperationsMap[v]
+		if ok {
+			break
+		}
+	}
 
+	validOperationsMap := getValidOperationsResponseMap()
 	for i, op := range resourceOperations {
-		if operationMapped, ok := validOperationsResponseMap[op]; ok {
+		if operationMapped, ok := validOperationsMap[op]; ok {
 			resourceOperations[i] = operationMapped
 		} else {
 			resourceOperations[i] = op


### PR DESCRIPTION
The Admin API will soon introduce a breaking change where the values from /resource-operations will change to match the enums from the aPI. This is a compatibility fix to ensure both scenarios are supported and can be removed in the future.

Backend change: https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/pull/140

### Verification Steps

1. In the delete command, modify `resourceOperations`:

```go
resourceOperations["TOPIC"] = []string{
		"ALL",
	}
delete(resourceOperations, "topic")
```

2. Then, delete the corresponding ACL:

```shell
./rhoas kafka acl delete --operation all --permission allow --topic "*" --all-accounts
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer