### PR TITLE
fix: clarify errors for kafka create

### DIFF
--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -217,8 +217,10 @@ func runCreate(opts *options) error {
 
 	if apiErr := kafkamgmtv1errors.GetAPIError(err); apiErr != nil {
 		switch apiErr.GetCode() {
-		case kafkamgmtv1errors.ERROR_24:
+		case kafkamgmtv1errors.ERROR_120:
 			return opts.localizer.MustLocalizeError("kafka.create.error.oneinstance")
+		case kafkamgmtv1errors.ERROR_24:
+			return opts.localizer.MustLocalizeError("kafka.create.error.temporary.unavailable")
 		case kafkamgmtv1errors.ERROR_36:
 			return opts.localizer.MustLocalizeError("kafka.create.error.conflictError", localize.NewEntry("Name", payload.Name))
 		}

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -317,7 +317,10 @@ one = 'name is required. Run "rhoas kafka create --name my-kafka"'
 one = 'Kafka instance "{{.Name}}" already exists'
 
 [kafka.create.error.oneinstance]
-one = 'unable to create new Kafka instance. Only one instance is allowed with an eval account'
+one = 'maximum number of allowed instances reached. Please review all instances that your user has access to and delete one or more instances before creating a new one.'
+
+[kafka.create.error.temporary.unavailable]
+one = 'unable to create new Kafka instance at this time in specified cloud provider and region. Please try again later or choose another region.'
 
 [kafka.create.region.error.invalidRegion]
 one = '''


### PR DESCRIPTION
Switching to support all error types that we can get back from the API