### PR TITLE
fix: change partition limit for new topic creation

### DIFF
--- a/pkg/cmd/kafka/topic/topiccmdutil/validators.go
+++ b/pkg/cmd/kafka/topic/topiccmdutil/validators.go
@@ -17,7 +17,7 @@ const (
 	legalNameChars = "^[a-zA-Z0-9._-]+$"
 	maxNameLength  = 249
 	minPartitions  = 1
-	maxPartitions  = 100
+	maxPartitions  = 1000
 )
 
 // Validator is a type for validating Kafka topic configuration values

--- a/pkg/cmd/kafka/topic/topiccmdutil/validators_test.go
+++ b/pkg/cmd/kafka/topic/topiccmdutil/validators_test.go
@@ -244,16 +244,16 @@ func TestValidatePartitionsN(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Should be valid when equal to max allowed value(100)",
+			name: "Should be valid when equal to max allowed value(1000)",
 			args: args{
-				partitions: "100",
+				partitions: "1000",
 			},
 			wantErr: false,
 		},
 		{
-			name: "Should be invalid when exceeds 100",
+			name: "Should be invalid when exceeds 1000",
 			args: args{
-				partitions: "102",
+				partitions: "1002",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Verification

```
#fail 
rhoas kafka topic create --partitions=3000
# pass
rhoas kafka topic create --partitions=900
```