### PR TITLE
fix!: use lowercase values for registry roles

### DIFF
--- a/docs/commands/rhoas_cluster_connect.md
+++ b/docs/commands/rhoas_cluster_connect.md
@@ -20,7 +20,7 @@ After running this command, you need to grant access for the service account tha
 
 For the Service Registry application service, enter this command:
 
-  $ rhoas service-registry role add --role=Manager --service-account your-sa
+  $ rhoas service-registry role add --role=manager --service-account your-sa
 
 
 ```

--- a/docs/commands/rhoas_service-registry_role.md
+++ b/docs/commands/rhoas_service-registry_role.md
@@ -7,9 +7,9 @@ Service Registry role management
 
 Manage Service Registry roles using a set of commands that give users one of following permissions:
 
-* Viewer (provides read access)
-* Manager (provides read and write access)
-* Admin (enables admin along with read and write access)
+* viewer (provides read access)
+* manager (provides read and write access)
+* admin (enables admin along with read and write access)
 
 Roles can be applied to users (for example, "martin_redhat") and Service Account Client IDs (for example, "srvc-acct-03ddedba-5b49-4aa0-9b68-02e8b8c31add").
 These commands are accessible only to users with the organization admin role or owners of the Service Registry instance.
@@ -19,7 +19,7 @@ These commands are accessible only to users with the organization admin role or 
 
 ```
 ## Create or update user role
-rhoas service-registry role add --role=Admin --username=joedough
+rhoas service-registry role add --role=admin --username=joedough
 
 ## List user and service account roles
 rhoas service-registry role list

--- a/docs/commands/rhoas_service-registry_role_add.md
+++ b/docs/commands/rhoas_service-registry_role_add.md
@@ -14,7 +14,7 @@ rhoas service-registry role add [flags]
 
 ```
 ## Create or update user role
-rhoas service-registry role add --role=Admin --username=joedough
+rhoas service-registry role add --role=admin --username=joedough
 
 ```
 

--- a/pkg/cmd/registry/artifact/util/constants.go
+++ b/pkg/cmd/registry/artifact/util/constants.go
@@ -26,9 +26,9 @@ var AllowedArtifactStateEnumValues = []string{
 }
 
 const (
-	ViewerRole  = "Viewer"
-	ManagerRole = "Manager"
-	AdminRole   = "Admin"
+	ViewerRole  = "viewer"
+	ManagerRole = "manager"
+	AdminRole   = "admin"
 )
 
 var AllowedRoleTypeEnumValues = []string{

--- a/pkg/core/localize/locales/en/cmd/cluster.en.toml
+++ b/pkg/core/localize/locales/en/cmd/cluster.en.toml
@@ -158,7 +158,7 @@ After running this command, you need to grant access for the service account tha
 
 For the Service Registry application service, enter this command:
 
-  $ rhoas service-registry role add --role=Manager --service-account your-sa
+  $ rhoas service-registry role add --role=manager --service-account your-sa
 '''
 
 [cluster.connect.cmd.example]
@@ -303,7 +303,7 @@ You need to separately grant service account access to Kafka by issuing followin
 one = '''
 You need to assign one of the roles for the service account in order to use it with service registry. For example:
 
-  $ rhoas service-registry role add --role=Manager --service-account {{.ClientID}}
+  $ rhoas service-registry role add --role=manager --service-account {{.ClientID}}
 '''
 
 [cluster.kubernetes.createTokenSecret.log.info.createFailed]

--- a/pkg/core/localize/locales/en/cmd/role.toml
+++ b/pkg/core/localize/locales/en/cmd/role.toml
@@ -6,9 +6,9 @@ one = '''
 
 Manage Service Registry roles using a set of commands that give users one of following permissions:
 
-* Viewer (provides read access)
-* Manager (provides read and write access)
-* Admin (enables admin along with read and write access)
+* viewer (provides read access)
+* manager (provides read and write access)
+* admin (enables admin along with read and write access)
 
 Roles can be applied to users (for example, "martin_redhat") and Service Account Client IDs (for example, "srvc-acct-03ddedba-5b49-4aa0-9b68-02e8b8c31add").
 These commands are accessible only to users with the organization admin role or owners of the Service Registry instance.
@@ -17,7 +17,7 @@ These commands are accessible only to users with the organization admin role or 
 [registry.role.cmd.example]
 one = '''
 ## Create or update user role
-rhoas service-registry role add --role=Admin --username=joedough
+rhoas service-registry role add --role=admin --username=joedough
 
 ## List user and service account roles
 rhoas service-registry role list
@@ -36,7 +36,7 @@ one = 'Add or update role for user or service account'
 [registry.role.cmd.add.example]
 one = '''
 ## Create or update user role
-rhoas service-registry role add --role=Admin --username=joedough
+rhoas service-registry role add --role=admin --username=joedough
 '''
 
 [artifact.cmd.common.error.useSaOrUserOnly]

--- a/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
@@ -54,7 +54,7 @@ To grant full access to produce and consume Kafka messages, enter this command:
 
 To grant read and write access to the currently selected Service Registry instance, enter this command:
 
- $ rhoas service-registry role add --role Manager --service-account {{.ClientID}}
+ $ rhoas service-registry role add --role manager --service-account {{.ClientID}}
 
 '''
 


### PR DESCRIPTION
We want the CLI to be a relatively quick way to execute operations against the service. By forcing users to toggle the case of a value, we are actually slowing them down.
As a rule of thumb we should use lowercase in almost all cases except for exceptional circumstances.