### PR TITLE
fix(kafka acl): disallow all alias for principal

### DIFF
--- a/pkg/cmd/kafka/acl/admin/admin.go
+++ b/pkg/cmd/kafka/acl/admin/admin.go
@@ -83,7 +83,7 @@ func NewAdminACLCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			// user and service account should not allow wildcard
-			if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard {
+			if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard || userID == aclutil.AllAlias || serviceAccount == aclutil.AllAlias {
 				return opts.localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
 			}
 

--- a/pkg/cmd/kafka/acl/create/create.go
+++ b/pkg/cmd/kafka/acl/create/create.go
@@ -186,7 +186,7 @@ func validateAndSetOpts(opts *aclutil.CrudOptions) error {
 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
 	}
 
-	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard {
+	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard || userID == aclutil.AllAlias || serviceAccount == aclutil.AllAlias {
 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
 	}
 

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -199,7 +199,7 @@ func validateAndSetOpts(opts *aclutil.CrudOptions) error {
 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
 	}
 
-	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard {
+	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard || userID == aclutil.AllAlias || serviceAccount == aclutil.AllAlias {
 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
 	}
 

--- a/pkg/cmd/kafka/acl/grant/grant.go
+++ b/pkg/cmd/kafka/acl/grant/grant.go
@@ -318,7 +318,7 @@ func validateFlagInputCombination(opts *options) error {
 
 	// user and service account can't be along with "--all-accounts" flag
 	if allAccounts && (serviceAccount != "" || userID != "") {
-		return opts.localizer.MustLocalizeError("kafka.acl.grantPermissions.allPrinciapls.error.notAllowed")
+		return opts.localizer.MustLocalizeError("kafka.acl.common.error.allAccountsCannotBeUsedWithUserFlag")
 	}
 
 	// checks if group resource name is provided when operation is not consumer
@@ -351,7 +351,7 @@ func validateFlagInputCombination(opts *options) error {
 	}
 
 	// user and service account should not allow wildcard
-	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard {
+	if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard || userID == aclutil.AllAlias || serviceAccount == aclutil.AllAlias {
 		return opts.localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
 	}
 

--- a/pkg/cmd/kafka/acl/list/list.go
+++ b/pkg/cmd/kafka/acl/list/list.go
@@ -93,7 +93,7 @@ func NewListACLCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			// user and service account should not allow wildcard
-			if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard {
+			if userID == aclutil.Wildcard || serviceAccount == aclutil.Wildcard || userID == aclutil.AllAlias || serviceAccount == aclutil.AllAlias {
 				return opts.localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
 			}
 

--- a/pkg/kafka/aclutil/constants.go
+++ b/pkg/kafka/aclutil/constants.go
@@ -3,6 +3,7 @@ package aclutil
 const (
 	Wildcard     = "*"
 	KafkaCluster = "kafka-cluster"
+	AllAlias     = "all"
 )
 
 const (

--- a/pkg/kafka/aclutil/util.go
+++ b/pkg/kafka/aclutil/util.go
@@ -41,7 +41,7 @@ type CrudOptions struct {
 // When the value of the `--topic`, `--group`, `user` or `service-account` option is one of
 // the keys of this map, it will be replaced by the corresponding value.
 var commonArgAliases = map[string]string{
-	"all": Wildcard,
+	AllAlias: Wildcard,
 }
 
 // ExecuteACLRuleCreate makes request to create an ACL rule

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -94,7 +94,7 @@ one = 'Kafka instance "{{.Name}}" has no ACLs matching the provided filters'
 one = '"--all-accounts" flag cannot be used in conjunction with "--user" or "--service-account" flags'
 
 [kafka.acl.common.error.useAllAccountsFlag]
-one = 'to set a wilcard on the ACL principal, pass "--all-accounts"'
+one = 'to set a wildcard on the ACL principal, pass "--all-accounts"'
 
 [kafka.acl.common.error.serviceAccount404]
 one = 'service account "{{.ClientID}}" does not exist'


### PR DESCRIPTION
Kafka acl commands should restrict user from setting principal value to `all` along with `*`.

Closes #1330 

### Verification Steps
1. Try to run grant-access with user set to all
> rhoas kafka acl grant-access --producer --user all --topic x 
It should throw the error: `to set a wilcard on the ACL principal, pass "--all-accounts".`

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer