### PR TITLE
fix: parse yq version for different outputs

### DIFF
--- a/pkg/core/ioutil/dump/dump.go
+++ b/pkg/core/ioutil/dump/dump.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
 
 	"github.com/landoop/tableprinter"
 	"gitlab.com/c0b/go-ordered-json"
@@ -123,7 +124,13 @@ func haveYQ(minVersion int) bool {
 		return false
 	}
 
-	versionStr := strings.TrimSpace(strings.TrimLeft(string(versionOutput), "yq version"))
+	prefixes := []string{"yq", "(https://github.com/mikefarah/yq/)", "version"}
+
+	versionStr := string(versionOutput)
+	for _, p := range prefixes {
+		versionStr = strings.TrimSpace(strings.TrimLeft(string(versionStr), p))
+	}
+
 	if versionStr == "" {
 		return false
 	}


### PR DESCRIPTION
YAML output was not being output in color due to a change in the output text of `yq --version`, from which we detect the YQ version.

### Verification

**Prerequisites**

- yq 4.x

Run `rhoas kafka describe -o yaml` and verify that it has been colored. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer