### PR TITLE
fix: remove non read only docs for srs

### DIFF
--- a/pkg/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster.en.toml
@@ -316,7 +316,7 @@ You need to separately grant service account access to Kafka by issuing followin
 
 [cluster.kubernetes.printRegistryAccessCommands]
 one = '''
-You need to assign role for the service account:
+You need to assign one of the roles for the service account in order to use it with service registry. For example:
 
   $ rhoas service-registry role add --role=DEVELOPER --service-account {{.ClientID}}
 '''

--- a/pkg/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/localize/locales/en/cmd/cluster.en.toml
@@ -316,7 +316,7 @@ You need to separately grant service account access to Kafka by issuing followin
 
 [cluster.kubernetes.printRegistryAccessCommands]
 one = '''
-You might need to assign non-readonly roles for the service account based on the use case (READ_ONLY by default):
+You need to assign role for the service account:
 
   $ rhoas service-registry role add --role=DEVELOPER --service-account {{.ClientID}}
 '''


### PR DESCRIPTION
Based on https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/issues/168#issuecomment-983023914

Sa for registry will have no permissions by default and it will always require user to execute that command.