### PR TITLE
feat(acl grant-admin): add flag for instance id

### DIFF
--- a/docs/commands/rhoas_kafka_acl_grant-admin.adoc
+++ b/docs/commands/rhoas_kafka_acl_grant-admin.adoc
@@ -33,6 +33,7 @@ $ rhoas kafka acl grant-admin --all-accounts --instance-id c5hv7iru4an1g84pogp0
 == Options
 
       `--all-accounts`::               Set the ACL principal to match all principals (users and service accounts)
+      `--instance-id` _string_::       Kafka instance ID. Uses the current instance if not set
       `--service-account` _string_::   Service account client ID used as principal for this operation
       `--user` _string_::              User ID to be used as principal
   `-y`, `--yes`::                      Skip confirmation of this action 

--- a/pkg/cmd/kafka/acl/admin/admin.go
+++ b/pkg/cmd/kafka/acl/admin/admin.go
@@ -59,18 +59,20 @@ func NewAdminACLCommand(f *factory.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 
-			cfg, err := opts.config.Load()
-			if err != nil {
-				return err
+			if opts.kafkaID == "" {
+				cfg, err := opts.config.Load()
+				if err != nil {
+					return err
+				}
+
+				instanceID, ok := cfg.GetKafkaIdOk()
+
+				if !ok {
+					return opts.localizer.MustLocalizeError("kafka.acl.common.error.noKafkaSelected")
+				}
+
+				opts.kafkaID = instanceID
 			}
-
-			instanceID, ok := cfg.GetKafkaIdOk()
-
-			if !ok {
-				return opts.localizer.MustLocalizeError("kafka.acl.common.error.noKafkaSelected")
-			}
-
-			opts.kafkaID = instanceID
 
 			// check if principal is provided
 			if userID == "" && serviceAccount == "" && !allAccounts {
@@ -108,6 +110,7 @@ func NewAdminACLCommand(f *factory.Factory) *cobra.Command {
 	fs.AddUser(&userID)
 	fs.AddServiceAccount(&serviceAccount)
 	fs.AddAllAccounts(&allAccounts)
+	fs.AddInstanceID(&opts.kafkaID)
 	fs.AddYes(&opts.skipConfirm)
 
 	return cmd


### PR DESCRIPTION
Add instance id flag to `grant-admin` command. Earlier command used context to set the Kafka instance id. 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run command to grant admin access for a specific Kafka instance
```
rhoas kafka acl grant-admin --user foo_user --instance-id c727fgnstb6seui1vnp0
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer