### PR TITLE
fix: allow to delete all ACLs for principal

### DIFF
--- a/docs/commands/rhoas_kafka_acl_delete.md
+++ b/docs/commands/rhoas_kafka_acl_delete.md
@@ -36,7 +36,7 @@ $ rhoas kafka acl delete --operation all --permission any --group "group-1" --al
       --instance-id string        Kafka instance ID. Uses the current instance if not set
       --operation string          Set the ACL operation. Choose from: "all", "alter", "alter-configs", "create", "delete", "describe", "describe-configs", "read", "write"
   -o, --output string             Specify the output format. Choose from: "json", "yaml", "yml"
-      --pattern-type string       Determine if the resource should be exact match, prefix or any [any literal prefix] (default "literal")
+      --pattern-type string      Allows to specify arguments matching strategy [any literal prefix] (default "literal")
       --permission string         Set the ACL permission. Choose from: "allow", "any", "deny" (default "any")
       --prefix                    Determine if the resource should be exact match or prefix
       --service-account string    Service account client ID used as principal for this operation

--- a/docs/commands/rhoas_kafka_acl_delete.md
+++ b/docs/commands/rhoas_kafka_acl_delete.md
@@ -20,7 +20,7 @@ $ rhoas kafka acl delete --operation write --permission allow --topic all --user
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
 
 # Delete all ACLs for a service account
-$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
+$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81 --pattern-type=all"
 
 # Delete an ACL for all users on the consumer group resource
 $ rhoas kafka acl delete --operation all --permission any --group "group-1" --all-accounts

--- a/docs/commands/rhoas_kafka_acl_delete.md
+++ b/docs/commands/rhoas_kafka_acl_delete.md
@@ -19,6 +19,9 @@ $ rhoas kafka acl delete --operation write --permission allow --topic all --user
 # Delete an ACL for a service account
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
 
+# Delete all ACLs for a service account
+$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
+
 # Delete an ACL for all users on the consumer group resource
 $ rhoas kafka acl delete --operation all --permission any --group "group-1" --all-accounts
 
@@ -33,8 +36,9 @@ $ rhoas kafka acl delete --operation all --permission any --group "group-1" --al
       --instance-id string        Kafka instance ID. Uses the current instance if not set
       --operation string          Set the ACL operation. Choose from: "all", "alter", "alter-configs", "create", "delete", "describe", "describe-configs", "read", "write"
   -o, --output string             Specify the output format. Choose from: "json", "yaml", "yml"
+      --pattern-type string       Determine if the resource should be exact match, prefix or any [any literal prefix] (default "literal")
       --permission string         Set the ACL permission. Choose from: "allow", "any", "deny" (default "any")
-      --prefix                    Determine if the resource should be exact match or prefix
+      --prefix                    DEPRECATED: Determine if the resource should be exact match or prefix. Use --pattern-type instead
       --service-account string    Service account client ID used as principal for this operation
       --topic string              Set the topic resource. When the --prefix option is also passed, this is used as the topic prefix
       --transactional-id string   Set the transactional ID resource

--- a/docs/commands/rhoas_kafka_acl_delete.md
+++ b/docs/commands/rhoas_kafka_acl_delete.md
@@ -36,7 +36,7 @@ $ rhoas kafka acl delete --operation all --permission any --group "group-1" --al
       --instance-id string        Kafka instance ID. Uses the current instance if not set
       --operation string          Set the ACL operation. Choose from: "all", "alter", "alter-configs", "create", "delete", "describe", "describe-configs", "read", "write"
   -o, --output string             Specify the output format. Choose from: "json", "yaml", "yml"
-      --pattern-type string      Allows to specify arguments matching strategy [any literal prefix] (default "literal")
+      --pattern-type string       Allows to specify arguments matching strategy [any literal prefix] (default "literal")
       --permission string         Set the ACL permission. Choose from: "allow", "any", "deny" (default "any")
       --prefix                    Determine if the resource should be exact match or prefix
       --service-account string    Service account client ID used as principal for this operation

--- a/docs/commands/rhoas_kafka_acl_delete.md
+++ b/docs/commands/rhoas_kafka_acl_delete.md
@@ -38,7 +38,7 @@ $ rhoas kafka acl delete --operation all --permission any --group "group-1" --al
   -o, --output string             Specify the output format. Choose from: "json", "yaml", "yml"
       --pattern-type string       Determine if the resource should be exact match, prefix or any [any literal prefix] (default "literal")
       --permission string         Set the ACL permission. Choose from: "allow", "any", "deny" (default "any")
-      --prefix                    DEPRECATED: Determine if the resource should be exact match or prefix. Use --pattern-type instead
+      --prefix                    Determine if the resource should be exact match or prefix
       --service-account string    Service account client ID used as principal for this operation
       --topic string              Set the topic resource. When the --prefix option is also passed, this is used as the topic prefix
       --transactional-id string   Set the transactional ID resource

--- a/pkg/cmd/kafka/acl/aclcmdutil/constants.go
+++ b/pkg/cmd/kafka/acl/aclcmdutil/constants.go
@@ -37,3 +37,5 @@ const (
 	PatternTypePREFIX  = "prefix"
 	PatternTypeANY     = "any"
 )
+
+var PatternTypes = []string{PatternTypeANY, PatternTypeLITERAL, PatternTypePREFIX}

--- a/pkg/cmd/kafka/acl/aclcmdutil/util.go
+++ b/pkg/cmd/kafka/acl/aclcmdutil/util.go
@@ -93,8 +93,8 @@ func IsValidResourceOperation(resourceType string, operation string, resourceOpe
 	return false, resourceOperations
 }
 
-// ValidateAndSetResources validates and sets resources options
-func ValidateAndSetResources(opts *CrudOptions, resourceTypeFlagEntries []*localize.TemplateEntry) error {
+// SetACLResources sets resources options and returns number of changed resources
+func SetACLResources(opts *CrudOptions) int {
 	var selectedResourceTypeCount int
 
 	if opts.Topic != "" {
@@ -118,11 +118,7 @@ func ValidateAndSetResources(opts *CrudOptions, resourceTypeFlagEntries []*local
 		opts.ResourceName = KafkaCluster
 	}
 
-	if selectedResourceTypeCount != 1 {
-		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.oneResourceTypeAllowed", resourceTypeFlagEntries...)
-	}
-
-	return nil
+	return selectedResourceTypeCount
 }
 
 // ValidateAPIError checks for a HTTP error and maps it to a user friendly error

--- a/pkg/cmd/kafka/acl/create/create.go
+++ b/pkg/cmd/kafka/acl/create/create.go
@@ -3,7 +3,7 @@ package create
 import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/aclcmdutil"
-	aclFlagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/flagutil"
+	aclFlagUtil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
@@ -63,8 +63,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
 			}
 
-			if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagutil.ResourceTypeFlagEntries); resourceErrors != nil {
-				errorCollection = append(errorCollection, resourceErrors)
+			selectedResourceTypeCount := aclcmdutil.SetACLResources(opts)
+
+			if selectedResourceTypeCount != 1 {
+				errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.error.oneResourceTypeAllowed", aclFlagUtil.ResourceTypeFlagEntries...))
 			}
 
 			if principalErrors := validateAndSetOpts(opts); principalErrors != nil {
@@ -79,7 +81,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	flags := aclFlagutil.NewFlagSet(cmd, f)
+	flags := aclFlagUtil.NewFlagSet(cmd, f)
 
 	flags.AddPermissionCreate(&opts.Permission)
 	flags.AddOperationCreate(&opts.Operation)

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -91,13 +91,7 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 	flags.AddServiceAccount(&serviceAccount)
 	flags.AddAllAccounts(&allAccounts)
 	flags.AddYes(&opts.SkipConfirm)
-
-	cmd.Flags().BoolVar(
-		&prefix,
-		"prefix",
-		false,
-		flagutil.DeprecateFlag(opts.Localizer.MustLocalize("kafka.acl.common.flag.delete.prefix.description")),
-	)
+	flags.AddPrefix(&prefix)
 
 	cmd.Flags().StringVar(
 		&patternTypeFlag,

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -4,7 +4,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/aclcmdutil"
 	aclFlagUtil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl/flagutil"
-	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
@@ -56,13 +55,13 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 
 			var errorCollection []error
 
-			if opts.Operation == "" {
-				errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
-			}
+			// if opts.Operation == "" {
+			// 	errorCollection = append(errorCollection, opts.Localizer.MustLocalizeError("kafka.acl.common.flag.operation.required"))
+			// }
 
-			if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
-				errorCollection = append(errorCollection, resourceErrors)
-			}
+			// if resourceErrors := aclcmdutil.ValidateAndSetResources(opts, aclFlagUtil.ResourceTypeFlagEntries); resourceErrors != nil {
+			// 	errorCollection = append(errorCollection, resourceErrors)
+			// }
 
 			if principalErrors := validateAndSetOpts(opts); principalErrors != nil {
 				errorCollection = append(errorCollection, principalErrors)
@@ -110,21 +109,21 @@ func runDelete(instanceID string, opts *aclcmdutil.CrudOptions) error {
 		return err
 	}
 
-	resourceOperations, httpRes, err := adminAPI.AclsApi.GetAclResourceOperations(ctx).Execute()
-	if httpRes != nil {
-		defer httpRes.Body.Close()
-	}
-	if err != nil {
-		return err
-	}
+	// resourceOperations, httpRes, err := adminAPI.AclsApi.GetAclResourceOperations(ctx).Execute()
+	// if httpRes != nil {
+	// 	defer httpRes.Body.Close()
+	// }
+	// if err != nil {
+	// 	return err
+	// }
 
-	if isValidOp, validResourceOperations := aclcmdutil.IsValidResourceOperation(opts.ResourceType, opts.Operation, resourceOperations); !isValidOp {
-		return opts.Localizer.MustLocalizeError("kafka.acl.common.error.invalidResourceOperation",
-			localize.NewEntry("ResourceType", opts.ResourceType),
-			localize.NewEntry("Operation", opts.Operation),
-			localize.NewEntry("ValidOperationList", cmdutil.StringSliceToListStringWithQuotes(validResourceOperations)),
-		)
-	}
+	// if isValidOp, validResourceOperations := aclcmdutil.IsValidResourceOperation(opts.ResourceType, opts.Operation, resourceOperations); !isValidOp {
+	// 	return opts.Localizer.MustLocalizeError("kafka.acl.common.error.invalidResourceOperation",
+	// 		localize.NewEntry("ResourceType", opts.ResourceType),
+	// 		localize.NewEntry("Operation", opts.Operation),
+	// 		localize.NewEntry("ValidOperationList", cmdutil.StringSliceToListStringWithQuotes(validResourceOperations)),
+	// 	)
+	// }
 
 	kafkaNameTmplEntry := localize.NewEntry("Name", kafkaInstance.GetName())
 
@@ -150,12 +149,13 @@ func runDelete(instanceID string, opts *aclcmdutil.CrudOptions) error {
 	requestParams := getRequestParams(opts)
 
 	deletedACLs, httpRes, err := adminAPI.AclsApi.DeleteAcls(ctx).
-		ResourceType(requestParams.resourceType).
+		//ResourceType(requestParams.resourceType).
 		Principal(requestParams.principal).
-		PatternType(requestParams.patternType).
-		ResourceName(requestParams.resourceName).
-		Operation(requestParams.operation).
-		Permission(requestParams.permission).
+
+		// PatternType(requestParams.patternType).
+		// ResourceName(requestParams.resourceName).
+		// Operation(requestParams.operation).
+		// Permission(requestParams.permission).
 		Execute()
 
 	if httpRes != nil {

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -257,9 +257,6 @@ func validateAndSetOpts(opts *aclcmdutil.CrudOptions) error {
 	}
 
 	// Backwards compatibility:
-	if prefix {
-		opts.PatternType = aclcmdutil.PatternTypePREFIX
-	}
 
 	switch patternTypeFlag {
 	case aclcmdutil.PatternTypeANY:
@@ -268,6 +265,10 @@ func validateAndSetOpts(opts *aclcmdutil.CrudOptions) error {
 		opts.PatternType = aclcmdutil.PatternTypePREFIX
 	case aclcmdutil.PatternTypeLITERAL:
 		opts.PatternType = aclcmdutil.PatternTypeLITERAL
+	}
+
+	if prefix {
+		opts.PatternType = aclcmdutil.PatternTypePREFIX
 	}
 
 	if userID != "" {

--- a/pkg/cmd/kafka/acl/delete/delete.go
+++ b/pkg/cmd/kafka/acl/delete/delete.go
@@ -107,7 +107,7 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 			localize.NewEntry("Types", aclcmdutil.PatternTypes)),
 	)
 
-	cmd.RegisterFlagCompletionFunc("pattern-type", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc("pattern-type", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return aclcmdutil.PatternTypes, cobra.ShellCompDirectiveNoSpace
 	})
 
@@ -265,9 +265,14 @@ func validateAndSetOpts(opts *aclcmdutil.CrudOptions) error {
 	// Backwards compatibility:
 	if prefix {
 		opts.PatternType = aclcmdutil.PatternTypePREFIX
-	} else if patternTypeFlag == aclcmdutil.PatternTypeANY {
+	}
+
+	switch patternTypeFlag {
+	case aclcmdutil.PatternTypeANY:
 		opts.PatternType = aclcmdutil.PatternTypeANY
-	} else {
+	case aclcmdutil.PatternTypePREFIX:
+		opts.PatternType = aclcmdutil.PatternTypePREFIX
+	case aclcmdutil.PatternTypeLITERAL:
 		opts.PatternType = aclcmdutil.PatternTypeLITERAL
 	}
 

--- a/pkg/core/cmdutil/flagutil/deprecation.go
+++ b/pkg/core/cmdutil/flagutil/deprecation.go
@@ -1,0 +1,6 @@
+package flagutil
+
+// DeprecateFlag provides a way to deprecate a flag by appending standard prefixes to the flag description.
+func DeprecateFlag(flagDescription string) string {
+	return "DEPRECATED: " + flagDescription
+}

--- a/pkg/core/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/core/localize/locales/en/cmd/acl.en.toml
@@ -85,6 +85,12 @@ one = 'Set the resource type to cluster'
 [kafka.acl.common.flag.prefix.description]
 one = 'Determine if the resource should be exact match or prefix'
 
+[kafka.acl.common.flag.delete.prefix.description]
+one = 'Determine if the resource should be exact match or prefix. Use --pattern-type instead'
+
+[kafka.acl.common.flag.patterntypes.description]
+one = 'Determine if the resource should be exact match, prefix or any {{.Types}}'
+
 [kafka.acl.common.flag.topic.description]
 one = 'Set the topic resource. When the --prefix option is also passed, this is used as the topic prefix'
 

--- a/pkg/core/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/core/localize/locales/en/cmd/acl.en.toml
@@ -86,7 +86,7 @@ one = 'Set the resource type to cluster'
 one = 'Determine if the resource should be exact match or prefix'
 
 [kafka.acl.common.flag.patterntypes.description]
-one = 'Determine if the resource should be exact match, prefix or any {{.Types}}'
+one = 'Allows to specify arguments matching strategy {{.Types}}'
 
 [kafka.acl.common.flag.topic.description]
 one = 'Set the topic resource. When the --prefix option is also passed, this is used as the topic prefix'

--- a/pkg/core/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/core/localize/locales/en/cmd/acl.en.toml
@@ -291,6 +291,9 @@ $ rhoas kafka acl delete --operation write --permission allow --topic all --user
 # Delete an ACL for a service account
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
 
+# Delete all ACLs for a service account
+$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
+
 # Delete an ACL for all users on the consumer group resource
 $ rhoas kafka acl delete --operation all --permission any --group "group-1" --all-accounts
 '''

--- a/pkg/core/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/core/localize/locales/en/cmd/acl.en.toml
@@ -85,9 +85,6 @@ one = 'Set the resource type to cluster'
 [kafka.acl.common.flag.prefix.description]
 one = 'Determine if the resource should be exact match or prefix'
 
-[kafka.acl.common.flag.delete.prefix.description]
-one = 'Determine if the resource should be exact match or prefix. Use --pattern-type instead'
-
 [kafka.acl.common.flag.patterntypes.description]
 one = 'Determine if the resource should be exact match, prefix or any {{.Types}}'
 

--- a/pkg/core/localize/locales/en/cmd/acl.en.toml
+++ b/pkg/core/localize/locales/en/cmd/acl.en.toml
@@ -298,7 +298,7 @@ $ rhoas kafka acl delete --operation write --permission allow --topic all --user
 $ rhoas kafka acl delete --operation all --permission any --topic "rhoas" --prefix --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
 
 # Delete all ACLs for a service account
-$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81"
+$ rhoas kafka acl delete --service-account "srvc-acct-11924479-43fe-42b4-9676-cf0c9aca81 --pattern-type=all"
 
 # Delete an ACL for all users on the consumer group resource
 $ rhoas kafka acl delete --operation all --permission any --group "group-1" --all-accounts


### PR DESCRIPTION
Creating for early feedback for https://github.com/redhat-developer/app-services-cli/issues/1430

Validation for delete command were redundant preventing users from deleting multiple acls. 
For example it would not be possible to remove all ACLs for Service account.

After this change it is possible:

```
✔️  Deleted 5 ACLs from Kafka instance "wtrocki"
The following ACL rules were deleted:

  PRINCIPAL (5)    PERMISSION   OPERATION   DESCRIPTION               
 ---------------- ------------ ----------- -------------------------- 
  test             allow        write       transactional-id is "*"   
  test             allow        describe    topic starts with "test"  
  test             allow        write       topic starts with "test"  
  test             allow        create      topic starts with "test"  
  test             allow        describe    transactional-id is "*"   
  ```

However we need to still spend some time cleaning up messages/validation and arguments to API.
Posted for early feedback

## Verification
```
[wtrocki@graphapi app-services-cli (delete-acl)]$ rhoas kafka acl delete --pattern-type=any --service-account=test
? All ACLs matching the criteria provided will be deleted from the Kafka instance "wtrocki". Are you sure you want to proceed? Yes


✔️  Deleted 5 ACLs from Kafka instance "wtrocki"
The following ACL rules were deleted:

  PRINCIPAL (5)    PERMISSION   OPERATION   DESCRIPTION               
 ---------------- ------------ ----------- -------------------------- 
  test             allow        describe    topic starts with "test"  
  test             allow        write       transactional-id is "*"   
  test             allow        describe    transactional-id is "*"   
  test             allow        write       topic starts with "test"  
  test             allow        create      topic starts with "test" 
  ```

Delete all write operations for sa
```
rhoas kafka acl delete --service-account=test1 --operation=write -v --pattern-type=any
```

other variations