### PR TITLE
fix: add plural form for ACL messages

### DIFF
--- a/pkg/cmd/kafka/acl/admin/admin.go
+++ b/pkg/cmd/kafka/acl/admin/admin.go
@@ -141,10 +141,11 @@ func runAdmin(opts *options) (err error) {
 		kafkainstanceclient.ACLPERMISSIONTYPE_ALLOW,
 	)
 
-	opts.logger.Info(opts.localizer.MustLocalize("kafka.acl.grantPermissions.log.info.aclsPreview"))
+	rows := aclutil.MapACLsToTableRows([]kafkainstanceclient.AclBinding{*aclBindClusterAlter}, opts.localizer)
+
+	opts.logger.Info(opts.localizer.MustLocalizePlural("kafka.acl.grantPermissions.log.info.aclsPreview", len(rows)))
 	opts.logger.Info()
 
-	rows := aclutil.MapACLsToTableRows([]kafkainstanceclient.AclBinding{*aclBindClusterAlter}, opts.localizer)
 	dump.Table(opts.io.Out, rows)
 	opts.logger.Info()
 

--- a/pkg/cmd/kafka/acl/create/create.go
+++ b/pkg/cmd/kafka/acl/create/create.go
@@ -141,10 +141,11 @@ func runAdd(instanceID string, opts *aclutil.CrudOptions) error {
 		kafkainstanceclient.AclPermissionType(requestParams.permission),
 	)
 
-	opts.Logger.Info(opts.Localizer.MustLocalize("kafka.acl.grantPermissions.log.info.aclsPreview"))
+	rows := aclutil.MapACLsToTableRows([]kafkainstanceclient.AclBinding{*newAclBinding}, opts.Localizer)
+
+	opts.Logger.Info(opts.Localizer.MustLocalizePlural("kafka.acl.grantPermissions.log.info.aclsPreview", len(rows)))
 	opts.Logger.Info()
 
-	rows := aclutil.MapACLsToTableRows([]kafkainstanceclient.AclBinding{*newAclBinding}, opts.Localizer)
 	dump.Table(opts.IO.Out, rows)
 	opts.Logger.Info()
 

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -182,9 +182,9 @@ func runDelete(instanceID string, opts *aclutil.CrudOptions) error {
 		localize.NewEntry("Count", deletedCount),
 	))
 
-	opts.Logger.Info(opts.Localizer.MustLocalize("kafka.acl.grantPermissions.log.delete.info.aclsPreview"))
-	opts.Logger.Info()
 	rows := aclutil.MapACLsToTableRows(*deletedACLs.Items, opts.Localizer)
+	opts.Logger.Info(opts.Localizer.MustLocalizePlural("kafka.acl.grantPermissions.log.delete.info.aclsPreview", len(rows)))
+	opts.Logger.Info()
 	dump.Table(opts.IO.Out, rows)
 	opts.Logger.Info()
 

--- a/pkg/cmd/kafka/acl/grant/grant.go
+++ b/pkg/cmd/kafka/acl/grant/grant.go
@@ -262,10 +262,11 @@ func runGrantPermissions(opts *options) (err error) {
 		aclBindRequests = append(aclBindRequests, req.AclBinding(*aclBindTransactionIDDescribe))
 	}
 
-	opts.Logger.Info(opts.localizer.MustLocalize("kafka.acl.grantPermissions.log.info.aclsPreview"))
+	rows := aclutil.MapACLsToTableRows(aclBindingList, opts.localizer)
+
+	opts.Logger.Info(opts.localizer.MustLocalizePlural("kafka.acl.grantPermissions.log.info.aclsPreview", len(rows)))
 	opts.Logger.Info()
 
-	rows := aclutil.MapACLsToTableRows(aclBindingList, opts.localizer)
 	dump.Table(opts.IO.Out, rows)
 	opts.Logger.Info()
 

--- a/pkg/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/localize/locales/en/cmd/acl.en.toml
@@ -263,10 +263,12 @@ one = 'Prefix name for topics to be selected'
 one = 'Prefix name for groups to be selected'
 
 [kafka.acl.grantPermissions.log.info.aclsPreview]
-one = 'The following ACL rule is going to be created:'
+one = 'The following ACL rule will be created:'
+other = 'The following ACL rules will be created:'
 
 [kafka.acl.grantPermissions.log.delete.info.aclsPreview]
-one = 'The following ACL rules were deleted:'
+one = 'The following ACL rule was deleted:'
+other = 'The following ACL rules were deleted:'
 
 [kafka.acl.grantPermissions.log.info.aclsCreated]
 one = 'ACLs successfully created in the Kafka instance "{{.InstanceName}}"'


### PR DESCRIPTION
The i18n library allows you to pass a number to indicate plurality, so I updated the messages to have a plural and singular form.

Closes #1300 

### Verification Steps

**Plural grant-access**

```shell
❯ rhoas kafka acl grant-access --producer --consumer --service-account dfgreg --topic enda --group enda
The following ACL rules will be created:

  PRINCIPAL (7)    PERMISSION   OPERATION   DESCRIPTION              
 ---------------- ------------ ----------- ------------------------- 
  dfgreg           allow        describe    topic is "enda"          
  dfgreg           allow        read        topic is "enda"          
  dfgreg           allow        read        group is "enda"          
  dfgreg           allow        write       topic is "enda"          
  dfgreg           allow        create      topic is "enda"          
  dfgreg           allow        write       transactional-id is "*"  
  dfgreg           allow        describe    transactional-id is "*"  
```

**Singular grant-admin**

```shell
$ rhoas kafka acl grant-admin --all-accounts
The following ACL rule will be created:

  PRINCIPAL      PERMISSION   OPERATION   DESCRIPTION                 
 -------------- ------------ ----------- ---------------------------- 
  All Accounts   allow        alter       cluster is "kafka-cluster"  
```

**Singular delete**

```shell
$ rhoas kafka acl delete --all-accounts --permission allow --operation describe --cluster
? All ACLs matching the criteria provided will be deleted from the Kafka instance "enda-dev". Are you sure you want to proceed? Yes


✔️  Deleted 1 ACL from Kafka instance "enda-dev"
The following ACL rule was deleted:

  PRINCIPAL      PERMISSION   OPERATION   DESCRIPTION                 
 -------------- ------------ ----------- ---------------------------- 
  All Accounts   allow        describe    cluster is "kafka-cluster"  
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer