### PR TITLE
refactor(kafka acl): smarter error handlings

### DIFF
--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -94,6 +94,10 @@ func rootError(err error, localizer localize.Localizer) error {
 	if prefix == icon.ErrorSymbol {
 		errMessage = firstCharToUpper(errMessage)
 	}
+
+	if strings.Contains(errMessage, "\n") {
+		return fmt.Errorf("%v %v\n%v", icon.ErrorPrefix(), errMessage, localizer.MustLocalize("common.log.error.verboseModeHint"))
+	}
 	return fmt.Errorf("%v %v. %v", icon.ErrorPrefix(), errMessage, localizer.MustLocalize("common.log.error.verboseModeHint"))
 }
 

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -10,6 +10,7 @@ const (
 	ErrorSymbol     = "\u274c"
 	checkMarkSymbol = "\u2714\ufe0f"
 	infoSymbol      = "\u2139"
+	arrowSymbol     = "\u2192"
 )
 
 // Emoji accepts two arguments, emoji sequence code, and fallback string, for the cases when emoji isn't supported.
@@ -39,12 +40,28 @@ func InfoPrefix() string {
 	return color.Info(emoji)
 }
 
+// ArrowPrefix returns an emoji indicating a bullet point
+func ArrowPrefix() string {
+	emoji := horizontalPadPrefixIcon(arrowSymbol)
+	return color.Error(emoji)
+}
+
 // Add a space after a prefix icon
 func rightPadPrefixIcon(emojiCode string) string {
 	fallback := ""
 	emoji := Emoji(emojiCode, fallback)
 	if emoji != fallback {
 		emoji += " "
+	}
+	return emoji
+}
+
+// Add a space on either side of a prefix icon
+func horizontalPadPrefixIcon(emojiCode string) string {
+	fallback := ""
+	emoji := Emoji(emojiCode, fallback)
+	if emoji != fallback {
+		emoji = " " + emoji + " "
 	}
 	return emoji
 }

--- a/pkg/icon/icon.go
+++ b/pkg/icon/icon.go
@@ -10,7 +10,6 @@ const (
 	ErrorSymbol     = "\u274c"
 	checkMarkSymbol = "\u2714\ufe0f"
 	infoSymbol      = "\u2139"
-	arrowSymbol     = "\u2192"
 )
 
 // Emoji accepts two arguments, emoji sequence code, and fallback string, for the cases when emoji isn't supported.
@@ -40,28 +39,12 @@ func InfoPrefix() string {
 	return color.Info(emoji)
 }
 
-// ArrowPrefix returns an emoji indicating a bullet point
-func ArrowPrefix() string {
-	emoji := horizontalPadPrefixIcon(arrowSymbol)
-	return color.Error(emoji)
-}
-
 // Add a space after a prefix icon
 func rightPadPrefixIcon(emojiCode string) string {
 	fallback := ""
 	emoji := Emoji(emojiCode, fallback)
 	if emoji != fallback {
 		emoji += " "
-	}
-	return emoji
-}
-
-// Add a space on either side of a prefix icon
-func horizontalPadPrefixIcon(emojiCode string) string {
-	fallback := ""
-	emoji := Emoji(emojiCode, fallback)
-	if emoji != fallback {
-		emoji = " " + emoji + " "
 	}
 	return emoji
 }

--- a/pkg/kafka/aclutil/util.go
+++ b/pkg/kafka/aclutil/util.go
@@ -2,6 +2,7 @@ package aclutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -152,4 +153,16 @@ func ValidateAPIError(httpRes *http.Response, localizer localize.Localizer, err 
 	default:
 		return err
 	}
+}
+
+// BuildInstructions accepts a slice of errors and creates a single formatted error object
+func BuildInstructions(errorCollection []error) error {
+
+	errString := "invalid or missing option(s):" + "\n"
+
+	for _, err := range errorCollection {
+		errString += "  " + err.Error() + "\n"
+	}
+
+	return errors.New(errString)
 }

--- a/pkg/kafka/aclutil/util.go
+++ b/pkg/kafka/aclutil/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/redhat-developer/app-services-cli/internal/config"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/color"
 	"github.com/redhat-developer/app-services-cli/pkg/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/logging"
@@ -161,7 +162,7 @@ func BuildInstructions(errorCollection []error) error {
 	errString := "invalid or missing option(s):" + "\n"
 
 	for _, err := range errorCollection {
-		errString += fmt.Sprintf("   * ") + err.Error() + "\n"
+		errString += fmt.Sprintf("   %s ", color.Error("*")) + err.Error() + "\n"
 	}
 
 	return errors.New(errString)

--- a/pkg/kafka/aclutil/util.go
+++ b/pkg/kafka/aclutil/util.go
@@ -161,7 +161,7 @@ func BuildInstructions(errorCollection []error) error {
 	errString := "invalid or missing option(s):" + "\n"
 
 	for _, err := range errorCollection {
-		errString += "  " + err.Error() + "\n"
+		errString += fmt.Sprintf("   * ") + err.Error() + "\n"
 	}
 
 	return errors.New(errString)

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -69,8 +69,14 @@ one = 'Service account client ID used as principal for this operation'
 [kafka.acl.common.flag.operation.description]
 one = 'Set the ACL operation'
 
+[kafka.acl.common.flag.operation.required]
+one = '"--operation" flag is required'
+
 [kafka.acl.common.flag.permission.description]
 one = 'Set the ACL permission'
+
+[kafka.acl.common.flag.permission.required]
+one = '"--permission" flag is required'
 
 [kafka.acl.common.flag.cluster.description]
 one = 'Set the resource type to cluster'


### PR DESCRIPTION
Iterate through all flag options to show every missing flag instead of the immediately missing flag option.

![Screenshot from 2021-11-23 16-28-44](https://user-images.githubusercontent.com/23582438/143012812-5585920a-17f6-4954-b101-7896f4e0d2df.png)

Closes #1229

### Verification Steps
Verification needs different flag combinations to be tried out for the commands:
- `rhoas kafka acl create`
- `rhoas kafka acl delete`
- `rhoas kafka acl grant-access`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer