### PR TITLE
Interactive create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0
 	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.4.0
-	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.8.2
+	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1
 	github.com/redhat-developer/service-binding-operator v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -703,8 +703,8 @@ github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0 h1:MOljVN8AKT
 github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0/go.mod h1:0LX7ZCEmMKAbncO05/zRYsV0K5wsds7AGPpOFC7KWGo=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.4.0 h1:eAtKA1umUzWMCtfgC28k59xTYS4uAoxIOiSlzdF8NhU=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.4.0/go.mod h1:6CxhBFDnXyrl5rWiLX2iBVs30o7Yhbt63SxGk4ZAnu0=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.8.2 h1:kpLSSOqMTd+aAN9vIQ0B8tOwFeFAcvTWe1rmM+tW4BU=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.8.2/go.mod h1:Bs/YQI9ZuZLzBoeBAWV6KmkO8Jwm8NcrUn3VFp8eleo=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0 h1:wb335WbgyhFZRIHOwqHJm+D877l50MPMacrONCmknnw=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0/go.mod h1:Bs/YQI9ZuZLzBoeBAWV6KmkO8Jwm8NcrUn3VFp8eleo=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1 h1:xRq5XJzRDs/Z7e/9SDt6zbNRIyesC4LTqN9ajHKwjHo=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1/go.mod h1:Z/gr/snlpsqYg4vftmcx97vCR3qMQJhALGelDHx4pMA=
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1 h1:3sUmQ3nAawsYWg7ZCO2Q8HF2J7MW6YA38h/YFL3ao6o=

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -56,13 +56,13 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 
 			var errorCollection []error
 
-			if opts.Operation == "" {
-				errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
-			}
+			// if opts.Operation == "" {
+			// 	errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
+			// }
 
-			if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
-				errorCollection = append(errorCollection, resourceErrors)
-			}
+			// if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
+			// 	errorCollection = append(errorCollection, resourceErrors)
+			// }
 
 			if principalErrors := validateAndSetOpts(opts); principalErrors != nil {
 				errorCollection = append(errorCollection, principalErrors)
@@ -205,37 +205,37 @@ func getRequestParams(opts *aclcmdutil.CrudOptions) *requestParams {
 
 func validateAndSetOpts(opts *aclcmdutil.CrudOptions) error {
 
-	// user and service account should not be provided together
-	if userID != "" && serviceAccount != "" {
-		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
-	}
+	// // user and service account should not be provided together
+	// if userID != "" && serviceAccount != "" {
+	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
+	// }
 
-	if userID == aclcmdutil.Wildcard || serviceAccount == aclcmdutil.Wildcard || userID == aclcmdutil.AllAlias || serviceAccount == aclcmdutil.AllAlias {
-		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
-	}
+	// if userID == aclcmdutil.Wildcard || serviceAccount == aclcmdutil.Wildcard || userID == aclcmdutil.AllAlias || serviceAccount == aclcmdutil.AllAlias {
+	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
+	// }
 
-	if allAccounts {
-		if userID != "" || serviceAccount != "" {
-			return opts.Localizer.MustLocalizeError("kafka.acl.common.error.allAccountsCannotBeUsedWithUserFlag")
-		}
-		opts.Principal = aclcmdutil.Wildcard
-	}
+	// if allAccounts {
+	// 	if userID != "" || serviceAccount != "" {
+	// 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.allAccountsCannotBeUsedWithUserFlag")
+	// 	}
+	// 	opts.Principal = aclcmdutil.Wildcard
+	// }
 
-	// check if principal is provided
-	if !allAccounts && (userID == "" && serviceAccount == "") {
-		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.noPrincipalsSelected")
-	}
+	// // check if principal is provided
+	// if !allAccounts && (userID == "" && serviceAccount == "") {
+	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.noPrincipalsSelected")
+	// }
 
-	opts.PatternType = aclcmdutil.PatternTypeLITERAL
-	if prefix {
-		opts.PatternType = aclcmdutil.PatternTypePREFIX
-	}
+	// opts.PatternType = aclcmdutil.PatternTypeLITERAL
+	// if prefix {
+	// 	opts.PatternType = aclcmdutil.PatternTypePREFIX
+	// }
 
-	if userID != "" {
-		opts.Principal = userID
-	} else if serviceAccount != "" {
-		opts.Principal = serviceAccount
-	}
+	// if userID != "" {
+	// 	opts.Principal = userID
+	// } else if serviceAccount != "" {
+	// 	opts.Principal = serviceAccount
+	// }
 
 	if opts.InstanceID == "" {
 		cfg, err := opts.Config.Load()

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -56,13 +56,13 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 
 			var errorCollection []error
 
-			// if opts.Operation == "" {
-			// 	errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
-			// }
+			if opts.Operation == "" {
+				errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
+			}
 
-			// if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
-			// 	errorCollection = append(errorCollection, resourceErrors)
-			// }
+			if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
+				errorCollection = append(errorCollection, resourceErrors)
+			}
 
 			if principalErrors := validateAndSetOpts(opts); principalErrors != nil {
 				errorCollection = append(errorCollection, principalErrors)
@@ -205,37 +205,37 @@ func getRequestParams(opts *aclcmdutil.CrudOptions) *requestParams {
 
 func validateAndSetOpts(opts *aclcmdutil.CrudOptions) error {
 
-	// // user and service account should not be provided together
-	// if userID != "" && serviceAccount != "" {
-	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
-	// }
+	// user and service account should not be provided together
+	if userID != "" && serviceAccount != "" {
+		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.bothPrincipalsSelected")
+	}
 
-	// if userID == aclcmdutil.Wildcard || serviceAccount == aclcmdutil.Wildcard || userID == aclcmdutil.AllAlias || serviceAccount == aclcmdutil.AllAlias {
-	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
-	// }
+	if userID == aclcmdutil.Wildcard || serviceAccount == aclcmdutil.Wildcard || userID == aclcmdutil.AllAlias || serviceAccount == aclcmdutil.AllAlias {
+		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.useAllAccountsFlag")
+	}
 
-	// if allAccounts {
-	// 	if userID != "" || serviceAccount != "" {
-	// 		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.allAccountsCannotBeUsedWithUserFlag")
-	// 	}
-	// 	opts.Principal = aclcmdutil.Wildcard
-	// }
+	if allAccounts {
+		if userID != "" || serviceAccount != "" {
+			return opts.Localizer.MustLocalizeError("kafka.acl.common.error.allAccountsCannotBeUsedWithUserFlag")
+		}
+		opts.Principal = aclcmdutil.Wildcard
+	}
 
-	// // check if principal is provided
-	// if !allAccounts && (userID == "" && serviceAccount == "") {
-	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.noPrincipalsSelected")
-	// }
+	// check if principal is provided
+	if !allAccounts && (userID == "" && serviceAccount == "") {
+		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.noPrincipalsSelected")
+	}
 
-	// opts.PatternType = aclcmdutil.PatternTypeLITERAL
-	// if prefix {
-	// 	opts.PatternType = aclcmdutil.PatternTypePREFIX
-	// }
+	opts.PatternType = aclcmdutil.PatternTypeLITERAL
+	if prefix {
+		opts.PatternType = aclcmdutil.PatternTypePREFIX
+	}
 
-	// if userID != "" {
-	// 	opts.Principal = userID
-	// } else if serviceAccount != "" {
-	// 	opts.Principal = serviceAccount
-	// }
+	if userID != "" {
+		opts.Principal = userID
+	} else if serviceAccount != "" {
+		opts.Principal = serviceAccount
+	}
 
 	if opts.InstanceID == "" {
 		cfg, err := opts.Config.Load()

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -388,6 +388,14 @@ func validateProviderRegion(conn connection.Connection, opts *options, selectedP
 	return nil
 }
 
+// set type to store the answers from the prompt with defaults
+type promptAnswers struct {
+	Name          string
+	Region        string
+	MultiAZ       bool
+	CloudProvider string
+}
+
 // Show a prompt to allow the user to interactively insert the data for their Kafka
 func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants) (payload *kafkamgmtclient.KafkaRequestPayload, err error) {
 	conn, err := opts.Connection(connection.DefaultConfigSkipMasAuth)
@@ -402,19 +410,13 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		Connection: opts.Connection,
 	}
 
-	// set type to store the answers from the prompt with defaults
-	answers := struct {
-		Name          string
-		Region        string
-		MultiAZ       bool
-		CloudProvider string
-	}{
-		MultiAZ: defaultMultiAZ,
-	}
-
 	promptName := &survey.Input{
 		Message: opts.localizer.MustLocalize("kafka.create.input.name.message"),
 		Help:    opts.localizer.MustLocalize("kafka.create.input.name.help"),
+	}
+
+	answers := &promptAnswers{
+		MultiAZ: defaultMultiAZ,
 	}
 
 	err = survey.AskOne(promptName, &answers.Name, survey.WithValidator(validator.ValidateName), survey.WithValidator(validator.ValidateNameIsAvailable))

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -188,19 +188,20 @@ func runCreate(opts *options) error {
 			opts.region = defaultRegion
 		}
 
+		if !opts.bypassAmsCheck {
+			err = validateProviderAndRegion(opts, constants, conn)
+			if err != nil {
+				return err
+			}
+		}
+
 		payload = &kafkamgmtclient.KafkaRequestPayload{
 			Name:          opts.name,
 			Region:        &opts.region,
 			CloudProvider: &opts.provider,
 			MultiAz:       &opts.multiAZ,
 		}
-	}
 
-	if !opts.bypassAmsCheck {
-		err = validateProviderAndRegion(opts, constants, conn)
-		if err != nil {
-			return err
-		}
 	}
 
 	api := conn.API()

--- a/pkg/cmd/kafka/list/list.go
+++ b/pkg/cmd/kafka/list/list.go
@@ -145,7 +145,8 @@ func runList(opts *options) error {
 func mapResponseItemsToRows(kafkas []kafkamgmtclient.KafkaRequest, selectedId string) []kafkaRow {
 	rows := make([]kafkaRow, len(kafkas))
 
-	for i, k := range kafkas {
+	for i := range kafkas {
+		k := kafkas[i]
 		name := k.GetName()
 		if k.GetId() == selectedId {
 			name = fmt.Sprintf("%s %s", name, icon.Emoji("✔", "(current)"))

--- a/pkg/cmd/serviceaccount/list/list.go
+++ b/pkg/cmd/serviceaccount/list/list.go
@@ -106,7 +106,7 @@ func mapResponseItemsToRows(svcAccts []kafkamgmtclient.ServiceAccountListItem) [
 			ID:        sa.GetId(),
 			Name:      sa.GetName(),
 			ClientID:  sa.GetClientId(),
-			Owner:     sa.GetOwner(),
+			Owner:     sa.GetCreatedBy(),
 			CreatedAt: sa.GetCreatedAt().String(),
 		}
 

--- a/pkg/shared/kafkautil/util.go
+++ b/pkg/shared/kafkautil/util.go
@@ -32,8 +32,8 @@ func RegisterNameFlagCompletionFunc(cmd *cobra.Command, f *factory.Factory) erro
 		}
 
 		items := kafkas.GetItems()
-		for _, kafka := range items {
-			validNames = append(validNames, kafka.GetName())
+		for index := range items {
+			validNames = append(validNames, items[index].GetName())
 		}
 
 		return validNames, directive
@@ -114,10 +114,10 @@ func FindCloudProviderByName(cloudProviders []kafkamgmtclient.CloudProvider, nam
 // GetEnabledCloudRegionIDs extracts and returns a slice of the unique IDs of all enabled regions
 func GetEnabledCloudRegionIDs(regions []kafkamgmtclient.CloudRegion, userAllowedInstanceTypes *[]string) []string {
 	var regionIDs []string
-	for _, region := range regions {
+	for i, region := range regions {
 		if region.GetEnabled() {
 			if userAllowedInstanceTypes != nil {
-				if IsRegionAllowed(region, *userAllowedInstanceTypes) {
+				if IsRegionAllowed(&regions[i], userAllowedInstanceTypes) {
 					regionIDs = append(regionIDs, region.GetId())
 				}
 			} else {
@@ -128,8 +128,8 @@ func GetEnabledCloudRegionIDs(regions []kafkamgmtclient.CloudRegion, userAllowed
 	return regionIDs
 }
 
-func IsRegionAllowed(region kafkamgmtclient.CloudRegion, userAllowedInstanceTypes []string) bool {
-	for _, userInstanceType := range userAllowedInstanceTypes {
+func IsRegionAllowed(region *kafkamgmtclient.CloudRegion, userAllowedInstanceTypes *[]string) bool {
+	for _, userInstanceType := range *userAllowedInstanceTypes {
 		if region.GetSupportedInstanceTypes() != nil {
 			for _, instanceType := range region.GetSupportedInstanceTypes() {
 				if instanceType == userInstanceType {

--- a/pkg/shared/kafkautil/util.go
+++ b/pkg/shared/kafkautil/util.go
@@ -85,7 +85,7 @@ func GetCloudProviderRegionCompletionValues(f *factory.Factory, providerID strin
 	}
 
 	cloudProviders := cloudProviderResponse.GetItems()
-	validRegions = GetEnabledCloudRegionIDs(cloudProviders)
+	validRegions = GetEnabledCloudRegionIDs(cloudProviders, nil)
 
 	return validRegions, directive
 }
@@ -112,14 +112,33 @@ func FindCloudProviderByName(cloudProviders []kafkamgmtclient.CloudProvider, nam
 }
 
 // GetEnabledCloudRegionIDs extracts and returns a slice of the unique IDs of all enabled regions
-func GetEnabledCloudRegionIDs(regions []kafkamgmtclient.CloudRegion) []string {
+func GetEnabledCloudRegionIDs(regions []kafkamgmtclient.CloudRegion, userAllowedInstanceTypes *[]string) []string {
 	var regionIDs []string
 	for _, region := range regions {
 		if region.GetEnabled() {
-			regionIDs = append(regionIDs, region.GetId())
+			if userAllowedInstanceTypes != nil {
+				if IsRegionAllowed(region, *userAllowedInstanceTypes) {
+					regionIDs = append(regionIDs, region.GetId())
+				}
+			} else {
+				regionIDs = append(regionIDs, region.GetId())
+			}
 		}
 	}
 	return regionIDs
+}
+
+func IsRegionAllowed(region kafkamgmtclient.CloudRegion, userAllowedInstanceTypes []string) bool {
+	for _, userInstanceType := range userAllowedInstanceTypes {
+		if region.GetSupportedInstanceTypes() != nil {
+			for _, instanceType := range region.GetSupportedInstanceTypes() {
+				if instanceType == userInstanceType {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // FilterValidTopicNameArgs filters topics from the API and returns the names


### PR DESCRIPTION
## Reason

When creating kafka should:

- not validate interactive mode - it would be valid by default 
- list only supported types for creation

## Verification

```
wtrocki@graphapi app-services-cli (interactive-create)]$ rhoas kafka create            
? Name: test
? Cloud Provider: aws
? Cloud Region:  [Use arrows to move, type to filter, ? for more help]
> us-east-1
```