### PR TITLE
Fixed path to the rhoas commands doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ See our [Guides](https://github.com/redhat-developer/app-services-guides/tree/ma
 
 ## Commands
 
-See the [Command-Line Reference](https://github.com/redhat-developer/app-services-cli/blob/main/docs/commands/rhoas.adoc) section for details of all available commands and options.
+See the [Command-Line Reference](https://github.com/redhat-developer/app-services-cli/blob/main/docs/commands/rhoas.md) section for details of all available commands and options.


### PR DESCRIPTION
This trivial PR fixes a wrong path to the RHOAS documentation page about commands from the landing page.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)