### PR TITLE
feat(artifact metadata-get): print url to UI

### DIFF
--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -206,9 +206,13 @@ func printBrowserUrl(opts *options, metadata *registryinstanceclient.ArtifactMet
 		group = util.DefaultArtifactGroup
 	}
 
-	registryURL := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", registry.GetBrowserUrl(), group, metadata.Id, metadata.Version)
+	homeURL, ok := registry.GetBrowserUrlOk()
 
-	opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.webURL", localize.NewEntry("URL", color.Info(registryURL))))
+	if ok {
+		registryURL := fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", *homeURL, group, metadata.Id, metadata.Version)
+		opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.webURL", localize.NewEntry("URL", color.Info(registryURL))))
+	}
+
 	return nil
 
 }

--- a/pkg/cmd/registry/artifact/util/util.go
+++ b/pkg/cmd/registry/artifact/util/util.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	registrymgmtclient "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
+)
+
+// GetArtifactURL takes registry and artifact metadata to build URL to artifact in console
+func GetArtifactURL(registry *registrymgmtclient.Registry, metadata *registryinstanceclient.ArtifactMetaData) (artifactURL string, ok bool) {
+
+	group := metadata.GetGroupId()
+
+	if group == "" {
+		group = DefaultArtifactGroup
+	}
+
+	homeURL, ok := registry.GetBrowserUrlOk()
+
+	if !ok {
+		return "", false
+	}
+
+	artifactURL = fmt.Sprintf("%s/artifacts/%s/%s/versions/%s", *homeURL, group, metadata.Id, metadata.Version)
+
+	return artifactURL, true
+}


### PR DESCRIPTION
`rhoas service-registry artifact metadata-get` should print URL to UI along with the fetched metadata.

Closes #1323

### Verification Steps
1. Run the command to fetch metadata of an artifact.
```
./rhoas service-registry artifact metadata-get --artifact-id <id>
```
The URL to artifact should be printed.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer