### PR TITLE
fix!: align roles for service registry

### DIFF
--- a/docs/commands/rhoas_cluster_connect.md
+++ b/docs/commands/rhoas_cluster_connect.md
@@ -20,7 +20,7 @@ After running this command, you need to grant access for the service account tha
 
 For the Service Registry application service, enter this command:
 
-  $ rhoas service-registry role add --role=DEVELOPER --service-account your-sa
+  $ rhoas service-registry role add --role=Manager --service-account your-sa
 
 
 ```

--- a/docs/commands/rhoas_service-registry_role.md
+++ b/docs/commands/rhoas_service-registry_role.md
@@ -7,9 +7,9 @@ Service Registry role management
 
 Manage Service Registry roles using a set of commands that give users one of following permissions:
 
-* READ_ONLY (read artifacts)
-* DEVELOPER (write access to all resources)
-* ADMIN (export or import artifacts, manage roles)
+* Viewer (provides read access)
+* Manager (provides read and write access)
+* Admin (enables admin along with read and write access)
 
 Roles can be applied to users (for example, "martin_redhat") and Service Account Client IDs (for example, "srvc-acct-03ddedba-5b49-4aa0-9b68-02e8b8c31add").
 These commands are accessible only to users with the organization admin role or owners of the Service Registry instance.
@@ -19,7 +19,7 @@ These commands are accessible only to users with the organization admin role or 
 
 ```
 ## Create or update user role
-rhoas service-registry role add --role=ADMIN --username=joedough
+rhoas service-registry role add --role=Admin --username=joedough
 
 ## List user and service account roles
 rhoas service-registry role list

--- a/docs/commands/rhoas_service-registry_role_add.md
+++ b/docs/commands/rhoas_service-registry_role_add.md
@@ -14,7 +14,7 @@ rhoas service-registry role add [flags]
 
 ```
 ## Create or update user role
-rhoas service-registry role add --role=ADMIN --username=joedough
+rhoas service-registry role add --role=Admin --username=joedough
 
 ```
 

--- a/pkg/cmd/registry/artifact/role/add/add.go
+++ b/pkg/cmd/registry/artifact/role/add/add.go
@@ -65,7 +65,7 @@ func NewAddCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if opts.role != "" {
-				if _, err := registryinstanceclient.NewRoleTypeFromValue(opts.role); err != nil {
+				if role := util.GetRoleEnum(opts.role); role == "" {
 					return opts.localizer.MustLocalizeError("artifact.cmd.common.error.invalidRole",
 						localize.NewEntry("AllowedRoles", util.GetAllowedRoleTypeEnumValuesAsString()))
 				}
@@ -114,13 +114,13 @@ func runAdd(opts *options) error {
 		return err
 	}
 
-	role, _ := registryinstanceclient.NewRoleTypeFromValue(opts.role)
+	role := util.GetRoleEnum(opts.role)
 
 	if principalHasRole(opts, dataAPI.AdminApi) {
 		opts.Logger.Info(opts.localizer.MustLocalize("registry.role.cmd.updating"))
 		request := dataAPI.AdminApi.UpdateRoleMapping(opts.Context, opts.principal)
 		_, err = request.UpdateRole(registryinstanceclient.UpdateRole{
-			Role: *role,
+			Role: role,
 		}).Execute()
 		if err != nil {
 			return registrycmdutil.TransformInstanceError(err)
@@ -129,7 +129,7 @@ func runAdd(opts *options) error {
 		opts.Logger.Info(opts.localizer.MustLocalize("registry.role.cmd.creating"))
 		roleMapping := registryinstanceclient.RoleMapping{
 			PrincipalId: opts.principal,
-			Role:        *role,
+			Role:        role,
 		}
 		request := dataAPI.AdminApi.CreateRoleMapping(opts.Context)
 		_, err = request.RoleMapping(roleMapping).Execute()

--- a/pkg/cmd/registry/artifact/role/list/list.go
+++ b/pkg/cmd/registry/artifact/role/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"context"
 
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
@@ -129,7 +130,7 @@ func mapResponseItemsToRows(artifacts []registryinstanceclient.RoleMapping) []re
 		k := (artifacts)[i]
 		row := registryRow{
 			Principal: k.GetPrincipalId(),
-			Role:      string(k.GetRole()),
+			Role:      util.GetRoleLabel(k.GetRole()),
 		}
 
 		rows = append(rows, row)

--- a/pkg/cmd/registry/artifact/util/constants.go
+++ b/pkg/cmd/registry/artifact/util/constants.go
@@ -25,10 +25,16 @@ var AllowedArtifactStateEnumValues = []string{
 	"DEPRECATED",
 }
 
+const (
+	ViewerRole  = "Viewer"
+	ManagerRole = "Manager"
+	AdminRole   = "Admin"
+)
+
 var AllowedRoleTypeEnumValues = []string{
-	"READ_ONLY",
-	"DEVELOPER",
-	"ADMIN",
+	ViewerRole,
+	ManagerRole,
+	AdminRole,
 }
 
 // GetAllowedArtifactTypeEnumValuesAsString gets artifact types as string.

--- a/pkg/cmd/registry/artifact/util/rolemapping.go
+++ b/pkg/cmd/registry/artifact/util/rolemapping.go
@@ -1,0 +1,29 @@
+package util
+
+import registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+
+func GetRoleLabel(role registryinstanceclient.RoleType) string {
+	switch role {
+	case registryinstanceclient.ROLETYPE_ADMIN:
+		return AdminRole
+	case registryinstanceclient.ROLETYPE_DEVELOPER:
+		return ManagerRole
+	case registryinstanceclient.ROLETYPE_READ_ONLY:
+		return ViewerRole
+	default:
+		return "Unknown"
+	}
+}
+
+func GetRoleEnum(role string) registryinstanceclient.RoleType {
+	switch role {
+	case AdminRole:
+		return registryinstanceclient.ROLETYPE_ADMIN
+	case ManagerRole:
+		return registryinstanceclient.ROLETYPE_DEVELOPER
+	case ViewerRole:
+		return registryinstanceclient.ROLETYPE_READ_ONLY
+	default:
+		return ""
+	}
+}

--- a/pkg/core/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/core/localize/locales/en/cmd/cluster.en.toml
@@ -158,7 +158,7 @@ After running this command, you need to grant access for the service account tha
 
 For the Service Registry application service, enter this command:
 
-  $ rhoas service-registry role add --role=DEVELOPER --service-account your-sa
+  $ rhoas service-registry role add --role=Manager --service-account your-sa
 '''
 
 [cluster.connect.cmd.example]
@@ -303,7 +303,7 @@ You need to separately grant service account access to Kafka by issuing followin
 one = '''
 You need to assign one of the roles for the service account in order to use it with service registry. For example:
 
-  $ rhoas service-registry role add --role=DEVELOPER --service-account {{.ClientID}}
+  $ rhoas service-registry role add --role=Manager --service-account {{.ClientID}}
 '''
 
 [cluster.kubernetes.createTokenSecret.log.info.createFailed]

--- a/pkg/core/localize/locales/en/cmd/role.toml
+++ b/pkg/core/localize/locales/en/cmd/role.toml
@@ -6,9 +6,9 @@ one = '''
 
 Manage Service Registry roles using a set of commands that give users one of following permissions:
 
-* READ_ONLY (read artifacts)
-* DEVELOPER (write access to all resources)
-* ADMIN (export or import artifacts, manage roles)
+* Viewer (provides read access)
+* Manager (provides read and write access)
+* Admin (enables admin along with read and write access)
 
 Roles can be applied to users (for example, "martin_redhat") and Service Account Client IDs (for example, "srvc-acct-03ddedba-5b49-4aa0-9b68-02e8b8c31add").
 These commands are accessible only to users with the organization admin role or owners of the Service Registry instance.
@@ -17,7 +17,7 @@ These commands are accessible only to users with the organization admin role or 
 [registry.role.cmd.example]
 one = '''
 ## Create or update user role
-rhoas service-registry role add --role=ADMIN --username=joedough
+rhoas service-registry role add --role=Admin --username=joedough
 
 ## List user and service account roles
 rhoas service-registry role list
@@ -36,7 +36,7 @@ one = 'Add or update role for user or service account'
 [registry.role.cmd.add.example]
 one = '''
 ## Create or update user role
-rhoas service-registry role add --role=ADMIN --username=joedough
+rhoas service-registry role add --role=Admin --username=joedough
 '''
 
 [artifact.cmd.common.error.useSaOrUserOnly]

--- a/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
@@ -54,7 +54,7 @@ To grant full access to produce and consume Kafka messages, enter this command:
 
 To grant read and write access to the currently selected Service Registry instance, enter this command:
 
- $ rhoas service-registry role add --role DEVELOPER --service-account {{.ClientID}}
+ $ rhoas service-registry role add --role Manager --service-account {{.ClientID}}
 
 '''
 


### PR DESCRIPTION
## Motivation

UI using some different values so we see this as confusing/mixed UX that should be aligned. 
New roles are introduced in breaking fashion as we can easily provide feedback to users about the change

## Verification

```
rhoas service-registry role add --role Viewer --username wtrocki_kafka_devexp
rhoas service-registry role list
```