### PR TITLE
fix: remove logging from segment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,11 +22,11 @@ require (
 	github.com/openconfig/goyang v0.3.2
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
+	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0
 	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.4.0
 	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.6.0
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.4.0
-	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0
 	github.com/redhat-developer/service-binding-operator v0.9.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/cobra v1.3.0

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -48,6 +48,7 @@ func newCustomClient(telemetryFilePath string, segmentEndpoint string) (*Telemet
 	// DefaultContext has IP set to 0.0.0.0 so that it does not track user's IP, which it does in case no IP is set
 	client, err := analytics.NewWithConfig(writeKey, analytics.Config{
 		Endpoint: segmentEndpoint,
+		Logger:   silentLogger{},
 		Verbose:  false,
 		DefaultContext: &analytics.Context{
 			IP: net.IPv4(0, 0, 0, 0),
@@ -92,3 +93,11 @@ func (c *TelemetryClient) Upload(data *TelemetryData) error {
 		Properties: properties,
 	})
 }
+
+// Overrides segment logger to not print into stderr
+type silentLogger struct {
+}
+
+func (l silentLogger) Logf(format string, args ...interface{}) {}
+
+func (l silentLogger) Errorf(format string, args ...interface{}) {}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -116,7 +116,7 @@ func (t *Telemetry) Finish(event string, cmdError error) {
 	}
 	defer telemetryClient.Close()
 
-	telemetryClient.Upload(t.telemetryData)
+	_ = telemetryClient.Upload(t.telemetryData)
 	telemetryClient.Close()
 
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,11 +1,12 @@
 package telemetry
 
 import (
-	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/factory"
 	"os"
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/factory"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/internal/build"
@@ -115,11 +116,7 @@ func (t *Telemetry) Finish(event string, cmdError error) {
 	}
 	defer telemetryClient.Close()
 
-	err = telemetryClient.Upload(t.telemetryData)
-	if err != nil {
-		t.factory.Logger.Info("Cannot send data to telemetry: %q", err)
-	}
-
+	telemetryClient.Upload(t.telemetryData)
 	telemetryClient.Close()
 
 }

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package apis

--- a/pkg/core/ioutil/editor/linux.go
+++ b/pkg/core/ioutil/editor/linux.go
@@ -1,4 +1,5 @@
 // nolint
+//go:build !windows
 // +build !windows
 
 package editor


### PR DESCRIPTION
Remove any logging from analytics so it is not issuing/obfuscating user response. 

Telemetry delivery can fail with bad network etc. so we should not print that. It is not critical for user to see it as well we cannot do much with error anyway.