### PR TITLE
Enable command collections

### DIFF
--- a/pkg/localize/locales/en/common.en.toml
+++ b/pkg/localize/locales/en/common.en.toml
@@ -14,9 +14,9 @@ one = 'A new version of rhoas is available:'
 one = 'Run the command in verbose mode using the -v flag to see more information'
 
 [common.telemetry.consent]
-one = '''Help us to improve RHOAS cli by allowing it to collect annonymous usage data. 
-Read about our privacy statement: https://developers.redhat.com/article/tool-data-collection 
-You can also disable telemetry by using RHOAS_TELEMETRY=false environment variable
+one = '''Help us to improve RHOAS CLI by allowing it to collect anonymous usage data. 
+Read our Telemetry data collection notice: https://developers.redhat.com/article/tool-data-collection 
+You can also disable telemetry by setting the "RHOAS_TELEMETRY" environment variable to false.
 '''
 
 [common.telemetry.question]

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -43,12 +43,7 @@ func CreateTelemetry(f *factory.Factory) (*Telemetry, error) {
 func (t *Telemetry) Init() error {
 	// The env variable with telemetry enablement
 	envVarEnablement := os.Getenv(ControlTelemetryEnv)
-	// Temporary - disable telemetry unless environment var is created
-	if envVarEnablement == "" {
-		t.enabled = false
-		return nil
-	}
-	// End of temporary change
+
 	if envVarEnablement != "" {
 		enabled, err := strconv.ParseBool(envVarEnablement)
 		if err != nil {


### PR DESCRIPTION
## Enable telemetry for RHOAS 

Telemetry was disabled this change removes temporary 

This change requires release both upstream and downstream


## Verification happy path

1. Download official build for that PR: https://github.com/redhat-developer/app-services-cli/releases/tag/v0.36.0-dev1
2. Execute any command (you should be asked for telemetry consent)
3. Review usage in the woopra (ping me if you do not have access)

## Disabled access

Verify if env var disables and enables telemetry:
1. RHOAS_TELEMETRY=false rhoas status
2. RHOAS_TELEMETRY=true
3. RHOASCONFIG=/tmp/test.json rhoas kafka list


## Verify programatic access:
1. wget https://gist.githubusercontent.com/wtrocki/aba66607aba5dcbddf234cafcd0aa4e1/raw/249425b98cad25dfdb354ab6ef7e6a526b8af46d/rhoasStatus.js

2. Execute "node [rhoasStatus.js](https://gist.github.com/wtrocki/aba66607aba5dcbddf234cafcd0aa4e1)"

stdout:
  Service Registry
  ------------------------------------------------------------------------------------------------------
  ID:                    912ae7a0-abea-4adf-875c-3e71b1cad21b
  Name:                  tes3
  Status:                ready
  Registry URL:        