### PR TITLE
feat(service-registry rule): add describe and list command

### DIFF
--- a/docs/commands/rhoas_service-registry_rule.md
+++ b/docs/commands/rhoas_service-registry_rule.md
@@ -34,5 +34,7 @@ $ rhoas service-registry rule describe --rule-type=validity
 ### SEE ALSO
 
 * [rhoas service-registry](rhoas_service-registry.md)	 - Service Registry commands
+* [rhoas service-registry rule describe](rhoas_service-registry_rule_describe.md)	 - Display configuration of a rule
 * [rhoas service-registry rule enable](rhoas_service-registry_rule_enable.md)	 - Enable validity and compatibility rules
+* [rhoas service-registry rule list](rhoas_service-registry_rule_list.md)	 - List validity and compatibility rules
 

--- a/docs/commands/rhoas_service-registry_rule_describe.md
+++ b/docs/commands/rhoas_service-registry_rule_describe.md
@@ -4,7 +4,7 @@ Display configuration of a rule
 
 ### Synopsis
 
-View configuration details of compatibility or validity rule for the selected Service Registry instance or specific artifact.
+View configuration details of compatibility or validity rule for the specified Service Registry instance or artifact.
 
 ```
 rhoas service-registry rule describe [flags]

--- a/docs/commands/rhoas_service-registry_rule_describe.md
+++ b/docs/commands/rhoas_service-registry_rule_describe.md
@@ -1,0 +1,44 @@
+## rhoas service-registry rule describe
+
+Display configuration of a rule
+
+### Synopsis
+
+View configuration details of compatibility or validity rule for the selected Service Registry instance or specific artifact.
+
+```
+rhoas service-registry rule describe [flags]
+```
+
+### Examples
+
+```
+## Display configuration details of global validity rule for current Service Registry instance
+$ rhoas service-registry rule describe --rule-type=validity
+
+## Display configuration details of compatibility rule for a specific artifact
+$ rhoas service-registry rule describe --rule-type=compatibility --artifact-id=my-artifact --group=my-group
+
+```
+
+### Options
+
+```
+      --artifact-id string   ID of the artifact
+  -g, --group string         Artifact group (default "default")
+      --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+  -o, --output string        Specify the output format. Choose from: "json", "yaml", "yml"
+      --rule-type string     Rule type determines how the content of an artifact can evolve over time
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry rule](rhoas_service-registry_rule.md)	 - Manage artifact rules in a Service Registry instance
+

--- a/docs/commands/rhoas_service-registry_rule_enable.md
+++ b/docs/commands/rhoas_service-registry_rule_enable.md
@@ -4,7 +4,7 @@ Enable validity and compatibility rules
 
 ### Synopsis
 
-Enable validity and compatibility rules for the selected Service Registry instance or specific artifact
+Enable validity and compatibility rules for the specified Service Registry instance or artifact
 
 ```
 rhoas service-registry rule enable [flags]

--- a/docs/commands/rhoas_service-registry_rule_list.md
+++ b/docs/commands/rhoas_service-registry_rule_list.md
@@ -4,7 +4,7 @@ List validity and compatibility rules
 
 ### Synopsis
 
-View validity and compatibility rules for the selected Service Registry instance or specific artifact
+View validity and compatibility rules for the specified Service Registry instance or artifact.
 
 ```
 rhoas service-registry rule list [flags]

--- a/docs/commands/rhoas_service-registry_rule_list.md
+++ b/docs/commands/rhoas_service-registry_rule_list.md
@@ -1,0 +1,45 @@
+## rhoas service-registry rule list
+
+List validity and compatibility rules
+
+### Synopsis
+
+View validity and compatibility rules for the selected Service Registry instance or specific artifact
+
+```
+rhoas service-registry rule list [flags]
+```
+
+### Examples
+
+```
+## List global rules for artifacts of the current Service Registry instance
+$ rhoas service-registry rule list
+
+## List global rule for artifacts of a specific Service Registry instance
+$ rhoas service-registry rule list --instance-id 8ecff228-1ffe-4cf5-b38b-55223885ee00
+
+## List rule for a specific artifact
+$ rhoas service-registry rule list --artifact-id=my-artifact
+
+```
+
+### Options
+
+```
+      --artifact-id string   ID of the artifact
+  -g, --group string         Artifact group (default "default")
+      --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry rule](rhoas_service-registry_rule.md)	 - Manage artifact rules in a Service Registry instance
+

--- a/pkg/cmd/registry/rule/describe/describe.go
+++ b/pkg/cmd/registry/rule/describe/describe.go
@@ -124,10 +124,7 @@ func runDescribe(opts *options) error {
 	if opts.artifactID == "" {
 
 		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix(
-			"registry.rule.describe.log.info.fetching.globalRule",
-			localize.NewEntry("Type", opts.ruleType),
-		)
+		s.SetLocalizedSuffix("registry.rule.describe.log.info.fetching.globalRule", localize.NewEntry("Type", opts.ruleType))
 		s.Start()
 
 		req := dataAPI.AdminApi.GetGlobalRuleConfig(opts.Context, *rulecmdutil.GetMappedRuleType(opts.ruleType))
@@ -137,6 +134,7 @@ func runDescribe(opts *options) error {
 			defer httpRes.Body.Close()
 		}
 
+		s.Stop()
 	} else {
 
 		request := dataAPI.ArtifactsApi.GetLatestArtifact(opts.Context, opts.group, opts.artifactID)
@@ -150,10 +148,7 @@ func runDescribe(opts *options) error {
 		}
 
 		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix(
-			"registry.rule.describe.log.info.fetching.artifactRule",
-			localize.NewEntry("Type", opts.ruleType),
-		)
+		s.SetLocalizedSuffix("registry.rule.describe.log.info.fetching.artifactRule", localize.NewEntry("Type", opts.ruleType))
 		s.Start()
 
 		ruleTypeParam := string(*rulecmdutil.GetMappedRuleType(opts.ruleType))
@@ -165,6 +160,7 @@ func runDescribe(opts *options) error {
 			defer httpRes.Body.Close()
 		}
 
+		s.Stop()
 	}
 
 	if err != nil {

--- a/pkg/cmd/registry/rule/describe/describe.go
+++ b/pkg/cmd/registry/rule/describe/describe.go
@@ -1,0 +1,175 @@
+package describe
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/config"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+)
+
+type options struct {
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     logging.Logger
+	localizer  localize.Localizer
+	Context    context.Context
+
+	ruleType string
+
+	registryID string
+	artifactID string
+	group      string
+	output     string
+}
+
+// NewDescribeCommand creates a new command for viewing configuration details of a rule
+func NewDescribeCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+		Context:    f.Context,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "describe",
+		Short:   f.Localizer.MustLocalize("registry.rule.describe.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("registry.rule.describe.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("registry.rule.describe.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			validator := rulecmdutil.Validator{
+				Localizer: opts.localizer,
+			}
+
+			err = validator.ValidateRuleType(opts.ruleType)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			instanceID, ok := cfg.GetServiceRegistryIdOk()
+			if !ok {
+				return opts.localizer.MustLocalizeError("artifact.cmd.common.error.noServiceRegistrySelected")
+			}
+
+			opts.registryID = instanceID
+
+			return runDescribe(opts)
+		},
+	}
+
+	flags := rulecmdutil.NewFlagSet(cmd, f)
+
+	_ = flags.AddRuleType(&opts.ruleType).Required()
+	flags.AddRegistryInstance(&opts.registryID)
+
+	flags.AddArtifactID(&opts.artifactID)
+	flags.AddGroup(&opts.group)
+	flags.AddOutput(&opts.output)
+
+	return cmd
+}
+
+func runDescribe(opts *options) error {
+
+	var httpRes *http.Response
+	var err error
+	var rule registryinstanceclient.Rule
+
+	validator := rulecmdutil.Validator{
+		Localizer: opts.localizer,
+	}
+
+	ruleErr := &rulecmdutil.RegistryRuleError{
+		Localizer:  opts.localizer,
+		InstanceID: opts.registryID,
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	err = validator.ValidateRuleType(opts.ruleType)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.artifactID == "" {
+
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.describe.log.info.fetching.globalRule", localize.NewEntry("Type", opts.ruleType)))
+
+		req := dataAPI.AdminApi.GetGlobalRuleConfig(opts.Context, *rulecmdutil.GetMappedRuleType(opts.ruleType))
+
+		rule, httpRes, err = req.Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
+
+	} else {
+
+		request := dataAPI.ArtifactsApi.GetLatestArtifact(opts.Context, opts.group, opts.artifactID)
+		_, httpRes, err = request.Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
+
+		if err != nil {
+			return registrycmdutil.TransformInstanceError(err)
+		}
+
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.describe.log.info.fetching.artifactRule", localize.NewEntry("Type", opts.ruleType)))
+
+		ruleTypeParam := string(*rulecmdutil.GetMappedRuleType(opts.ruleType))
+
+		req := dataAPI.ArtifactRulesApi.GetArtifactRuleConfig(opts.Context, opts.group, opts.artifactID, ruleTypeParam)
+
+		rule, httpRes, err = req.Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
+
+	}
+
+	if err != nil {
+		if httpRes == nil {
+			return registrycmdutil.TransformInstanceError(err)
+		}
+
+		switch httpRes.StatusCode {
+		case http.StatusNotFound:
+			return ruleErr.RuleNotEnabled(opts.ruleType)
+		default:
+			return registrycmdutil.TransformInstanceError(err)
+		}
+	}
+
+	return dump.Formatted(opts.IO.Out, opts.output, rule)
+
+}

--- a/pkg/cmd/registry/rule/describe/describe.go
+++ b/pkg/cmd/registry/rule/describe/describe.go
@@ -103,8 +103,7 @@ func runDescribe(opts *options) error {
 	}
 
 	ruleErrHandler := &rulecmdutil.RuleErrHandler{
-		Localizer:  opts.localizer,
-		InstanceID: opts.registryID,
+		Localizer: opts.localizer,
 	}
 
 	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -18,6 +18,8 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/spf13/cobra"
 
+	artifactutil "github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
+
 	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
 )
 
@@ -227,6 +229,37 @@ func runInteractivePrompt(opts *options) (err error) {
 	}
 
 	err = survey.AskOne(configPrompt, &opts.config)
+	if err != nil {
+		return err
+	}
+
+	instanceIDPrompt := &survey.Input{
+		Message: opts.localizer.MustLocalize("registry.rule.enable.input.instanceID.message"),
+		Help:    opts.localizer.MustLocalize("registry.rule.enable.input.instanceID.help"),
+	}
+
+	err = survey.AskOne(instanceIDPrompt, &opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	artifactIDPrompt := &survey.Input{
+		Message: opts.localizer.MustLocalize("registry.rule.enable.input.artifactID.message"),
+		Help:    opts.localizer.MustLocalize("registry.rule.enable.input.artifactID.help"),
+	}
+
+	err = survey.AskOne(artifactIDPrompt, &opts.artifactID)
+	if err != nil {
+		return err
+	}
+
+	groupPrompt := &survey.Input{
+		Message: opts.localizer.MustLocalize("registry.rule.enable.input.group.message"),
+		Help:    opts.localizer.MustLocalize("registry.rule.enable.input.group.help"),
+		Default: artifactutil.DefaultArtifactGroup,
+	}
+
+	err = survey.AskOne(groupPrompt, &opts.group)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -167,6 +167,8 @@ func runEnable(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
+
+		s.Stop()
 	} else {
 
 		s := spinner.New(opts.IO.ErrOut, opts.localizer)
@@ -186,6 +188,8 @@ func runEnable(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
+
+		s.Stop()
 	}
 
 	ruleErrHandler := &rulecmdutil.RuleErrHandler{

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -189,8 +189,7 @@ func runEnable(opts *options) error {
 	}
 
 	ruleErrHandler := &rulecmdutil.RuleErrHandler{
-		Localizer:  opts.localizer,
-		InstanceID: opts.registryID,
+		Localizer: opts.localizer,
 	}
 
 	if newErr != nil {

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -183,18 +183,16 @@ func runEnable(opts *options) error {
 
 	if newErr != nil {
 		if httpRes == nil {
-			return newErr
+			return registrycmdutil.TransformInstanceError(newErr)
 		}
 
 		switch httpRes.StatusCode {
-		case http.StatusUnauthorized, http.StatusInternalServerError, http.StatusForbidden:
-			return registrycmdutil.TransformInstanceError(newErr)
 		case http.StatusNotFound:
 			return ruleErr.ArtifactNotFoundError(opts.artifactID)
 		case http.StatusConflict:
 			return ruleErr.ConflictError(opts.ruleType)
 		default:
-			return newErr
+			return registrycmdutil.TransformInstanceError(newErr)
 		}
 
 	}

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -61,23 +61,26 @@ func NewEnableCommand(f *factory.Factory) *cobra.Command {
 				Localizer: opts.localizer,
 			}
 
-			if !opts.IO.CanPrompt() {
-				var missingFlags []string
-				if opts.ruleType == "" {
-					missingFlags = append(missingFlags, "rule-type")
-				}
-				if opts.config == "" {
-					missingFlags = append(missingFlags, "config")
-				}
-				if len(missingFlags) > 0 {
-					return flagutil.RequiredWhenNonInteractiveError(missingFlags...)
-				}
+			var missingFlags []string
+
+			if opts.ruleType == "" {
+				missingFlags = append(missingFlags, "rule-type")
 			}
-			if opts.ruleType == "" && opts.config == "" {
+			if opts.config == "" {
+				missingFlags = append(missingFlags, "config")
+			}
+
+			if !opts.IO.CanPrompt() && len(missingFlags) > 0 {
+				return flagutil.RequiredWhenNonInteractiveError(missingFlags...)
+			}
+
+			if len(missingFlags) == 2 {
 				err = runInteractivePrompt(opts)
 				if err != nil {
 					return err
 				}
+			} else if len(missingFlags) > 0 {
+				return flagutil.RequiredWhenNonInteractiveError(missingFlags...)
 			}
 
 			cfg, err := opts.Config.Load()

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -120,7 +120,6 @@ func runList(opts *options) error {
 	}
 
 	if opts.artifactID == "" {
-
 		s := spinner.New(opts.IO.ErrOut, opts.localizer)
 		s.SetLocalizedSuffix("registry.rule.list.log.info.fetching.globalRules")
 		s.Start()
@@ -131,8 +130,9 @@ func runList(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-	} else {
 
+		s.Stop()
+	} else {
 		s := spinner.New(opts.IO.ErrOut, opts.localizer)
 		s.SetLocalizedSuffix("registry.rule.list.log.info.fetching.artifactRules")
 		s.Start()
@@ -143,6 +143,8 @@ func runList(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
+
+		s.Stop()
 	}
 
 	if newErr != nil {

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -106,8 +106,7 @@ func runList(opts *options) error {
 	var enabledRules []registryinstanceclient.RuleType
 
 	ruleErrHandler := &rulecmdutil.RuleErrHandler{
-		Localizer:  opts.localizer,
-		InstanceID: opts.registryID,
+		Localizer: opts.localizer,
 	}
 
 	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -1,0 +1,181 @@
+package list
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/config"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+)
+
+const (
+	ruleValidity      = "VALIDITY"
+	ruleCompatibility = "COMPATIBILITY"
+)
+
+// ruleRow is the details of a Service Registry rules needed to print to a table
+type ruleRow struct {
+	RuleType string `json:"ruleType" header:"Rule Type"`
+
+	Description string `json:"description,omitempty" header:"Description"`
+
+	Status string `json:"status" header:"Status"`
+}
+
+type options struct {
+	IO         *iostreams.IOStreams
+	Config     config.IConfig
+	Connection factory.ConnectionFunc
+	Logger     logging.Logger
+	localizer  localize.Localizer
+	Context    context.Context
+
+	registryID string
+	artifactID string
+	group      string
+}
+
+var compatibilityRuleStatus = ruleRow{
+	RuleType:    ruleCompatibility,
+	Description: "Enforce a compatibility level when updating this artifact (for example, Backwards Compatibility).",
+	Status:      "DISABLED",
+}
+
+var validityRuleStatus = ruleRow{
+	RuleType:    ruleValidity,
+	Description: "Ensure that content is valid when updating this artifact.",
+	Status:      "DISABLED",
+}
+
+// NewListCommand creates a new command to view status of rules
+func NewListCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		Connection: f.Connection,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+		Context:    f.Context,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   f.Localizer.MustLocalize("registry.rule.list.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("registry.rule.list.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("registry.rule.list.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			cfg, err := opts.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			instanceID, ok := cfg.GetServiceRegistryIdOk()
+			if !ok {
+				return opts.localizer.MustLocalizeError("artifact.cmd.common.error.noServiceRegistrySelected")
+			}
+
+			opts.registryID = instanceID
+
+			return runList(opts)
+		},
+	}
+
+	flags := rulecmdutil.NewFlagSet(cmd, f)
+
+	flags.AddRegistryInstance(&opts.registryID)
+
+	flags.AddArtifactID(&opts.artifactID)
+	flags.AddGroup(&opts.group)
+
+	return cmd
+
+}
+
+func runList(opts *options) error {
+
+	var httpRes *http.Response
+	var newErr error
+	var enabledRules []registryinstanceclient.RuleType
+
+	var ruleErr = &rulecmdutil.RegistryRuleError{
+		Localizer:  opts.localizer,
+		InstanceID: opts.registryID,
+	}
+
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if opts.artifactID == "" {
+
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.list.log.info.fetching.globalRules"))
+
+		req := dataAPI.AdminApi.ListGlobalRules(opts.Context)
+
+		enabledRules, httpRes, newErr = req.Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
+	} else {
+
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.list.log.info.fetching.artifactRules"))
+
+		req := dataAPI.ArtifactRulesApi.ListArtifactRules(opts.Context, opts.group, opts.artifactID)
+
+		enabledRules, httpRes, newErr = req.Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
+	}
+
+	if newErr != nil {
+		if httpRes == nil {
+			return registrycmdutil.TransformInstanceError(newErr)
+		}
+
+		switch httpRes.StatusCode {
+		case http.StatusNotFound:
+			return ruleErr.ArtifactNotFoundError(opts.artifactID)
+		default:
+			return registrycmdutil.TransformInstanceError(newErr)
+		}
+	}
+
+	for _, rule := range enabledRules {
+		if rule == ruleValidity {
+			validityRuleStatus.Status = "ENABLED"
+		}
+		if rule == ruleCompatibility {
+			compatibilityRuleStatus.Status = "ENABLED"
+		}
+	}
+
+	var adminRules = []ruleRow{validityRuleStatus, compatibilityRuleStatus}
+
+	opts.Logger.Info()
+	dump.Table(opts.IO.Out, adminRules)
+
+	opts.Logger.Info()
+	opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.list.log.info.describeHint"))
+
+	return nil
+}

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -19,8 +19,13 @@ import (
 )
 
 const (
-	ruleValidity      = "VALIDITY"
-	ruleCompatibility = "COMPATIBILITY"
+	RuleValidity      = "VALIDITY"
+	RuleCompatibility = "COMPATIBILITY"
+)
+
+const (
+	RuleDisabled = "DISABLED"
+	RuleEnabled  = "ENABLED"
 )
 
 // ruleRow is the details of a Service Registry rules needed to print to a table
@@ -43,18 +48,6 @@ type options struct {
 	registryID string
 	artifactID string
 	group      string
-}
-
-var compatibilityRuleStatus = ruleRow{
-	RuleType:    ruleCompatibility,
-	Description: "Enforce a compatibility level when updating this artifact (for example, Backwards Compatibility).",
-	Status:      "DISABLED",
-}
-
-var validityRuleStatus = ruleRow{
-	RuleType:    ruleValidity,
-	Description: "Ensure that content is valid when updating this artifact.",
-	Status:      "DISABLED",
 }
 
 // NewListCommand creates a new command to view status of rules
@@ -160,12 +153,26 @@ func runList(opts *options) error {
 		}
 	}
 
+	opts.localizer.MustLocalize("registry.rule.list.compatibilityRule.description")
+
+	var compatibilityRuleStatus = ruleRow{
+		RuleType:    RuleCompatibility,
+		Description: opts.localizer.MustLocalize("registry.rule.list.compatibilityRule.description"),
+		Status:      RuleDisabled,
+	}
+
+	var validityRuleStatus = ruleRow{
+		RuleType:    RuleValidity,
+		Description: opts.localizer.MustLocalize("registry.rule.list.validityRule.description"),
+		Status:      RuleDisabled,
+	}
+
 	for _, rule := range enabledRules {
-		if rule == ruleValidity {
-			validityRuleStatus.Status = "ENABLED"
+		if rule == RuleValidity {
+			validityRuleStatus.Status = RuleEnabled
 		}
-		if rule == ruleCompatibility {
-			compatibilityRuleStatus.Status = "ENABLED"
+		if rule == RuleCompatibility {
+			compatibilityRuleStatus.Status = RuleEnabled
 		}
 	}
 

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
@@ -19,13 +20,13 @@ import (
 )
 
 const (
-	RuleValidity      = "VALIDITY"
-	RuleCompatibility = "COMPATIBILITY"
+	RuleValidity      = "validity"
+	RuleCompatibility = "compatibility"
 )
 
 const (
-	RuleDisabled = "DISABLED"
-	RuleEnabled  = "ENABLED"
+	RuleDisabled = "disabled"
+	RuleEnabled  = "enabled"
 )
 
 // ruleRow is the details of a Service Registry rules needed to print to a table
@@ -168,10 +169,10 @@ func runList(opts *options) error {
 	}
 
 	for _, rule := range enabledRules {
-		if rule == RuleValidity {
+		if strings.EqualFold(string(rule), RuleValidity) {
 			validityRuleStatus.Status = RuleEnabled
 		}
-		if rule == RuleCompatibility {
+		if strings.EqualFold(string(rule), RuleCompatibility) {
 			compatibilityRuleStatus.Status = RuleEnabled
 		}
 	}

--- a/pkg/cmd/registry/rule/rule.go
+++ b/pkg/cmd/registry/rule/rule.go
@@ -1,7 +1,9 @@
 package rule
 
 import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/describe"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/enable"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/list"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/spf13/cobra"
 )
@@ -18,6 +20,8 @@ func NewRuleCommand(f *factory.Factory) *cobra.Command {
 	// add sub-commands
 	cmd.AddCommand(
 		enable.NewEnableCommand(f),
+		list.NewListCommand(f),
+		describe.NewDescribeCommand(f),
 	)
 
 	return cmd

--- a/pkg/cmd/registry/rule/rulecmdutil/constants.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/constants.go
@@ -8,7 +8,7 @@ const (
 const (
 	ConfigFULL                = "full"
 	ConfigSYNTAX_ONLY         = "syntax-only"
-	ConfigFULL_TRANSITIVE     = "full-trannsitive"
+	ConfigFULL_TRANSITIVE     = "full-transitive"
 	ConfigBACKWARD            = "backward"
 	ConfigBACKWARD_TRANSITIVE = "backward-transitive"
 	ConfigFORWARD             = "forward"

--- a/pkg/cmd/registry/rule/rulecmdutil/error.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/error.go
@@ -28,3 +28,7 @@ func (r *RegistryRuleError) ServerError() error {
 func (r *RegistryRuleError) ArtifactNotFoundError(artifactID string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.artifactNotFound", localize.NewEntry("ID", artifactID))
 }
+
+func (r *RegistryRuleError) RuleNotEnabled(ruleTYpe string) error {
+	return r.Localizer.MustLocalizeError("registry.rule.common.error.notEnabled", localize.NewEntry("Type", ruleTYpe))
+}

--- a/pkg/cmd/registry/rule/rulecmdutil/error.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/error.go
@@ -13,18 +13,6 @@ func (r *RegistryRuleError) ConflictError(ruleType string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.conflict", localize.NewEntry("Type", ruleType))
 }
 
-func (r *RegistryRuleError) UnathorizedError(operation string) error {
-	return r.Localizer.MustLocalizeError("registry.rule.common.error.unauthorized", localize.NewEntry("Operation", operation))
-}
-
-func (r *RegistryRuleError) ForbiddenError(operation string) error {
-	return r.Localizer.MustLocalizeError("registry.rule.common.error.forbidden", localize.NewEntry("Operation", operation))
-}
-
-func (r *RegistryRuleError) ServerError() error {
-	return r.Localizer.MustLocalizeError("registry.rule.common.error.internalServerError")
-}
-
 func (r *RegistryRuleError) ArtifactNotFoundError(artifactID string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.artifactNotFound", localize.NewEntry("ID", artifactID))
 }

--- a/pkg/cmd/registry/rule/rulecmdutil/error.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/error.go
@@ -5,8 +5,7 @@ import (
 )
 
 type RuleErrHandler struct {
-	Localizer  localize.Localizer
-	InstanceID string
+	Localizer localize.Localizer
 }
 
 func (r *RuleErrHandler) ConflictError(ruleType string) error {
@@ -17,6 +16,6 @@ func (r *RuleErrHandler) ArtifactNotFoundError(artifactID string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.artifactNotFound", localize.NewEntry("ID", artifactID))
 }
 
-func (r *RuleErrHandler) RuleNotEnabled(ruleTYpe string) error {
-	return r.Localizer.MustLocalizeError("registry.rule.common.error.notEnabled", localize.NewEntry("Type", ruleTYpe))
+func (r *RuleErrHandler) RuleNotEnabled(ruleType string) error {
+	return r.Localizer.MustLocalizeError("registry.rule.common.error.notEnabled", localize.NewEntry("Type", ruleType))
 }

--- a/pkg/cmd/registry/rule/rulecmdutil/error.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/error.go
@@ -4,19 +4,19 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 )
 
-type RegistryRuleError struct {
+type RuleErrHandler struct {
 	Localizer  localize.Localizer
 	InstanceID string
 }
 
-func (r *RegistryRuleError) ConflictError(ruleType string) error {
+func (r *RuleErrHandler) ConflictError(ruleType string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.conflict", localize.NewEntry("Type", ruleType))
 }
 
-func (r *RegistryRuleError) ArtifactNotFoundError(artifactID string) error {
+func (r *RuleErrHandler) ArtifactNotFoundError(artifactID string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.artifactNotFound", localize.NewEntry("ID", artifactID))
 }
 
-func (r *RegistryRuleError) RuleNotEnabled(ruleTYpe string) error {
+func (r *RuleErrHandler) RuleNotEnabled(ruleTYpe string) error {
 	return r.Localizer.MustLocalizeError("registry.rule.common.error.notEnabled", localize.NewEntry("Type", ruleTYpe))
 }

--- a/pkg/cmd/registry/rule/rulecmdutil/validator.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/validator.go
@@ -18,7 +18,7 @@ func (v *Validator) ValidateRuleType(ruleType string) error {
 		return nil
 	}
 
-	return flagutil.InvalidValueError("rule-type", v, ValidRules...)
+	return flagutil.InvalidValueError("rule-type", ruleType, ValidRules...)
 }
 
 func (v *Validator) IsValidRuleConfig(ruleType string, config string) (bool, []string) {

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -57,12 +57,6 @@ one='Config:'
 [registry.rule.common.flag.config]
 one='Configuration value for a rule'
 
-[registry.rule.enable.input.instanceID.message]
-one='Instance ID:'
-
-[registry.rule.enable.input.instanceID.help]
-one='ID of the Service Registry instance to be used. Leave blank to use the currently selected instance'
-
 [registry.rule.enable.input.artifactID.message]
 one='Artifact ID:'
 

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -125,9 +125,9 @@ one = 'No rules enabled'
 
 [registry.rule.list.log.info.describeHint]
 one = '''
-Run describe command to view configuration of an enabled rule:
+Run the following to view the configuration of an enabled rule:
 
-$ rhoas service-registry rule describe --rule-type <compatibility/validity>
+ $ rhoas service-registry rule describe --rule-type <compatibility/validity>
 '''
 
 [registry.rule.list.compatibilityRule.description]

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -106,7 +106,17 @@ one = 'Fetching rules for the artifact'
 one = 'No rules enabled'
 
 [registry.rule.list.log.info.describeHint]
-one = 'Run describe command to view confiuration of enabled rule'
+one = '''
+Run describe command to view configuration of an enabled rule:
+
+$ rhoas service-registry rule describe --rule-type <compatibility/validity>
+'''
+
+[registry.rule.list.compatibilityRule.description]
+one = 'Enforce a compatibility level when updating this artifact (for example, Backwards Compatibility).'
+
+[registry.rule.list.validityRule.description]
+one = 'Ensure that content is valid when updating this artifact.'
 
 [registry.rule.describe.cmd.description.short]
 one='Display configuration of a rule'

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -91,7 +91,7 @@ one = 'Rule successfully enabled'
 one='List validity and compatibility rules'
 
 [registry.rule.list.cmd.description.long]
-one='View validity and compatibility rules for the selected Service Registry instance or specific artifact'
+one='View validity and compatibility rules for the specified Service Registry instance or artifact.'
 
 [registry.rule.list.cmd.example]
 one='''
@@ -121,7 +121,7 @@ one = 'Run describe command to view confiuration of enabled rule'
 one='Display configuration of a rule'
 
 [registry.rule.describe.cmd.description.long]
-one='View configuration details of compatibility or validity rule for the selected Service Registry instance or specific artifact.'
+one='View configuration details of compatibility or validity rule for the specified Service Registry instance or artifact.'
 
 [registry.rule.describe.cmd.example]
 one='''

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -86,3 +86,54 @@ one = 'internal server error'
 
 [registry.rule.enable.log.info.ruleEnabled]
 one = 'Rule successfully enabled'
+
+[registry.rule.list.cmd.description.short]
+one='List validity and compatibility rules'
+
+[registry.rule.list.cmd.description.long]
+one='View validity and compatibility rules for the selected Service Registry instance or specific artifact'
+
+[registry.rule.list.cmd.example]
+one='''
+## List global rules for artifacts of the current Service Registry instance
+$ rhoas service-registry rule list
+
+## List global rule for artifacts of a specific Service Registry instance
+$ rhoas service-registry rule list --instance-id 8ecff228-1ffe-4cf5-b38b-55223885ee00
+
+## List rule for a specific artifact
+$ rhoas service-registry rule list --artifact-id=my-artifact
+'''
+
+[registry.rule.list.log.info.fetching.globalRules]
+one = 'Fetching global rules for artifacts in Service Registry Instance'
+
+[registry.rule.list.log.info.fetching.artifactRules]
+one = 'Fetching rules for the artifact'
+
+[registry.rule.list.log.info.noEnabledRule]
+one = 'No rules enabled'
+
+[registry.rule.list.log.info.describeHint]
+one = 'Run describe command to view confiuration of enabled rule'
+
+[registry.rule.describe.cmd.description.short]
+one='Display configuration of a rule'
+
+[registry.rule.describe.cmd.description.long]
+one='View configuration details of compatibility or validity rule for the selected Service Registry instance or specific artifact.'
+
+[registry.rule.describe.cmd.example]
+one='''
+## Display configuration details of global validity rule for current Service Registry instance
+$ rhoas service-registry rule describe --rule-type=validity
+
+## Display configuration details of compatibility rule for a specific artifact
+$ rhoas service-registry rule describe --rule-type=compatibility --artifact-id=my-artifact --group=my-group
+'''
+
+[registry.rule.describe.log.info.fetching.globalRule]
+one='Fetching global {{.Type}} rule for artifacts in the Service Registry instance'
+
+[registry.rule.describe.log.info.fetching.artifactRule]
+one = 'Fetching {{.Type}} rule for the artifact'

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -60,12 +60,6 @@ one='Configuration value for a rule'
 [registry.rule.common.error.invalidRuleConfig]
 one = 'invalid configuration value "{{.Config}}" for rule type "{{.RuleType}}". Valid operations are: {{.ValidConfigList}}'
 
-[registry.rule.common.error.unauthorized]
-one = 'you are unauthorized to {{.Operation}} this rule'
-
-[registry.rule.common.error.forbidden]
-one = 'you are forbidden to {{.Operation}} this rule'
-
 [registry.rule.common.error.artifactNotFound]
 one = 'artifact with ID {{.ID}} not found'
 
@@ -80,9 +74,6 @@ one = '"{{.Type}}" rule not enabled for Service Registry instance with ID "{{.ID
 
 [registry.rule.common.error.conflict]
 one = 'rule of type "{{.Type}}" is already enabled'
-
-[registry.rule.common.error.internalServerError]
-one = 'internal server error'
 
 [registry.rule.enable.log.info.ruleEnabled]
 one = 'Rule successfully enabled'

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -55,7 +55,25 @@ one='Rule type determines how the content of an artifact can evolve over time'
 one='Config:'
 
 [registry.rule.common.flag.config]
-one='Configuration value for a rule' 
+one='Configuration value for a rule'
+
+[registry.rule.enable.input.instanceID.message]
+one='Instance ID:'
+
+[registry.rule.enable.input.instanceID.help]
+one='ID of the Service Registry instance to be used. Leave blank to use the currently selected instance'
+
+[registry.rule.enable.input.artifactID.message]
+one='Artifact ID:'
+
+[registry.rule.enable.input.artifactID.help]
+one='ID of the artifact. Leave blank for global rule'
+
+[registry.rule.enable.input.group.message]
+one='Group:'
+
+[registry.rule.enable.input.group.help]
+one='Artifact group. Leave blank for global rule'
 
 [registry.rule.common.error.invalidRuleConfig]
 one = 'invalid configuration value "{{.Config}}" for rule type "{{.RuleType}}". Valid operations are: {{.ValidConfigList}}'


### PR DESCRIPTION
Add `describe` and `list` command for `service-registry rules`.

```
Fetching global compatibility rule for artifacts in the Service Registry instance
{
  "config": "FULL",
  "type": "COMPATIBILITY"
}
```

```
Fetching global rules for artifacts in Service Registry Instance

  RULE TYPE       DESCRIPTION                                                 STATUS    
 --------------- ----------------------------------------------------------- ---------- 
  VALIDITY        Ensure that content is valid when updating this artifact.   DISABLED  
  COMPATIBILITY   Enforce a compatibility level when updating this            ENABLED   
                  artifact (for example, Backwards Compatibility).                      

Run describe command to view confiuration of enabled rule
```

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following commands for list operation:
```
rhoas service-registry rule list 
```
```
rhoas service-registry rule list --artifact-id my-id
```
2. Run following commands for describe operation.
```
./rhoas service-registry rule describe --rule-type compatibility
```
```
./rhoas service-registry rule describe --rule-type compatibility --artifact-id my-artifact
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer