### PR TITLE
refactor: check for new version in upstream build only

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       main: ./cmd/rhoas
       ldflags:
         - -s -w -X github.com/redhat-developer/app-services-cli/internal/build.Version={{.Version}}
+        - -s -w -X github.com/redhat-developer/app-services-cli/internal/build.BuildSource="github"
     id: macos
     goos: [darwin]
     goarch: [amd64, arm64]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ REPOSITORY_NAME ?= "app-services-cli"
 TERMS_SPEC_URL ?= "https://console.redhat.com/apps/application-services/terms-conditions-spec.json"
 SSO_REDIRECT_PATH ?= "sso-redhat-callback"
 MAS_SSO_REDIRECT_PATH ?= "mas-sso-callback"
+BUILD_SOURCE ?= "local"
 
 # see pkg/cmdutil/constants.go
 DEFAULT_PAGE_NUMBER ?= "1"
@@ -21,6 +22,7 @@ GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.Def
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageNumber=$(DEFAULT_PAGE_NUMBER) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.SSORedirectPath=$(SSO_REDIRECT_PATH) $(GO_LDFLAGS)
 GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.MASSSORedirectPath=$(MAS_SSO_REDIRECT_PATH) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/redhat-developer/app-services-cli/internal/build.BuildSource=$(BUILD_SOURCE) $(GO_LDFLAGS)
 
 BUILDFLAGS :=
 

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -44,12 +44,12 @@ func main() {
 
 	if err == nil {
 		if debug.Enabled() {
-			build.CheckForUpdate(cmdFactory.Context, cmdFactory.Logger, localizer)
+			build.CheckForUpdate(cmdFactory.Context, build.Version, cmdFactory.Logger, localizer)
 		}
 		return
 	}
 	cmdFactory.Logger.Errorf("%v\n", rootError(err, localizer))
-	build.CheckForUpdate(context.Background(), cmdFactory.Logger, localizer)
+	build.CheckForUpdate(context.Background(), build.Version, cmdFactory.Logger, localizer)
 	os.Exit(1)
 }
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -9,6 +10,12 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
+)
+
+type buildSource string
+
+const (
+	githubBuildSource buildSource = "github"
 )
 
 // Define public variables here which you wish to be configurable at build time
@@ -39,6 +46,9 @@ var (
 
 	// MASSSORedirectPath is the default MAS-SSO redirect path
 	MASSSORedirectPath = "mas-sso-callback"
+
+	// BuildSource is a unique key which indicates the infrastructure on which the binary was built
+	BuildSource = "local"
 )
 
 // Auth Build variables
@@ -68,6 +78,11 @@ func init() {
 // the version currently being used. If so, it logs this information
 // to the console.
 func CheckForUpdate(ctx context.Context, logger logging.Logger, localizer localize.Localizer) {
+	if BuildSource != string(githubBuildSource) {
+		return
+	}
+	fmt.Println("Checking for a new version")
+
 	releases, err := getReleases(ctx)
 	if err != nil {
 		return

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -81,7 +80,6 @@ func CheckForUpdate(ctx context.Context, logger logging.Logger, localizer locali
 	if BuildSource != string(githubBuildSource) {
 		return
 	}
-	fmt.Println("Checking for a new version")
 
 	releases, err := getReleases(ctx)
 	if err != nil {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v39/github"
@@ -76,9 +77,13 @@ func init() {
 // CheckForUpdate checks if there is a newer version of the CLI than
 // the version currently being used. If so, it logs this information
 // to the console.
-func CheckForUpdate(ctx context.Context, logger logging.Logger, localizer localize.Localizer) {
+func CheckForUpdate(ctx context.Context, version string, logger logging.Logger, localizer localize.Localizer) {
 	if BuildSource != string(githubBuildSource) {
 		return
+	}
+	// prefix version with a v to correspond with Git tag
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
 	}
 
 	releases, err := getReleases(ctx)
@@ -97,12 +102,12 @@ func CheckForUpdate(ctx context.Context, logger logging.Logger, localizer locali
 		// create an tag:index map of the releases
 		// the first index (0) is the latest release
 		releaseTagIndexMap[release.GetTagName()] = i
-		if release.GetTagName() == Version {
+		if release.GetTagName() == version {
 			break
 		}
 	}
 
-	currentVersionIndex, ok := releaseTagIndexMap[Version]
+	currentVersionIndex, ok := releaseTagIndexMap[version]
 	if !ok {
 		// the currently used version does not exist as a public release
 		// assume it to be an unpublished or dev release

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -215,7 +215,7 @@ func runLogin(opts *options) (err error) {
 	// debug mode checks this for a version update also.
 	// so we check if is enabled first so as not to print it twice
 	if !debug.Enabled() {
-		build.CheckForUpdate(opts.Context, opts.Logger, opts.localizer)
+		build.CheckForUpdate(opts.Context, build.Version, opts.Logger, opts.localizer)
 	}
 
 	return nil

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -47,7 +47,7 @@ func runCmd(opts *options) (err error) {
 	// debug mode checks this for a version update also.
 	// so we check if is enabled first so as not to print it twice
 	if !debug.Enabled() {
-		build.CheckForUpdate(opts.Context, opts.Logger, opts.localizer)
+		build.CheckForUpdate(opts.Context, build.Version, opts.Logger, opts.localizer)
 	}
 	return nil
 }


### PR DESCRIPTION
This is a stop-gap solution to #1290 by ensuring that version checking and printiing will only occur for the upstream CLI, when the `BuildSource` build variable is "github".
