### PR TITLE
WIP: dynamic cloud region completion support

### DIFF
--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -128,6 +128,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		return kafkacmdutil.GetCloudProviderCompletionValues(f)
 	})
 
+	_ = cmd.RegisterFlagCompletionFunc(flagutil.FlagRegion, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return kafkacmdutil.GetCloudProviderRegionCompletionValues(f, opts.provider)
+	})
+
 	cmdFlagUtil.EnableOutputFlagCompletion(cmd)
 
 	return cmd

--- a/pkg/kafka/cmdutil/util.go
+++ b/pkg/kafka/cmdutil/util.go
@@ -59,6 +59,34 @@ func GetCloudProviderCompletionValues(f *factory.Factory) (validProviders []stri
 	return validProviders, directive
 }
 
+// GetCloudProviderCompletionValues returns the list of region IDs for a particular cloud provider
+func GetCloudProviderRegionCompletionValues(f *factory.Factory, providerID string) (validRegions []string, directive cobra.ShellCompDirective) {
+	validRegions = []string{}
+	directive = cobra.ShellCompDirectiveNoSpace
+
+	if providerID == "" {
+		return
+	}
+
+	conn, err := f.Connection(connection.DefaultConfigSkipMasAuth)
+	if err != nil {
+		return validRegions, directive
+	}
+
+	cloudProviderResponse, _, err := conn.API().
+		Kafka().
+		GetCloudProviderRegions(f.Context, providerID).
+		Execute()
+	if err != nil {
+		return validRegions, directive
+	}
+
+	cloudProviders := cloudProviderResponse.GetItems()
+	validRegions = GetEnabledCloudRegionIDs(cloudProviders)
+
+	return validRegions, directive
+}
+
 // GetEnabledCloudProviderNames returns a list of cloud provider names from the enabled cloud providers
 func GetEnabledCloudProviderNames(cloudProviders []kafkamgmtclient.CloudProvider) []string {
 	cloudProviderNames := []string{}


### PR DESCRIPTION
fixes #1277 

### Verification Steps

Add `rhoas kafka create --provider aws` to your terminal. Next add `--region` and double-tab to invoke completion lookup. It should load the regions for aws.

![Screenshot 2021-12-22 at 14 56 13](https://user-images.githubusercontent.com/11743717/147111823-35c00618-a816-4498-ba34-319386c61b78.png)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
