### PR TITLE
chore: add a self-maintaining help command to Makefile

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -31,8 +31,8 @@ jobs:
           # skip-build-cache: true
           args: --timeout 2m0s  
       - name: Check documentation
-        run: make docs/check
+        run: make check-docs
       - name: Build
         run: make binary
       - name: Unit tests
-        run: make test/unit
+        run: make test

--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - run: make docs/generate-modular-docs
+      - run: make generate-modular-docs
         name: Generate modular-docs
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Generates code based on comments in code. This is primarily used to generate int
 
 If you have the Go extension for VS Code, you can generate test stubs for a file, package or function. See [Go#Test](https://code.visualstudio.com/docs/languages/go#_test)
 
-### `make test/unit`
+### `make test`
 
 Runs unit tests
 
@@ -111,17 +111,11 @@ The CLI documentation output is generated in the `./docs` directory.
 
 ### Generating documentation
 
-Documentation can be generated from the CLI commands.
-
-```shell
-make docs/generate
-```
-
-#### `make docs/generate`
+#### `make generate-docs`
 
 After running the command, the documentation should be generated in AsciiDoc format.
 
-#### `make docs/generate-modular-docs`
+#### `make generate-modular-docs`
 
 After running the command, the `dist` directory will contain the documentation conforming to the modular docs specification.
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ format: ## Clean up code and dependencies
 	@gofmt -w `find . -type f -name '*.go'`
 .PHONY: format
 
-check-docs: docs/generate ## Check whether reference documentation needs to be generated
+check-docs: generate-docs ## Check whether reference documentation needs to be generated
 	./scripts/check-docs.sh
 .PHONY: check-docs
 
@@ -88,7 +88,7 @@ generate-docs: ## Generate command-line reference documentation
 	go run ./cmd/rhoas docs --dir ./docs/commands --file-format adoc
 .PHONY: generate-docs
 
-generate-modular-docs: docs/generate ## Generate modular command-line reference documentation
+generate-modular-docs: generate-docs ## Generate modular command-line reference documentation
 	SRC_DIR=$$(pwd)/docs/commands DEST_DIR=$$(pwd)/dist go run ./cmd/modular-docs
 .PHONY: generate-modular-docs
 


### PR DESCRIPTION
This trick found [in this article](http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html) introspects the Makefile to dynamically create an output for `make help`. 
I've changed some commands to not include a `/` as it did not work for these.

### Verification Steps

Run `make help`