### PR TITLE
fix(cluster connect): print access commands separately for services

### DIFF
--- a/docs/commands/rhoas_cluster_connect.adoc
+++ b/docs/commands/rhoas_cluster_connect.adoc
@@ -27,6 +27,10 @@ For example for Kafka service you should execute the following command to grant 
 
   $ rhoas kafka acl grant-access --producer --consumer --service-account your-sa --topic all --group all
 
+Similarly for service registry you should execute the following command:
+
+  $ rhoas service-registry role add --role=DEVELOPER --service-account your-sa
+
 
 
 ....

--- a/pkg/cluster/connect.go
+++ b/pkg/cluster/connect.go
@@ -89,7 +89,7 @@ func (api *KubernetesClusterAPIImpl) ExecuteConnect(connectOpts *v1alpha.Connect
 		return kubeclient.TranslatedKubernetesErrors(api.CommandEnvironment, err)
 	}
 
-	err = api.createServiceAccountSecretIfNeeded(currentNamespace)
+	err = api.createServiceAccountSecretIfNeeded(currentNamespace, currentService)
 	if err != nil {
 		return kubeclient.TranslatedKubernetesErrors(api.CommandEnvironment, err)
 	}
@@ -181,7 +181,7 @@ func (c *KubernetesClusterAPIImpl) createTokenSecretIfNeeded(namespace string, a
 }
 
 // createSecret creates a new secret to store the SASL/PLAIN credentials from the service account
-func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace string) error {
+func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace string, currentService services.RHOASKubernetesService) error {
 	cliOpts := c.CommandEnvironment
 	kClients := c.KubernetesClients
 	ctx := cliOpts.Context
@@ -217,6 +217,8 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 		localize.NewEntry("Name", createdSecret.Name),
 		localize.NewEntry("ClientID", serviceAcct.GetClientId()),
 	))
+
+	currentService.PrintAccessCommands(serviceAcct.GetClientId())
 
 	return nil
 }

--- a/pkg/cluster/connect.go
+++ b/pkg/cluster/connect.go
@@ -89,9 +89,13 @@ func (api *KubernetesClusterAPIImpl) ExecuteConnect(connectOpts *v1alpha.Connect
 		return kubeclient.TranslatedKubernetesErrors(api.CommandEnvironment, err)
 	}
 
-	err = api.createServiceAccountSecretIfNeeded(currentNamespace, currentService)
+	clientID, err := api.createServiceAccountSecretIfNeeded(currentNamespace)
 	if err != nil {
 		return kubeclient.TranslatedKubernetesErrors(api.CommandEnvironment, err)
+	}
+
+	if clientID != "" {
+		currentService.PrintAccessCommands(clientID)
 	}
 
 	err = api.createCustomResource(serviceDetails, currentNamespace)
@@ -181,7 +185,7 @@ func (c *KubernetesClusterAPIImpl) createTokenSecretIfNeeded(namespace string, a
 }
 
 // createSecret creates a new secret to store the SASL/PLAIN credentials from the service account
