### PR TITLE
feat(artifact list): add flags to filter result

### DIFF
--- a/docs/commands/rhoas_service-registry_artifact_list.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_list.adoc
@@ -30,8 +30,8 @@ rhoas service-registry artifact list --page=2 --limit=10
 ## List all artifacts for the "default" artifact group with name containing "sample"
 rhoas service-registry artifact list --name sample
 
-## List all artifacts for the "default" artifact group having label "my-label"
-rhoas service-registry artifact list --label "my-label"
+## List all artifacts for the "default" artifact group having labels "my-label" and "sample"
+rhoas service-registry artifact list --label "my-label" --labels "sample"
 
 ## List all artifacts for the "default" artifact group with description containing "sample"
 rhoas service-registry artifact list --description sample
@@ -41,15 +41,15 @@ rhoas service-registry artifact list --description sample
 [discrete]
 == Options
 
-      `--description` _string_::       Text search to filter artifacts by description
-  `-g`, `--group` _string_::           Artifact group (default "default")
-      `--instance-id` _string_::       ID of the Service Registry instance to be used. By default, uses the currently selected instance
-      `--labels` _stringArray_::       Text search to filter artifacts by labels
-      `--limit` _int32_::              Page limit (default 100)
-      `--name` _string_::              Text search to filter artifacts by topic name
-  `-o`, `--output` _string_::          Output format (json, yaml, yml)
-      `--page` _int32_::               Page number (default 1)
-      `--properties` _stringArray_::   Text search to filter artifacts by properties (separate each name/value pair using a colon)
+      `--description` _string_::     Text search to filter artifacts by description
+  `-g`, `--group` _string_::         Artifact group (default "default")
+      `--instance-id` _string_::     ID of the Service Registry instance to be used. By default, uses the currently selected instance
+      `--label` _stringArray_::      Text search to filter artifacts by labels
+      `--limit` _int32_::            Page limit (default 100)
+      `--name` _string_::            Text search to filter artifacts by topic name
+  `-o`, `--output` _string_::        Output format (json, yaml, yml)
+      `--page` _int32_::             Page number (default 1)
+      `--property` _stringArray_::   Text search to filter artifacts by properties (separate each name/value pair using a colon)
 
 [discrete]
 == Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_artifact_list.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_list.adoc
@@ -46,7 +46,7 @@ rhoas service-registry artifact list --description sample
       `--instance-id` _string_::     ID of the Service Registry instance to be used. By default, uses the currently selected instance
       `--label` _stringArray_::      Text search to filter artifacts by labels
       `--limit` _int32_::            Page limit (default 100)
-      `--name` _string_::            Text search to filter artifacts by topic name
+      `--name` _string_::            Text search to filter artifacts by name
   `-o`, `--output` _string_::        Output format (json, yaml, yml)
       `--page` _int32_::             Page number (default 1)
       `--property` _stringArray_::   Text search to filter artifacts by properties (separate each name/value pair using a colon)

--- a/docs/commands/rhoas_service-registry_artifact_list.adoc
+++ b/docs/commands/rhoas_service-registry_artifact_list.adoc
@@ -27,16 +27,29 @@ rhoas service-registry artifact list --group=my-group
 ## List all artifacts with limit and group
 rhoas service-registry artifact list --page=2 --limit=10
 
+## List all artifacts for the "default" artifact group with name containing "sample"
+rhoas service-registry artifact list --name sample
+
+## List all artifacts for the "default" artifact group having label "my-label"
+rhoas service-registry artifact list --label "my-label"
+
+## List all artifacts for the "default" artifact group with description containing "sample"
+rhoas service-registry artifact list --description sample
+
 ....
 
 [discrete]
 == Options
 
-  `-g`, `--group` _string_::       Artifact group (default "default")
-      `--instance-id` _string_::   ID of the Service Registry instance to be used. By default, uses the currently selected instance
-      `--limit` _int32_::          Page limit (default 100)
-  `-o`, `--output` _string_::      Output format (json, yaml, yml)
-      `--page` _int32_::           Page number (default 1)
+      `--description` _string_::       Text search to filter artifacts by description
+  `-g`, `--group` _string_::           Artifact group (default "default")
+      `--instance-id` _string_::       ID of the Service Registry instance to be used. By default, uses the currently selected instance
+      `--labels` _stringArray_::       Text search to filter artifacts by labels
+      `--limit` _int32_::              Page limit (default 100)
+      `--name` _string_::              Text search to filter artifacts by topic name
+  `-o`, `--output` _string_::          Output format (json, yaml, yml)
+      `--page` _int32_::               Page number (default 1)
+      `--properties` _stringArray_::   Text search to filter artifacts by properties (separate each name/value pair using a colon)
 
 [discrete]
 == Options inherited from parent commands

--- a/pkg/cmd/registry/artifact/crud/list/list.go
+++ b/pkg/cmd/registry/artifact/crud/list/list.go
@@ -110,9 +110,9 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().Int32VarP(&opts.limit, "limit", "", 100, opts.localizer.MustLocalize("artifact.common.page.limit"))
 
 	cmd.Flags().StringVar(&opts.name, "name", "", opts.localizer.MustLocalize("artifact.cmd.list.flag.name.description"))
-	cmd.Flags().StringArrayVar(&opts.labels, "labels", []string{}, opts.localizer.MustLocalize("artifact.cmd.list.flag.labels.description"))
+	cmd.Flags().StringArrayVar(&opts.labels, "label", []string{}, opts.localizer.MustLocalize("artifact.cmd.list.flag.labels.description"))
 	cmd.Flags().StringVar(&opts.description, "description", "", opts.localizer.MustLocalize("artifact.cmd.list.flag.description.description"))
-	cmd.Flags().StringArrayVar(&opts.properties, "properties", []string{}, opts.localizer.MustLocalize("artifact.cmd.list.flag.properties.description"))
+	cmd.Flags().StringArrayVar(&opts.properties, "property", []string{}, opts.localizer.MustLocalize("artifact.cmd.list.flag.properties.description"))
 
 	cmd.Flags().StringVar(&opts.registryID, "instance-id", "", opts.localizer.MustLocalize("artifact.common.instance.id"))
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", opts.localizer.MustLocalize("artifact.common.message.output.format"))

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -113,7 +113,7 @@ one = 'Location of the output file'
 one = 'Output format (json, yaml, yml)'
 
 [artifact.common.message.no.artifact.available.for.group.and.registry]
-one = 'No artifacts available for {{.Group}} group and registry ID {{.Registry}}'
+one = 'No artifacts found for {{.Group}} group and registry ID {{.Registry}}'
 
 [artifact.common.message.reading.file]
 one = 'Reading file content from standard input'
@@ -307,8 +307,8 @@ rhoas service-registry artifact list --page=2 --limit=10
 ## List all artifacts for the "default" artifact group with name containing "sample"
 rhoas service-registry artifact list --name sample
 
-## List all artifacts for the "default" artifact group having label "my-label"
-rhoas service-registry artifact list --label "my-label"
+## List all artifacts for the "default" artifact group having labels "my-label" and "sample"
+rhoas service-registry artifact list --label "my-label" --labels "sample"
 
 ## List all artifacts for the "default" artifact group with description containing "sample"
 rhoas service-registry artifact list --description sample

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -487,7 +487,7 @@ one = 'Successfully updated artifact state'
 one = 'invalid artifact state. Please use one of following values: {{.AllowedTypes}}'
 
 [artifact.cmd.list.flag.name.description]
-one = 'Text search to filter artifacts by topic name'
+one = 'Text search to filter artifacts by name'
 
 [artifact.cmd.list.flag.labels.description]
 one = 'Text search to filter artifacts by labels'

--- a/pkg/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/localize/locales/en/cmd/artifact.en.toml
@@ -303,6 +303,15 @@ rhoas service-registry artifact list --group=my-group
 
 ## List all artifacts with limit and group
 rhoas service-registry artifact list --page=2 --limit=10
+
+## List all artifacts for the "default" artifact group with name containing "sample"
+rhoas service-registry artifact list --name sample
+
+## List all artifacts for the "default" artifact group having label "my-label"
+rhoas service-registry artifact list --label "my-label"
+
+## List all artifacts for the "default" artifact group with description containing "sample"
+rhoas service-registry artifact list --description sample
 '''
 
 [artifact.cmd.update.description.short]
@@ -476,3 +485,15 @@ one = 'Successfully updated artifact state'
 
 [artifact.cmd.state.error.invalidArtifactState]
 one = 'invalid artifact state. Please use one of following values: {{.AllowedTypes}}'
+
+[artifact.cmd.list.flag.name.description]
+one = 'Text search to filter artifacts by topic name'
+
+[artifact.cmd.list.flag.labels.description]
+one = 'Text search to filter artifacts by labels'
+
+[artifact.cmd.list.flag.description.description]
+one = 'Text search to filter artifacts by description'
+
+[artifact.cmd.list.flag.properties.description]
+one = 'Text search to filter artifacts by properties (separate each name/value pair using a colon)'


### PR DESCRIPTION
Added `--name`, `--labels`, `--description` and `--properties` flag to `service-registry artifact list` command to enable filtering the artifacts.

### Verification Steps
Run the following commands by adjusting the parameters in accordance to the artifact list:
```
## List all artifacts for the "default" artifact group with name containing "sample"
rhoas service-registry artifact list --name sample

## List all artifacts for the "default" artifact group having label "my-label"
rhoas service-registry artifact list --label "my-label"

## List all artifacts for the "default" artifact group with description containing "sample"
rhoas service-registry artifact list --description sample
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer