### PR TITLE
feat: make the spinner cyan color

### DIFF
--- a/pkg/core/ioutil/spinner/spinner.go
+++ b/pkg/core/ioutil/spinner/spinner.go
@@ -2,9 +2,10 @@ package spinner
 
 import (
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"io"
 	"time"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 
 	"github.com/briandowns/spinner"
 )
@@ -24,6 +25,7 @@ func New(w io.Writer, localizer localize.Localizer) *Spinner {
 			spinner.CharSets[11],
 			100*time.Millisecond,
 			spinner.WithWriter(w),
+			spinner.WithColor("cyan"),
 		),
 	}
 }


### PR DESCRIPTION
Changed the color of the spinner to cyan to make it stand out more.

<img width="154" alt="Screenshot 2022-01-20 at 17 35 17" src="https://user-images.githubusercontent.com/11743717/150391777-c501fb95-2365-465e-b737-a6cb699efa1e.png">

I actually wanted to do it in red to align with the product color scheme but it could be mistaken to mean an error.