-func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace string, currentService services.RHOASKubernetesService) error {
+func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace string) (string, error) {
 	cliOpts := c.CommandEnvironment
 	kClients := c.KubernetesClients
 	ctx := cliOpts.Context
@@ -189,12 +193,12 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 	_, err := kClients.Clientset.CoreV1().Secrets(namespace).Get(context.TODO(), constants.ServiceAccountSecretName, metav1.GetOptions{})
 	if err == nil {
 		cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.serviceaccountsecret.log.info.exist"))
-		return nil
+		return "", nil
 	}
 
 	serviceAcct, err := c.createServiceAccount(ctx, cliOpts)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	secret := &apiv1.Secret{
@@ -210,7 +214,7 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 
 	createdSecret, err := kClients.Clientset.CoreV1().Secrets(namespace).Create(cliOpts.Context, secret, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("%v: %w", cliOpts.Localizer.MustLocalize("cluster.kubernetes.serviceaccountsecret.error.createError"), err)
+		return "", fmt.Errorf("%v: %w", cliOpts.Localizer.MustLocalize("cluster.kubernetes.serviceaccountsecret.error.createError"), err)
 	}
 
 	cliOpts.Logger.Info(icon.SuccessPrefix(), cliOpts.Localizer.MustLocalize("cluster.kubernetes.createSASecret.log.info.createSuccess",
@@ -218,9 +222,7 @@ func (c *KubernetesClusterAPIImpl) createServiceAccountSecretIfNeeded(namespace 
 		localize.NewEntry("ClientID", serviceAcct.GetClientId()),
 	))
 
-	currentService.PrintAccessCommands(serviceAcct.GetClientId())
-
-	return nil
+	return serviceAcct.GetClientId(), nil
 }
 
 // createServiceAccount creates a service account

--- a/pkg/cluster/services/custom_connection.go
+++ b/pkg/cluster/services/custom_connection.go
@@ -17,4 +17,7 @@ type RHOASKubernetesService interface {
 
 	// Build Custom Resource representing desired service that should be created
 	BuildServiceDetails(serviceName string, namespace string, ignoreConfigContext bool) (*ServiceDetails, error)
+
+	// Print commands to be executed to grant access to the service
+	PrintAccessCommands(clientID string)
 }

--- a/pkg/cluster/services/kafka.go
+++ b/pkg/cluster/services/kafka.go
@@ -80,6 +80,7 @@ func (s KafkaService) BuildServiceDetails(serviceName string, namespace string, 
 	return &serviceDetails, nil
 }
 
+// Print command to grant service account acccess to the Kafka instance
 func (s KafkaService) PrintAccessCommands(clientID string) {
 	cliOpts := s.CommandEnvironment
 	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printKafkaAccessCommands", localize.NewEntry("ClientID", clientID)))

--- a/pkg/cluster/services/kafka.go
+++ b/pkg/cluster/services/kafka.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/services/resources"
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/v1alpha"
 	"github.com/redhat-developer/app-services-cli/pkg/kafka"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -77,4 +78,9 @@ func (s KafkaService) BuildServiceDetails(serviceName string, namespace string, 
 	}
 
 	return &serviceDetails, nil
+}
+
+func (s KafkaService) PrintAccessCommands(clientID string) {
+	cliOpts := s.CommandEnvironment
+	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printKafkaAccessCommands", localize.NewEntry("ClientID", clientID)))
 }

--- a/pkg/cluster/services/kafka.go
+++ b/pkg/cluster/services/kafka.go
@@ -80,7 +80,7 @@ func (s KafkaService) BuildServiceDetails(serviceName string, namespace string, 
 	return &serviceDetails, nil
 }
 
-// Print command to grant service account acccess to the Kafka instance
+// PrintAccessCommands prints command to grant service account acccess to the Kafka instance
 func (s KafkaService) PrintAccessCommands(clientID string) {
 	cliOpts := s.CommandEnvironment
 	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printKafkaAccessCommands", localize.NewEntry("ClientID", clientID)))

--- a/pkg/cluster/services/service-registry.go
+++ b/pkg/cluster/services/service-registry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/kubeclient"
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/services/resources"
 	"github.com/redhat-developer/app-services-cli/pkg/cluster/v1alpha"
+	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/serviceregistry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -78,4 +79,9 @@ func (s RegistryService) BuildServiceDetails(serviceName string, namespace strin
 	}
 
 	return &serviceDetails, nil
+}
+
+func (s RegistryService) PrintAccessCommands(clientID string) {
+	cliOpts := s.CommandEnvironment
+	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printRegistryAccessCommands", localize.NewEntry("ClientID", clientID)))
 }

--- a/pkg/cluster/services/service-registry.go
+++ b/pkg/cluster/services/service-registry.go
@@ -81,7 +81,7 @@ func (s RegistryService) BuildServiceDetails(serviceName string, namespace strin
 	return &serviceDetails, nil
 }
 
-// Print commands to assign service account roles in the service registry instance
+// PrintAccessCommands prints command to assign service account roles in the service registry instance
 func (s RegistryService) PrintAccessCommands(clientID string) {
 	cliOpts := s.CommandEnvironment
 	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printRegistryAccessCommands", localize.NewEntry("ClientID", clientID)))

--- a/pkg/cluster/services/service-registry.go
+++ b/pkg/cluster/services/service-registry.go
@@ -81,6 +81,7 @@ func (s RegistryService) BuildServiceDetails(serviceName string, namespace strin
 	return &serviceDetails, nil
 }
 
+// Print commands to assign service account roles in the service registry instance
 func (s RegistryService) PrintAccessCommands(clientID string) {
 	cliOpts := s.CommandEnvironment
 	cliOpts.Logger.Info(cliOpts.Localizer.MustLocalize("cluster.kubernetes.printRegistryAccessCommands", localize.NewEntry("ClientID", clientID)))

--- a/pkg/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster.en.toml
@@ -168,6 +168,10 @@ For example for Kafka service you should execute the following command to grant 
 
   $ rhoas kafka acl grant-access --producer --consumer --service-account your-sa --topic all --group all
 
+Similarly for service registry you should execute the following command:
+
+  $ rhoas service-registry role add --role=DEVELOPER --service-account your-sa
+
 '''
 
 [cluster.connect.cmd.example]
@@ -301,11 +305,21 @@ Client ID:     {{.ClientID}}
 Make a copy of the client ID to store in a safe place. Credentials won't appear again after closing the terminal.
 
 You will need to assign permissions to service account in order to use it. 
-For example for Kafka service you should execute the following command to grant access to the service account:
+'''
+
+[cluster.kubernetes.printKafkaAccessCommands]
+one = '''
+For Kafka service you should execute the following command to grant access to the service account:
 
   $ rhoas kafka acl grant-access --producer --consumer --service-account {{.ClientID}} --topic all --group all
 '''
- 
+
+[cluster.kubernetes.printRegistryAccessCommands]
+one = '''
+For service registry you should execute the following command to grant access to the service account:
+
+  $ rhoas service-registry role add --role=DEVELOPER --service-account {{.ClientID}}
+'''
 
 [cluster.kubernetes.createTokenSecret.log.info.createFailed]
 one = 'Creation of the "{{.Name}}" secret failed:'

--- a/pkg/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster.en.toml
@@ -309,14 +309,14 @@ You will need to assign permissions to service account in order to use it.
 
 [cluster.kubernetes.printKafkaAccessCommands]
 one = '''
-For Kafka service you should execute the following command to grant access to the service account:
+You need to separately grant service account access to Kafka by issuing following command 
 
   $ rhoas kafka acl grant-access --producer --consumer --service-account {{.ClientID}} --topic all --group all
 '''
 
 [cluster.kubernetes.printRegistryAccessCommands]
 one = '''
-For service registry you should execute the following command to grant access to the service account:
+You might need to assign non-readonly roles for the service account based on the use case (READ_ONLY by default):
 
   $ rhoas service-registry role add --role=DEVELOPER --service-account {{.ClientID}}
 '''


### PR DESCRIPTION
Display commands required to grant access to the service-account.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Connect a service registry instance with the cluster:
```
rhoas cluster connect --service-type service-registry --namespace default -y
```
It should print command to give access to the the service registry

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer