### PR TITLE
fix: auto-close MAS-SSO redirect page

### DIFF
--- a/pkg/auth/login/mas_sso_redirect_handler.go
+++ b/pkg/auth/login/mas_sso_redirect_handler.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/redhat-developer/app-services-cli/internal/config"
-	"github.com/redhat-developer/app-services-cli/pkg/auth/token"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
@@ -79,19 +78,9 @@ func (h *masRedirectPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userName, ok := token.GetUsername(resp.OAuth2Token.AccessToken)
-	if !ok {
-		userName = "unknown"
-	}
-
-	pageTitle := h.Localizer.MustLocalize("login.redirectPage.title")
-	pageBody := h.Localizer.MustLocalize("login.masRedirectPage.body", localize.NewEntry("Host", h.AuthURL.Host), localize.NewEntry("Username", userName))
-
-	redirectPage := fmt.Sprintf(masSSOredirectHTMLPage, pageTitle, pageTitle, pageBody)
-
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, redirectPage)
+	fmt.Fprint(w, masSSOredirectHTMLPage)
 
 	cfg, err := h.Config.Load()
 	if err != nil {

--- a/pkg/auth/login/static/mas-sso-redirect-page.html
+++ b/pkg/auth/login/static/mas-sso-redirect-page.html
@@ -1,17 +1,3 @@
 <!DOCTYPE html>
 
-<head>
-  <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@4.70.2/patternfly.css">
-  <title>%v</title>
-  <link rel="icon" type="image/x-icon" href="/static/img/favicon.ico"/>
-</head>
-
-<body>
-  <div class="pf-c-empty-state">
-    <div class="pf-c-empty-state__content">
-      <img src="/static/img/logo.svg" alt="Logo" width="180"/>
-      <h1 class="pf-c-title pf-m-lg">%v</h1>
-      <div class="pf-c-empty-state__body">%v</div>
-    </div>
-  </div>
-</body>
+<script>window.close()</script>


### PR DESCRIPTION
Closes #1304 

### Verification Steps

Run `rhoas login`. The second redirect page will auto-close so that you do not see it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer