### PR TITLE
fix(consumer-group): offset validation error message

### DIFF
--- a/pkg/cmd/kafka/consumergroup/groupcmdutil/validators.go
+++ b/pkg/cmd/kafka/consumergroup/groupcmdutil/validators.go
@@ -22,7 +22,7 @@ func (v *Validator) ValidateOffset(offset string) error {
 		return nil
 	}
 
-	return flagutil.InvalidValueError("output", v, ValidOffsets...)
+	return flagutil.InvalidValueError("offset", offset, ValidOffsets...)
 }
 
 // ValidateOffsetValue validates value for timestamp and absolute offset

--- a/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
+++ b/pkg/cmd/serviceaccount/resetcredentials/reset_credentials.go
@@ -173,7 +173,10 @@ func runResetCredentials(opts *options) (err error) {
 		return err
 	}
 
-	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("serviceAccount.common.log.info.credentialsSaved", localize.NewEntry("FilePath", opts.filename)))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("serviceAccount.common.log.info.credentialsSaved",
+		localize.NewEntry("FilePath", opts.filename),
+		localize.NewEntry("ClientID", color.Success(creds.ClientID)),
+	))
 
 	return nil
 }

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -751,7 +751,7 @@ one = 'Cleanup Policy [optional]:'
 
 [kafka.topic.update.input.cleanupPolicy.help]
 description = 'Help for the Cleanup policy input'
-one = 'Determines whether log messages are deleted, compacted, or both. Leave blank to skip updating this value.'
+one = 'Determines whether log messages are deleted, compacted, or both.'
 
 [kafka.topic.update.input.partitions.message]
 description = 'Message for the Partitions input'


### PR DESCRIPTION
Wrong error message for validating offset flag of `consumer-group reset-offset`. 

![Screenshot from 2022-02-11 22-51-28](https://user-images.githubusercontent.com/23582438/153638592-5d0bf6a1-edd0-4e1b-a61b-b96447ccdda4.png)


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run command to reset offset for a consumer group with random offset value
```
 ./rhoas kafka consumer-group reset-offset --id vkjkjv --topic naruto --offset ppl 
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer