### PR TITLE
chore: fix CODEOWNERS not working

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-@redhat-developer/app-services-cli-maintainers
+# All files are maintained by @redhat-developer/app-services-cli-maintainers
+*	@redhat-developer/app-services-cli-maintainers


### PR DESCRIPTION
The CODEOWNERS file needs to pair a glob with an owner. It was missing the glob.
