### PR TITLE
fix: commit linting github workflow only on main

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -1,6 +1,9 @@
 name: Validate
-on: [pull_request]
-
+on: 
+  push:
+    branches:
+      - main
+ 
 jobs:
   validate_comments:
     name: 'Validate Conventional Commits'


### PR DESCRIPTION
Running job on PRs when we always squashing commits makes less sense and it changes status of the build (where sometimes we want to get notified about build failing). To minimize spam I think we should change job to run on main only