### PR TITLE
feat(service-registry): add description flag for create command

### DIFF
--- a/docs/commands/rhoas_service-registry_create.adoc
+++ b/docs/commands/rhoas_service-registry_create.adoc
@@ -22,14 +22,18 @@ rhoas service-registry create [flags]
 ## Create Service Registry instance
 rhoas service-registry create --name myregistry
 
+## Create Service Registry instance with description
+rhoas service-registry create --name myregistry --description "description of instance"
+
 ....
 
 [discrete]
 == Options
 
-      `--name` _string_::       Unique name of the Service Registry instance
-  `-o`, `--output` _string_::   Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
-      `--use`::                 Set the new Service Registry instance to the current instance (default true)
+      `--description` _string_::   User-provided description of the new Service Registry instance
+      `--name` _string_::          Unique name of the Service Registry instance
+  `-o`, `--output` _string_::      Format in which to display the Service Registry instance (choose from: "json", "yml", "yaml") (default "json")
+      `--use`::                    Set the new Service Registry instance to the current instance (default true)
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -174,9 +174,7 @@ func runCreate(opts *options) error {
 		request = request.XRegistryName(opts.name)
 	}
 
-	if opts.description != "" {
-		request = request.XRegistryDescription(opts.description)
-	}
+	request = request.XRegistryDescription(opts.description)
 
 	request = request.Body(specifiedFile)
 	metadata, _, err := request.Execute()

--- a/pkg/cmd/registry/artifact/metadata/set.go
+++ b/pkg/cmd/registry/artifact/metadata/set.go
@@ -166,6 +166,9 @@ func runEditor(currentMetadata *registryinstanceclient.EditableMetaData) (*regis
 	if currentMetadata.Properties == nil {
 		currentMetadata.Properties = &map[string]string{}
 	}
+	if currentMetadata.Description == nil {
+		currentMetadata.Description = new(string)
+	}
 	metadataJson, err := json.MarshalIndent(currentMetadata, "", " ")
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -114,8 +114,11 @@ func runCreate(opts *options) error {
 		}
 	} else {
 		payload = &srsmgmtv1.RegistryCreate{
-			Name:        &opts.name,
-			Description: &opts.description,
+			Name: &opts.name,
+		}
+
+		if opts.description != "" {
+			payload.SetDescription(opts.description)
 		}
 	}
 
@@ -209,8 +212,11 @@ func promptPayload(opts *options) (payload *srsmgmtv1.RegistryCreate, err error)
 	}
 
 	payload = &srsmgmtv1.RegistryCreate{
-		Name:        &answers.Name,
-		Description: &answers.Description,
+		Name: &answers.Name,
+	}
+
+	if answers.Description != "" {
+		payload.SetDescription(answers.Description)
 	}
 
 	return payload, nil

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -201,7 +201,7 @@ func promptPayload(opts *options) (payload *srsmgmtv1.RegistryCreate, err error)
 		return nil, err
 	}
 
-	promptDescription := &survey.Input{
+	promptDescription := &survey.Multiline{
 		Message: opts.localizer.MustLocalize("registry.cmd.create.input.description.message"),
 		Help:    opts.localizer.MustLocalize("registry.cmd.create.input.description.help"),
 	}

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -29,7 +29,8 @@ import (
 )
 
 type options struct {
-	name string
+	name        string
+	description string
 
 	outputFormat string
 	autoUse      bool
@@ -88,6 +89,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 
 	flags.StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("registry.cmd.create.flag.name.description"))
 	flags.StringVarP(&opts.outputFormat, "output", "o", "json", opts.localizer.MustLocalize("registry.cmd.flag.output.description"))
+	flags.StringVar(&opts.description, "description", "", opts.localizer.MustLocalize("registry.cmd.create.flag.description.description"))
 	flags.BoolVar(&opts.autoUse, "use", true, opts.localizer.MustLocalize("registry.cmd.create.flag.use.description"))
 	flags.AddBypassTermsCheck(&opts.bypassTermsCheck)
 
@@ -112,7 +114,8 @@ func runCreate(opts *options) error {
 		}
 	} else {
 		payload = &srsmgmtv1.RegistryCreate{
-			Name: &opts.name,
+			Name:        &opts.name,
+			Description: &opts.description,
 		}
 	}
 
@@ -181,7 +184,8 @@ func promptPayload(opts *options) (payload *srsmgmtv1.RegistryCreate, err error)
 
 	// set type to store the answers from the prompt with defaults
 	answers := struct {
-		Name string
+		Name        string
+		Description string
 	}{}
 
 	promptName := &survey.Input{
@@ -194,8 +198,19 @@ func promptPayload(opts *options) (payload *srsmgmtv1.RegistryCreate, err error)
 		return nil, err
 	}
 
+	promptDescription := &survey.Input{
+		Message: opts.localizer.MustLocalize("registry.cmd.create.input.description.message"),
+		Help:    opts.localizer.MustLocalize("registry.cmd.create.input.description.help"),
+	}
+
+	err = survey.AskOne(promptDescription, &answers.Description)
+	if err != nil {
+		return nil, err
+	}
+
 	payload = &srsmgmtv1.RegistryCreate{
-		Name: &answers.Name,
+		Name:        &answers.Name,
+		Description: &answers.Description,
 	}
 
 	return payload, nil

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -34,6 +34,9 @@ Create a Service Registry instance to store and manage your schema and API artif
 one = '''
 ## Create Service Registry instance
 rhoas service-registry create --name myregistry
+
+## Create Service Registry instance with description
+rhoas service-registry create --name myregistry --description "description of instance"
 '''
 
 [registry.cmd.create.info.successMessage]
@@ -121,6 +124,10 @@ one = 'Name argument is required when not running interactively'
 [registry.cmd.create.flag.use.description]
 one = 'Set the new Service Registry instance to the current instance'
 
+[registry.cmd.create.flag.description.description]
+description = "Description for --description flag"
+one = 'User-provided description of the new Service Registry instance'
+
 [registry.cmd.create.flag.name.description]
 one = 'Unique name of the Service Registry instance'
 
@@ -129,6 +136,12 @@ one = 'Name of Service Registry instance:'
 
 [registry.cmd.create.input.name.help]
 one = 'Name can be any alphanumeric characters'
+
+[registry.cmd.create.input.description.message]
+one = 'Description of Service Registry instance:'
+
+[registry.cmd.create.input.description.help]
+one = 'Description can be any alphanumeric characters'
 
 [registry.cmd.create.error.couldNotUse]
 description = 'Error message when Service Registry instance could not be set to the current instance'

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -132,13 +132,13 @@ one = 'User-provided description of the new Service Registry instance'
 one = 'Unique name of the Service Registry instance'
 
 [registry.cmd.create.input.name.message]
-one = 'Name of Service Registry instance:'
+one = 'Name:'
 
 [registry.cmd.create.input.name.help]
 one = 'Name can be any alphanumeric characters'
 
 [registry.cmd.create.input.description.message]
-one = 'Description of Service Registry instance [optional]:'
+one = 'Description [optional]:'
 
 [registry.cmd.create.input.description.help]
 one = 'Description can be any alphanumeric characters. Leave blank to skip setting this value'

--- a/pkg/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/localize/locales/en/cmd/registry_crud.en.toml
@@ -138,10 +138,10 @@ one = 'Name of Service Registry instance:'
 one = 'Name can be any alphanumeric characters'
 
 [registry.cmd.create.input.description.message]
-one = 'Description of Service Registry instance:'
+one = 'Description of Service Registry instance [optional]:'
 
 [registry.cmd.create.input.description.help]
-one = 'Description can be any alphanumeric characters'
+one = 'Description can be any alphanumeric characters. Leave blank to skip setting this value'
 
 [registry.cmd.create.error.couldNotUse]
 description = 'Error message when Service Registry instance could not be set to the current instance'


### PR DESCRIPTION
Add `--description` flag to `service-registry create` command.

### Verification Steps
1. Try creating a service registry instance with description flag.
```
rhoas service-registry create --name test-instance --description "random description"
```
2. Create a registry instance through interactive mode:
```
rhoas service-registry create
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer