### PR TITLE
feat(service-registry artifact): allow loading artifact from remote URL

### DIFF
--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -5,7 +5,6 @@ import (
 
 	"os"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
 
 	"github.com/redhat-developer/app-services-cli/pkg/color"
@@ -147,9 +146,9 @@ func runCreate(opts *options) error {
 
 	var specifiedFile *os.File
 	if opts.file != "" {
-		if cmdutil.IsURL(opts.file) {
+		if util.IsURL(opts.file) {
 			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.loading.file", localize.NewEntry("FileName", opts.file)))
-			specifiedFile, err = cmdutil.GetContentFromFileURL(opts.file, opts.Context)
+			specifiedFile, err = util.GetContentFromFileURL(opts.Context, opts.file)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/registry/artifact/crud/create/create.go
+++ b/pkg/cmd/registry/artifact/crud/create/create.go
@@ -5,6 +5,7 @@ import (
 
 	"os"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
 
 	"github.com/redhat-developer/app-services-cli/pkg/color"
@@ -146,10 +147,18 @@ func runCreate(opts *options) error {
 
 	var specifiedFile *os.File
 	if opts.file != "" {
-		opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.opening.file", localize.NewEntry("FileName", opts.file)))
-		specifiedFile, err = os.Open(opts.file)
-		if err != nil {
-			return err
+		if cmdutil.IsURL(opts.file) {
+			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.loading.file", localize.NewEntry("FileName", opts.file)))
+			specifiedFile, err = cmdutil.GetContentFromFileURL(opts.file, opts.Context)
+			if err != nil {
+				return err
+			}
+		} else {
+			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.opening.file", localize.NewEntry("FileName", opts.file)))
+			specifiedFile, err = os.Open(opts.file)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.reading.file"))

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
@@ -119,9 +118,9 @@ func runUpdate(opts *options) error {
 
 	var specifiedFile *os.File
 	if opts.file != "" {
-		if cmdutil.IsURL(opts.file) {
+		if util.IsURL(opts.file) {
 			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.loading.file", localize.NewEntry("FileName", opts.file)))
-			specifiedFile, err = cmdutil.GetContentFromFileURL(opts.file, opts.Context)
+			specifiedFile, err = util.GetContentFromFileURL(opts.Context, opts.file)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/registry/artifact/crud/update/update.go
+++ b/pkg/cmd/registry/artifact/crud/update/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/localize"
 
@@ -118,10 +119,18 @@ func runUpdate(opts *options) error {
 
 	var specifiedFile *os.File
 	if opts.file != "" {
-		opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.opening.file", localize.NewEntry("FileName", opts.file)))
-		specifiedFile, err = os.Open(opts.file)
-		if err != nil {
-			return err
+		if cmdutil.IsURL(opts.file) {
+			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.loading.file", localize.NewEntry("FileName", opts.file)))
+			specifiedFile, err = cmdutil.GetContentFromFileURL(opts.file, opts.Context)
+			if err != nil {
+				return err
+			}
+		} else {
+			opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.opening.file", localize.NewEntry("FileName", opts.file)))
+			specifiedFile, err = os.Open(opts.file)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		opts.Logger.Info(opts.localizer.MustLocalize("artifact.common.message.reading.file"))

--- a/pkg/cmd/registry/artifact/util/files.go
+++ b/pkg/cmd/registry/artifact/util/files.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"strings"
 )
 
 func CreateFileFromStdin() (*os.File, error) {
@@ -25,4 +29,52 @@ func CreateFileFromStdin() (*os.File, error) {
 		return nil, err
 	}
 	return specifiedFile, nil
+}
+
+// IsURL accepts a string and determines if it is a URL
+func IsURL(s string) bool {
+	return strings.HasPrefix(s, "http:/") || strings.HasPrefix(s, "https:/")
+}
+
+// GetContentFromFileURL loads file content from the provided URL
+func GetContentFromFileURL(ctx context.Context, url string) (*os.File, error) {
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.DefaultClient
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error loading file: %s", http.StatusText(resp.StatusCode))
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	tmpfile, err := ioutil.TempFile("", "rhoas-std-input")
+	if err != nil {
+		return nil, fmt.Errorf("error initializing temporary file: %w", err)
+	}
+
+	_, err = (*tmpfile).Write(data)
+	if err != nil {
+		return nil, err
+	}
+	_, err = (*tmpfile).Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpfile, nil
 }

--- a/pkg/cmd/registry/artifact/util/files_test.go
+++ b/pkg/cmd/registry/artifact/util/files_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestIsURL(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Should return true for url starting with https",
+			args: args{
+				path: "https://bu98.serviceregistry-stage.rhcloud.com/t/8ecff228-1ffe-4cf5-b38b-55223885ee00/apis/registry/v2",
+			},
+			want: true,
+		},
+		{
+			name: "Should return true for url starting with http",
+			args: args{
+				path: "http://localhost:8082/",
+			},
+			want: true,
+		},
+		{
+			name: "Should return false for regular file path",
+			args: args{
+				path: "./schema/artifact.json",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsURL(tt.args.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IsURL(%v) = %v, want %v", tt.args.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetContentFromFileURL(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Should load file content from valid url",
+			args: args{
+				path: "https://raw.githubusercontent.com/bolcom/avro-schema-viewer/master/docs/assets/avsc/1.0/schema.avsc",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should throw error if URL is not found",
+			args: args{
+				path: "https://test-123-test-404.com/test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should throw error if argument is not a URL",
+			args: args{
+				path: "./schema/artifact.json",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := GetContentFromFileURL(context.TODO(), tt.args.path); (err != nil) != tt.wantErr {
+				t.Errorf("GetContentFromFileURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -1,14 +1,8 @@
 package cmdutil
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
 	"strconv"
-	"strings"
 )
 
 func ConvertPageValueToInt32(s string) int32 {
@@ -43,55 +37,4 @@ func StringSliceToListStringWithQuotes(validOptions []string) string {
 		}
 	}
 	return listF
-}
-
-// IsURL accepts a string and determines if it is a URL
-func IsURL(s string) bool {
-	return strings.HasPrefix(s, "http:/") || strings.HasPrefix(s, "https:/")
-}
-
-// GetContentFromFileURL loads file content from the provided URL
-func GetContentFromFileURL(url string, ctx context.Context) (*os.File, error) {
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	client := http.DefaultClient
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error loading file: %s", http.StatusText(resp.StatusCode))
-	}
-
-	respbody := resp.Body
-
-	defer resp.Body.Close()
-
-	tmpfile, err := ioutil.TempFile("", "rhoas_file-*")
-	if err != nil {
-		return nil, fmt.Errorf("error initializing temporary file: %w", err)
-	}
-
-	defer func() {
-		_ = tmpfile.Close()
-		_ = os.Remove(tmpfile.Name())
-	}()
-
-	_, err = io.Copy(tmpfile, respbody)
-	if err != nil {
-		return nil, err
-	}
-
-	specifiedFile, err := os.Open(tmpfile.Name())
-	if err != nil {
-		return nil, err
-	}
-
-	return specifiedFile, nil
 }

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -1,8 +1,14 @@
 package cmdutil
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
 	"strconv"
+	"strings"
 )
 
 func ConvertPageValueToInt32(s string) int32 {
@@ -37,4 +43,55 @@ func StringSliceToListStringWithQuotes(validOptions []string) string {
 		}
 	}
 	return listF
+}
+
+// IsURL accepts a string and determines if it is a URL
+func IsURL(s string) bool {
+	return strings.HasPrefix(s, "http:/") || strings.HasPrefix(s, "https:/")
+}
+
+// GetContentFromFileURL loads file content from the provided URL
+func GetContentFromFileURL(url string, ctx context.Context) (*os.File, error) {
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.DefaultClient
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error loading file: %s", http.StatusText(resp.StatusCode))
+	}
+
+	respbody := resp.Body
+
+	defer resp.Body.Close()
+
+	tmpfile, err := ioutil.TempFile("", "rhoas_file-*")
+	if err != nil {
+		return nil, fmt.Errorf("error initializing temporary file: %w", err)
+	}
+
+	defer func() {
+		_ = tmpfile.Close()
+		_ = os.Remove(tmpfile.Name())
+	}()
+
+	_, err = io.Copy(tmpfile, respbody)
+	if err != nil {
+		return nil, err
+	}
+
+	specifiedFile, err := os.Open(tmpfile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return specifiedFile, nil
 }

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -106,6 +106,9 @@ one = 'Using {{.DefaultArtifactGroup}} artifacts group.'
 [artifact.common.message.opening.file]
 one = 'Opening file: {{.FileName}}'
 
+[artifact.common.message.loading.file]
+one = 'Loading file from url: {{.FileName}}'
+
 [artifact.common.message.file.location]
 one = 'Location of the output file'
 


### PR DESCRIPTION
It should be possible to create/update artifacts using remote URLs.

### Verification Steps
1. Pass url as value for `--file` while creating an artifact.
```
rhoas service-registry artifact create --type OPENAPI --file "https://raw.githubusercontent.com/bolcom/avro-schema-viewer/master/docs/assets/avsc/1.0/schema.avsc" --artifact-id foo_id
```
2. Pass url as value for `--file` to update an artifact.
```
rhoas service-registry artifact update --artifact-id foo_id --group DEFAULT --file "https://raw.githubusercontent.com/bolcom/avro-schema-viewer/master/docs/assets/avsc/1.0/schema.avsc"
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer