### PR TITLE
feat(service-registry artifact create): print url to UI

### DIFF
--- a/docs/commands/rhoas_service-registry_artifact_create.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_create.adoc
@@ -63,7 +63,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
   `-o`, `--output` _string_::      Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
   `-t`, `--type` _string_::        Type of artifact. Choose from: AVRO, PROTOBUF, JSON, OPENAPI, ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XSD, XML
       `--version` _string_::       Custom version of the artifact (for example 1.0.0)
-      `--web`::                    Display web URL of the artifact
+      `--web-url`::                Display web URL of the artifact
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_artifact_create.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_create.adoc
@@ -63,7 +63,6 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
   `-o`, `--output` _string_::      Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
   `-t`, `--type` _string_::        Type of artifact. Choose from: AVRO, PROTOBUF, JSON, OPENAPI, ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XSD, XML
       `--version` _string_::       Custom version of the artifact (for example 1.0.0)
-      `--web-url`::                Display web URL of the artifact
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_artifact_create.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_create.adoc
@@ -63,6 +63,7 @@ rhoas service-registry artifact create --type=JSON my-artifact.json
   `-o`, `--output` _string_::      Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
   `-t`, `--type` _string_::        Type of artifact. Choose from: AVRO, PROTOBUF, JSON, OPENAPI, ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XSD, XML
       `--version` _string_::       Custom version of the artifact (for example 1.0.0)
+      `--web`::                    Display web URL of the artifact
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -203,10 +203,10 @@ func printBrowserUrl(opts *options, metadata *registryinstanceclient.ArtifactMet
 	group := metadata.GetGroupId()
 
 	if group == "" {
-		group = "default"
+		group = util.DefaultArtifactGroup
 	}
 
-	registryURL := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", *registry.BrowserUrl, group, metadata.Id, metadata.Version)
+	registryURL := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", registry.GetBrowserUrl(), group, metadata.Id, metadata.Version)
 
 	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.webURL", localize.NewEntry("URL", color.Info(registryURL))))
 	return nil

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -116,7 +116,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", opts.localizer.MustLocalize("artifact.common.type", localize.NewEntry("AllowedTypes", util.GetAllowedArtifactTypeEnumValuesAsString())))
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", opts.localizer.MustLocalize("artifact.common.instance.id"))
 
-	cmd.Flags().BoolVar(&opts.web, "web", false, opts.localizer.MustLocalize("artifact.common.webURL"))
+	cmd.Flags().BoolVar(&opts.web, "web-url", false, opts.localizer.MustLocalize("artifact.common.webURL"))
 
 	flagutil.EnableOutputFlagCompletion(cmd)
 
@@ -185,7 +185,7 @@ func runCreate(opts *options) error {
 	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.created"))
 
 	if opts.web {
-		err = printBrowserUrl(opts, metadata)
+		err = printBrowserUrl(opts, &metadata)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func runCreate(opts *options) error {
 	return dump.Formatted(opts.IO.Out, opts.outputFormat, metadata)
 }
 
-func printBrowserUrl(opts *options, metadata registryinstanceclient.ArtifactMetaData) error {
+func printBrowserUrl(opts *options, metadata *registryinstanceclient.ArtifactMetaData) error {
 	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
 		return err

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"context"
 	"fmt"
+
 	"os"
 
 	"github.com/redhat-developer/app-services-cli/pkg/color"
@@ -41,8 +42,6 @@ type options struct {
 
 	registryID   string
 	outputFormat string
-
-	web bool
 
 	IO         *iostreams.IOStreams
 	Config     config.IConfig
@@ -116,8 +115,6 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.artifactType, "type", "t", "", opts.localizer.MustLocalize("artifact.common.type", localize.NewEntry("AllowedTypes", util.GetAllowedArtifactTypeEnumValuesAsString())))
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", opts.localizer.MustLocalize("artifact.common.instance.id"))
 
-	cmd.Flags().BoolVar(&opts.web, "web-url", false, opts.localizer.MustLocalize("artifact.common.webURL"))
-
 	flagutil.EnableOutputFlagCompletion(cmd)
 
 	_ = cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -184,11 +181,9 @@ func runCreate(opts *options) error {
 	}
 	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.created"))
 
-	if opts.web {
-		err = printBrowserUrl(opts, &metadata)
-		if err != nil {
-			return err
-		}
+	err = printBrowserUrl(opts, &metadata)
+	if err != nil {
+		return err
 	}
 
 	return dump.Formatted(opts.IO.Out, opts.outputFormat, metadata)
@@ -211,9 +206,9 @@ func printBrowserUrl(opts *options, metadata *registryinstanceclient.ArtifactMet
 		group = "default"
 	}
 
-	finalUrl := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", *registry.BrowserUrl, group, metadata.Id, metadata.Version)
+	registryURL := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", *registry.BrowserUrl, group, metadata.Id, metadata.Version)
 
-	opts.Logger.Info("URL:", color.Info(finalUrl))
+	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.webURL", localize.NewEntry("URL", color.Info(registryURL))))
 	return nil
 
 }

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -80,6 +80,9 @@ one = 'Custom description of the artifact'
 [artifact.common.type]
 one = 'Type of artifact. Choose from: {{.AllowedTypes}}'
 
+[artifact.common.webURL]
+one = 'Display web URL of the artifact'
+
 [artifact.common.global.id]
 one = 'Global ID of the artifact'
 

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -81,8 +81,10 @@ one = 'Custom description of the artifact'
 one = 'Type of artifact. Choose from: {{.AllowedTypes}}'
 
 [artifact.common.webURL]
-one = 'Display web URL of the artifact'
-
+one = '''
+You can view or manage this artifact in your browser by accessing:
+{{.URL}}
+'''
 [artifact.common.global.id]
 one = 'Global ID of the artifact'
 


### PR DESCRIPTION
Print URL to UI of the artifact created.

Closes #1321 

![Screenshot from 2021-11-16 20-46-05](https://user-images.githubusercontent.com/23582438/142012333-f0fb6253-382f-4540-ab30-476381027ed6.png)


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create an artifact:
```
./rhoas service-registry artifact create  --file ./artifact.json --name rama-tes35  --type JSON --group schema --artifact-id rama-53909uj
```
It should display the web url for the artifact.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer