### PR TITLE
feat(kafka update): add reauthentication flag

### DIFF
--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -29,7 +29,7 @@ $ rhoas kafka update --name=my-kafka --owner=other-user
 $ rhoas kafka update --owner=other-user
 
 # update the reauthentication configuration of the current Kafka instance
-$ rhoas kafka update --reauthentication true
+$ rhoas kafka update --reauthentication=true
 
 # update the current Kafka instance in interactive mode
 $ rhoas kafka update

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -28,6 +28,9 @@ $ rhoas kafka update --name=my-kafka --owner=other-user
 # update the owner of the current Kafka instance
 $ rhoas kafka update --owner=other-user
 
+# update the reauthentication configuration of the current Kafka instance
+$ rhoas kafka update --reauthentication true
+
 # update the current Kafka instance in interactive mode
 $ rhoas kafka update
 
@@ -36,11 +39,11 @@ $ rhoas kafka update
 [discrete]
 == Options
 
-      `--enable-reauth` _string_::   Enable connection reauthentication for the Kafka instance
-      `--id` _string_::              Unique ID of the Kafka instance you want to update
-      `--name` _string_::            Name of the Kafka instance you want to update
-      `--owner` _string_::           ID of the user you want to set as the owner of this Kafka instance
-  `-y`, `--yes`::                    Skip confirmation of this action 
+      `--id` _string_::                 Unique ID of the Kafka instance you want to update
+      `--name` _string_::               Name of the Kafka instance you want to update
+      `--owner` _string_::              ID of the user you want to set as the owner of this Kafka instance
+      `--reauthentication` _string_::   Enable connection reauthentication for the Kafka instance
+  `-y`, `--yes`::                       Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -36,10 +36,11 @@ $ rhoas kafka update
 [discrete]
 == Options
 
-      `--id` _string_::      Unique ID of the Kafka instance you want to update
-      `--name` _string_::    Name of the Kafka instance you want to update
-      `--owner` _string_::   ID of the user you want to set as the owner of this Kafka instance
-  `-y`, `--yes`::            Skip confirmation of this action 
+      `--enable-reauth` _string_::   Enable connection reauthentication for the Kafka instance
+      `--id` _string_::              Unique ID of the Kafka instance you want to update
+      `--name` _string_::            Name of the Kafka instance you want to update
+      `--owner` _string_::           ID of the user you want to set as the owner of this Kafka instance
+  `-y`, `--yes`::                    Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_kafka_update.adoc
+++ b/docs/commands/rhoas_kafka_update.adoc
@@ -39,11 +39,11 @@ $ rhoas kafka update
 [discrete]
 == Options
 
-      `--id` _string_::                 Unique ID of the Kafka instance you want to update
-      `--name` _string_::               Name of the Kafka instance you want to update
-      `--owner` _string_::              ID of the user you want to set as the owner of this Kafka instance
-      `--reauthentication` _string_::   Enable connection reauthentication for the Kafka instance
-  `-y`, `--yes`::                       Skip confirmation of this action 
+      `--id` _string_::                  Unique ID of the Kafka instance you want to update
+      `--name` _string_::                Name of the Kafka instance you want to update
+      `--owner` _string_::               ID of the user you want to set as the owner of this Kafka instance
+      `--reauthentication` _Tribool_::   Enable connection reauthentication for the Kafka instance
+  `-y`, `--yes`::                        Skip confirmation of this action 
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -216,6 +216,10 @@ func run(opts *options) error {
 		updateSummary,
 	)
 
+	if opts.reauth == "false" {
+		opts.logger.Info(opts.localizer.MustLocalize("kafka.update.reauthentication.disclaimer"))
+	}
+
 	if !opts.skipConfirm {
 		//nolint:govet
 		confirm, err := promptConfirmUpdate(opts)

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -221,10 +220,9 @@ func run(opts *options) error {
 	}
 
 	if !opts.skipConfirm {
-		//nolint:govet
-		confirm, err := promptConfirmUpdate(opts)
-		if err != nil {
-			return err
+		confirm, promptErr := promptConfirmUpdate(opts)
+		if promptErr != nil {
+			return promptErr
 		}
 		if !confirm {
 			opts.logger.Debug("User has chosen to not update Kafka instance")
@@ -248,9 +246,8 @@ func run(opts *options) error {
 	s.Stop()
 
 	if err != nil {
-		opts.logger.Info(opts.localizer.MustLocalize("kafka.update.log.info.updateFailed"))
 		if apiError := kas.GetAPIError(err); apiError != nil {
-			return errors.New(apiError.GetReason())
+			return opts.localizer.MustLocalizeError("kafka.update.log.info.updateFailed", localize.NewEntry("Reason", apiError.GetReason()))
 		}
 		return err
 	}

--- a/pkg/cmd/kafka/update/update.go
+++ b/pkg/cmd/kafka/update/update.go
@@ -244,6 +244,7 @@ func run(opts *options) error {
 	s.Stop()
 
 	if err != nil {
+		opts.logger.Info(opts.localizer.MustLocalize("kafka.update.log.info.updateFailed"))
 		if apiError := kas.GetAPIError(err); apiError != nil {
 			return errors.New(apiError.GetReason())
 		}

--- a/pkg/cmdutil/flagutil/tribool.go
+++ b/pkg/cmdutil/flagutil/tribool.go
@@ -1,0 +1,60 @@
+package flagutil
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	TRIBOOL_TRUE    = "true"
+	TRIBOOL_FALSE   = "false"
+	TRIBOOL_DEFAULT = ""
+)
+
+var validTribools = []string{
+	TRIBOOL_TRUE,
+	TRIBOOL_FALSE,
+	TRIBOOL_DEFAULT,
+}
+
+func isTriboolValid(val string) error {
+	switch Tribool(val) {
+	case TRIBOOL_FALSE, TRIBOOL_TRUE:
+		return nil
+	}
+
+	return errors.New("invalid tribool")
+}
+
+type Tribool string
+
+func (s *Tribool) Set(val string) error {
+	err := isTriboolValid(val)
+	if err != nil {
+		return err
+	}
+	*s = Tribool(val)
+	return nil
+}
+
+func (s *Tribool) Type() string {
+	return "Tribool"
+}
+
+func (s *Tribool) String() string { return string(*s) }
+
+// TriBoolVar defines a tribool flag with specified name, default value, and usage string.
+// The argument p points to a tribool variable in which to store the value of the flag.
+func (fs *FlagSet) TriBoolVar(p *Tribool, name string, value Tribool, usage string) {
+	fs.VarP(newTriBoolValue(value, p), name, "", usage)
+
+	_ = fs.cmd.RegisterFlagCompletionFunc(name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return validTribools, cobra.ShellCompDirectiveNoSpace
+	})
+}
+
+func newTriBoolValue(val Tribool, p *Tribool) *Tribool {
+	*p = Tribool(val)
+	return (*Tribool)(p)
+}

--- a/pkg/cmdutil/flagutil/tribool.go
+++ b/pkg/cmdutil/flagutil/tribool.go
@@ -12,25 +12,29 @@ const (
 	TRIBOOL_DEFAULT = ""
 )
 
-var validTribools = []string{
+// ValidTribools is an array of valid tribool string values
+var ValidTribools = []string{
 	TRIBOOL_TRUE,
 	TRIBOOL_FALSE,
 	TRIBOOL_DEFAULT,
 }
 
-func isTriboolValid(val string) error {
+// IsTriboolValid validates if a string corresponds to a valid tribool value
+func IsTriboolValid(val string) error {
 	switch Tribool(val) {
-	case TRIBOOL_FALSE, TRIBOOL_TRUE:
+	case TRIBOOL_FALSE, TRIBOOL_TRUE, TRIBOOL_DEFAULT:
 		return nil
 	}
 
 	return errors.New("invalid tribool")
 }
 
+// Tribool is a tri-state boolean where extra state corresponds to ""
 type Tribool string
 
+// Set accepts the CLI input as string and assigns it to the tribool variable
 func (s *Tribool) Set(val string) error {
-	err := isTriboolValid(val)
+	err := IsTriboolValid(val)
 	if err != nil {
 		return err
 	}
@@ -38,10 +42,12 @@ func (s *Tribool) Set(val string) error {
 	return nil
 }
 
+// Type returns the type of flag
 func (s *Tribool) Type() string {
 	return "Tribool"
 }
 
+// String returns the tribool as a string
 func (s *Tribool) String() string { return string(*s) }
 
 // TriBoolVar defines a tribool flag with specified name, default value, and usage string.
@@ -50,7 +56,7 @@ func (fs *FlagSet) TriBoolVar(p *Tribool, name string, value Tribool, usage stri
 	fs.VarP(newTriBoolValue(value, p), name, "", usage)
 
 	_ = fs.cmd.RegisterFlagCompletionFunc(name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return validTribools, cobra.ShellCompDirectiveNoSpace
+		return ValidTribools, cobra.ShellCompDirectiveNoSpace
 	})
 }
 

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -80,7 +80,7 @@ one = 'Loading users...'
 one = "Select new owner:"
 
 [kafka.update.input.message.reauthentication]
-one = "Enable connection reauthentication [optional]:"
+one = "Enable connection reauthentication:"
 
 [kafka.update.error.loadUsersError]
 one = 'unable to load users'

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -71,7 +71,7 @@ one = 'Provided values match current Kafka configuration'
 one = 'Kafka instance "{{.Name}}" has been updated. Run "rhoas kafka describe --name {{.Name}}" to view its configuration.'
 
 [kafka.update.log.info.updateFailed]
-one = 'Kafka instance could not be updated.'
+one = 'Kafka instance could not be updated: {{.Reason}}'
 
 [kafka.update.log.info.loadingUsers]
 one = 'Loading users...'

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -50,12 +50,12 @@ one = 'Summary of Proposed Changes'
 
 [kafka.update.reauthentication.disclaimer]
 one = '''
-A suspected incident of credential leak for a Kafka instance with disabled
-reauthentication needs to be handled by disconnecting the clients.
+If a bad actor obtains credentials or service account to Kafka instance that has disabled reauthentication,
+deactivating the user account or service account will not disconnect already established connections.
 
-Options to disconnect client:
-- Use ACLs to prevent unauthorized connections from performing any operation
+Options to disconnect client when reauthentication is disabled:
 - Contact Red Hat support
+- Use ACLs to prevent unauthorized connections from performing any operation
 '''
 
 [kafka.update.confirmDialog.message]

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -20,6 +20,9 @@ $ rhoas kafka update --name=my-kafka --owner=other-user
 # update the owner of the current Kafka instance
 $ rhoas kafka update --owner=other-user
 
+# update the reauthentication configuration of the current Kafka instance
+$ rhoas kafka update --reauthentication true
+
 # update the current Kafka instance in interactive mode
 $ rhoas kafka update
 '''
@@ -36,7 +39,7 @@ one = 'Name of the Kafka instance you want to update'
 description = 'Description for the --owner flag'
 one = 'ID of the user you want to set as the owner of this Kafka instance'
 
-[kafka.update.flag.enableReauth]
+[kafka.update.flag.reauthentication]
 one = 'Enable connection reauthentication for the Kafka instance'
 
 [kafka.update.flag.yes]
@@ -63,7 +66,7 @@ one = 'Loading users...'
 [kafka.update.input.message.selectOwner]
 one = "Select new owner:"
 
-[kafka.update.input.message.enableReauth]
+[kafka.update.input.message.reauthentication]
 one = "Enable connection reauthentication [optional]:"
 
 [kafka.update.error.loadUsersError]

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -21,7 +21,7 @@ $ rhoas kafka update --name=my-kafka --owner=other-user
 $ rhoas kafka update --owner=other-user
 
 # update the reauthentication configuration of the current Kafka instance
-$ rhoas kafka update --reauthentication true
+$ rhoas kafka update --reauthentication=true
 
 # update the current Kafka instance in interactive mode
 $ rhoas kafka update
@@ -54,8 +54,8 @@ If a bad actor obtains credentials or service account to Kafka instance that has
 deactivating the user account or service account will not disconnect already established connections.
 
 Options to disconnect client when reauthentication is disabled:
-- Contact Red Hat support
 - Use ACLs to prevent unauthorized connections from performing any operation
+- Create support case for RHOSAK product
 '''
 
 [kafka.update.confirmDialog.message]
@@ -65,7 +65,7 @@ one = 'Are you sure you want to update the Kafka instance "{{.Name}}"?'
 one = 'Updating Kafka instance "{{.Name}}"...'
 
 [kafka.update.log.info.nothingToUpdate]
-one = 'Nothing to update'
+one = 'Provided values match current Kafka configuration'
 
 [kafka.update.log.info.updateSuccess]
 one = 'Kafka instance "{{.Name}}" has been updated. Run "rhoas kafka describe --name {{.Name}}" to view its configuration.'

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -60,6 +60,9 @@ one = 'Nothing to update'
 [kafka.update.log.info.updateSuccess]
 one = 'Kafka instance "{{.Name}}" has been updated. Run "rhoas kafka describe --name {{.Name}}" to view its configuration.'
 
+[kafka.update.log.info.updateFailed]
+one = 'Kafka instance could not be updated.'
+
 [kafka.update.log.info.loadingUsers]
 one = 'Loading users...'
 

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -36,6 +36,9 @@ one = 'Name of the Kafka instance you want to update'
 description = 'Description for the --owner flag'
 one = 'ID of the user you want to set as the owner of this Kafka instance'
 
+[kafka.update.flag.enableReauth]
+one = 'Enable connection reauthentication for the Kafka instance'
+
 [kafka.update.flag.yes]
 one = 'Forcibly update the Kafka instance without confirmation'
 
@@ -45,11 +48,11 @@ one = 'Summary of Proposed Changes'
 [kafka.update.confirmDialog.message]
 one = 'Are you sure you want to update the Kafka instance "{{.Name}}"?'
 
-[kafka.update.log.info.sameOwnerNoChanges]
-one = 'Nothing to update: user "{{.Owner}}" is already the owner of the Kafka instance "{{.InstanceName}}".'
-
 [kafka.update.log.info.updating]
 one = 'Updating Kafka instance "{{.Name}}"...'
+
+[kafka.update.log.info.nothingToUpdate]
+one = 'Nothing to update'
 
 [kafka.update.log.info.updateSuccess]
 one = 'Kafka instance "{{.Name}}" has been updated. Run "rhoas kafka describe --name {{.Name}}" to view its configuration.'
@@ -59,6 +62,9 @@ one = 'Loading users...'
 
 [kafka.update.input.message.selectOwner]
 one = "Select new owner:"
+
+[kafka.update.input.message.enableReauth]
+one = "Enable connection reauthentication [optional]:"
 
 [kafka.update.error.loadUsersError]
 one = 'unable to load users'

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -50,12 +50,12 @@ one = 'Summary of Proposed Changes'
 
 [kafka.update.reauthentication.disclaimer]
 one = '''
-If a bad actor obtains credentials or service account to Kafka instance that has disabled reauthentication,
+This change can affect your Kafka security if a bad actor obtains credentials or service account to Kafka instance that has disabled reauthentication,
 deactivating the user account or service account will not disconnect already established connections.
 
 Options to disconnect client when reauthentication is disabled:
-- Use ACLs to prevent unauthorized connections from performing any operation
-- Create support case for RHOSAK product
+* Use ACLs to prevent unauthorized connections from performing any operation
+* Create support case for RHOSAK product
 '''
 
 [kafka.update.confirmDialog.message]

--- a/pkg/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/localize/locales/en/cmd/kafka_update.en.toml
@@ -48,6 +48,16 @@ one = 'Forcibly update the Kafka instance without confirmation'
 [kafka.update.summaryTitle]
 one = 'Summary of Proposed Changes'
 
+[kafka.update.reauthentication.disclaimer]
+one = '''
+A suspected incident of credential leak for a Kafka instance with disabled
+reauthentication needs to be handled by disconnecting the clients.
+
+Options to disconnect client:
+- Use ACLs to prevent unauthorized connections from performing any operation
+- Contact Red Hat support
+'''
+
 [kafka.update.confirmDialog.message]
 one = 'Are you sure you want to update the Kafka instance "{{.Name}}"?'
 


### PR DESCRIPTION
Add `--reauthentication` flag to Kafka update

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Set value for "enable_reauthentication" using the `--reauthentication` flag
`rhoas kafka update --reauthentication false`
2. Try running kafka update in interactive mode

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer