### PR TITLE
fix(service-registry rule): confirm prompt ant remove spinners

### DIFF
--- a/docs/commands/rhoas_service-registry_rule_disable.md
+++ b/docs/commands/rhoas_service-registry_rule_disable.md
@@ -31,6 +31,7 @@ $ rhoas service-registry rule disable --rule-type=validity --artifact-id=my-arti
   -g, --group string         Artifact group (default "default")
       --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
       --rule-type string     Rule type determines how the content of an artifact can evolve over time
+  -y, --yes                  Disable rule(s) without prompt
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/registry/rule/describe/describe.go
+++ b/pkg/cmd/registry/rule/describe/describe.go
@@ -9,7 +9,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/spinner"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
@@ -123,9 +122,7 @@ func runDescribe(opts *options) error {
 
 	if opts.artifactID == "" {
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.describe.log.info.fetching.globalRule", localize.NewEntry("Type", opts.ruleType))
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.describe.log.info.fetching.globalRule", localize.NewEntry("Type", opts.ruleType)))
 
 		req := dataAPI.AdminApi.GetGlobalRuleConfig(opts.Context, *rulecmdutil.GetMappedRuleType(opts.ruleType))
 
@@ -133,8 +130,6 @@ func runDescribe(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	} else {
 
 		if opts.group == registrycmdutil.DefaultArtifactGroup {
@@ -151,9 +146,7 @@ func runDescribe(opts *options) error {
 			return registrycmdutil.TransformInstanceError(err)
 		}
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.describe.log.info.fetching.artifactRule", localize.NewEntry("Type", opts.ruleType))
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.describe.log.info.fetching.artifactRule", localize.NewEntry("Type", opts.ruleType)))
 
 		ruleTypeParam := string(*rulecmdutil.GetMappedRuleType(opts.ruleType))
 
@@ -163,8 +156,6 @@ func runDescribe(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	}
 
 	if err != nil {

--- a/pkg/cmd/registry/rule/disable/disable.go
+++ b/pkg/cmd/registry/rule/disable/disable.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/spinner"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
-	"github.com/spf13/cobra"
-
 	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	"github.com/spf13/cobra"
 )
 
 type options struct {
@@ -32,6 +32,8 @@ type options struct {
 	registryID string
 	artifactID string
 	group      string
+
+	skipConfirm bool
 }
 
 // NewDisableCommand creates a new command for disabling rule
@@ -53,6 +55,10 @@ func NewDisableCommand(f *factory.Factory) *cobra.Command {
 		Example: f.Localizer.MustLocalize("registry.rule.disable.cmd.example"),
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			if !opts.IO.CanPrompt() && !opts.skipConfirm {
+				return flagutil.RequiredWhenNonInteractiveError("yes")
+			}
 
 			validator := rulecmdutil.Validator{
 				Localizer: opts.localizer,
@@ -78,6 +84,8 @@ func NewDisableCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(&opts.skipConfirm, "yes", "y", false, opts.localizer.MustLocalize("registry.rule.disable.flag.yes"))
+
 	flags := rulecmdutil.NewFlagSet(cmd, f)
 
 	flags.AddRegistryInstance(&opts.registryID)
@@ -97,6 +105,20 @@ func runDisable(opts *options) error {
 	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
 		return err
+	}
+
+	if !opts.skipConfirm {
+		prompt := &survey.Confirm{
+			Message: opts.localizer.MustLocalize("registry.rule.disable.confirm"),
+		}
+		if promptErr := survey.AskOne(prompt, &opts.skipConfirm); err != nil {
+			return promptErr
+		}
+
+		if !opts.skipConfirm {
+			opts.Logger.Debug(opts.localizer.MustLocalize("registry.rule.disable.prompt.denied"))
+			return nil
+		}
 	}
 
 	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)
@@ -161,26 +183,18 @@ func disableGlobalRule(opts *options, dataAPI *registryinstanceclient.APIClient)
 
 	if opts.ruleType != "" {
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.disable.log.info.disabling.globalRule", localize.NewEntry("RuleType", opts.ruleType))
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.disable.log.info.disabling.globalRule", localize.NewEntry("RuleType", opts.ruleType)))
 
 		req := dataAPI.AdminApi.DeleteGlobalRule(opts.Context, *rulecmdutil.GetMappedRuleType(opts.ruleType))
 
 		httpRes, err = req.Execute()
-
-		s.Stop()
 	} else {
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.disable.log.info.disabling.globalRules", localize.NewEntry("RuleType", opts.ruleType))
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.disable.log.info.disabling.globalRules", localize.NewEntry("RuleType", opts.ruleType)))
 
 		req := dataAPI.AdminApi.DeleteAllGlobalRules(opts.Context)
 
 		httpRes, err = req.Execute()
-
-		s.Stop()
 	}
 
 	return httpRes, err
@@ -189,13 +203,12 @@ func disableGlobalRule(opts *options, dataAPI *registryinstanceclient.APIClient)
 func disableArtifactRule(opts *options, dataAPI *registryinstanceclient.APIClient) (httpRes *http.Response, err error) {
 	if opts.ruleType != "" {
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix(
-			"registry.rule.disable.log.info.disabling.artifactRule",
-			localize.NewEntry("RuleType", opts.ruleType),
-			localize.NewEntry("ArtifactID", opts.artifactID),
+		opts.Logger.Info(
+			opts.localizer.MustLocalize("registry.rule.disable.log.info.disabling.artifactRule",
+				localize.NewEntry("RuleType", opts.ruleType),
+				localize.NewEntry("ArtifactID", opts.artifactID),
+			),
 		)
-		s.Start()
 
 		req := dataAPI.ArtifactRulesApi.DeleteArtifactRule(opts.Context, opts.group, opts.artifactID, string(*rulecmdutil.GetMappedRuleType(opts.ruleType)))
 
@@ -204,12 +217,8 @@ func disableArtifactRule(opts *options, dataAPI *registryinstanceclient.APIClien
 			defer httpRes.Body.Close()
 		}
 
-		s.Stop()
 	} else {
-
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.disable.log.info.disabling.artifactRules", localize.NewEntry("ArtifactID", opts.artifactID))
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.disable.log.info.disabling.artifactRules", localize.NewEntry("ArtifactID", opts.artifactID)))
 
 		req := dataAPI.ArtifactRulesApi.DeleteArtifactRules(opts.Context, opts.group, opts.artifactID)
 
@@ -217,8 +226,6 @@ func disableArtifactRule(opts *options, dataAPI *registryinstanceclient.APIClien
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	}
 
 	return httpRes, err

--- a/pkg/cmd/registry/rule/disable/disable.go
+++ b/pkg/cmd/registry/rule/disable/disable.go
@@ -114,11 +114,6 @@ func runDisable(opts *options) error {
 		if promptErr := survey.AskOne(prompt, &opts.skipConfirm); err != nil {
 			return promptErr
 		}
-
-		if !opts.skipConfirm {
-			opts.Logger.Debug(opts.localizer.MustLocalize("registry.rule.disable.prompt.denied"))
-			return nil
-		}
 	}
 
 	dataAPI, _, err := conn.API().ServiceRegistryInstance(opts.registryID)

--- a/pkg/cmd/registry/rule/enable/enable.go
+++ b/pkg/cmd/registry/rule/enable/enable.go
@@ -12,7 +12,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/spinner"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
@@ -149,13 +148,12 @@ func runEnable(opts *options) error {
 
 	if opts.artifactID == "" {
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix(
-			"registry.rule.enable.log.info.enabling.globalRules",
-			localize.NewEntry("RuleType", opts.ruleType),
-			localize.NewEntry("Configuration", opts.config),
+		opts.Logger.Info(
+			opts.localizer.MustLocalize("registry.rule.enable.log.info.enabling.globalRules",
+				localize.NewEntry("RuleType", opts.ruleType),
+				localize.NewEntry("Configuration", opts.config),
+			),
 		)
-		s.Start()
 
 		req := dataAPI.AdminApi.CreateGlobalRule(opts.Context)
 
@@ -165,22 +163,19 @@ func runEnable(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	} else {
 
 		if opts.group == registrycmdutil.DefaultArtifactGroup {
 			opts.Logger.Info(opts.localizer.MustLocalize("registry.artifact.common.message.no.group", localize.NewEntry("DefaultArtifactGroup", registrycmdutil.DefaultArtifactGroup)))
 		}
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix(
-			"registry.rule.enable.log.info.enabling.artifactRules",
-			localize.NewEntry("RuleType", opts.ruleType),
-			localize.NewEntry("Configuration", opts.config),
-			localize.NewEntry("ArtifactID", opts.artifactID),
+		opts.Logger.Info(
+			opts.localizer.MustLocalize("registry.rule.enable.log.info.enabling.artifactRules",
+				localize.NewEntry("RuleType", opts.ruleType),
+				localize.NewEntry("Configuration", opts.config),
+				localize.NewEntry("ArtifactID", opts.artifactID),
+			),
 		)
-		s.Start()
 
 		req := dataAPI.ArtifactRulesApi.CreateArtifactRule(opts.Context, opts.group, opts.artifactID)
 
@@ -190,8 +185,6 @@ func runEnable(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	}
 
 	ruleErrHandler := &rulecmdutil.RuleErrHandler{

--- a/pkg/cmd/registry/rule/list/list.go
+++ b/pkg/cmd/registry/rule/list/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/spinner"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
@@ -120,9 +119,8 @@ func runList(opts *options) error {
 	}
 
 	if opts.artifactID == "" {
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.list.log.info.fetching.globalRules")
-		s.Start()
+
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.list.log.info.fetching.globalRules"))
 
 		req := dataAPI.AdminApi.ListGlobalRules(opts.Context)
 
@@ -130,16 +128,12 @@ func runList(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	} else {
 		if opts.group == registrycmdutil.DefaultArtifactGroup {
 			opts.Logger.Info(opts.localizer.MustLocalize("registry.artifact.common.message.no.group", localize.NewEntry("DefaultArtifactGroup", registrycmdutil.DefaultArtifactGroup)))
 		}
 
-		s := spinner.New(opts.IO.ErrOut, opts.localizer)
-		s.SetLocalizedSuffix("registry.rule.list.log.info.fetching.artifactRules")
-		s.Start()
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.rule.list.log.info.fetching.artifactRules"))
 
 		req := dataAPI.ArtifactRulesApi.ListArtifactRules(opts.Context, opts.group, opts.artifactID)
 
@@ -147,8 +141,6 @@ func runList(opts *options) error {
 		if httpRes != nil {
 			defer httpRes.Body.Close()
 		}
-
-		s.Stop()
 	}
 
 	if newErr != nil {

--- a/pkg/cmd/registry/rule/update/update.go
+++ b/pkg/cmd/registry/rule/update/update.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/spinner"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
@@ -169,13 +168,12 @@ func runUpdate(opts *options) error {
 
 func updateGlobalRule(opts *options, dataAPI *registryinstanceclient.APIClient) (httpRes *http.Response, err error) {
 
-	s := spinner.New(opts.IO.ErrOut, opts.localizer)
-	s.SetLocalizedSuffix(
-		"registry.rule.update.log.info.updating.globalRule",
-		localize.NewEntry("RuleType", opts.ruleType),
-		localize.NewEntry("Configuration", opts.config),
+	opts.Logger.Info(
+		opts.localizer.MustLocalize("registry.rule.update.log.info.updating.globalRule",
+			localize.NewEntry("RuleType", opts.ruleType),
+			localize.NewEntry("Configuration", opts.config),
+		),
 	)
-	s.Start()
 
 	req := dataAPI.AdminApi.UpdateGlobalRuleConfig(opts.Context, *rulecmdutil.GetMappedRuleType(opts.ruleType))
 
@@ -188,21 +186,18 @@ func updateGlobalRule(opts *options, dataAPI *registryinstanceclient.APIClient) 
 
 	_, httpRes, err = req.Execute()
 
-	s.Stop()
-
 	return httpRes, err
 }
 
 func updateArtifactRule(opts *options, dataAPI *registryinstanceclient.APIClient) (httpRes *http.Response, err error) {
 
-	s := spinner.New(opts.IO.ErrOut, opts.localizer)
-	s.SetLocalizedSuffix(
-		"registry.rule.update.log.info.updating.artifactRule",
-		localize.NewEntry("RuleType", opts.ruleType),
-		localize.NewEntry("Configuration", opts.config),
-		localize.NewEntry("ArtifactID", opts.artifactID),
+	opts.Logger.Info(
+		opts.localizer.MustLocalize("registry.rule.update.log.info.updating.artifactRule",
+			localize.NewEntry("RuleType", opts.ruleType),
+			localize.NewEntry("Configuration", opts.config),
+			localize.NewEntry("ArtifactID", opts.artifactID),
+		),
 	)
-	s.Start()
 
 	req := dataAPI.ArtifactRulesApi.UpdateArtifactRuleConfig(opts.Context, opts.group, opts.artifactID, string(*rulecmdutil.GetMappedRuleType(opts.ruleType)))
 
@@ -217,8 +212,6 @@ func updateArtifactRule(opts *options, dataAPI *registryinstanceclient.APIClient
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
-
-	s.Stop()
 
 	return httpRes, err
 }

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -187,9 +187,6 @@ one = 'Disable rule(s) without prompt'
 [registry.rule.disable.confirm]
 one='Do you want to disable specified rule(s)?'
 
-[registry.rule.disable.prompt.denied]
-one='User has chosen to not disable rule(s)'
-
 [registry.rule.disable.log.info.success]
 one='Successfully disabled'
 

--- a/pkg/core/localize/locales/en/cmd/rule.en.toml
+++ b/pkg/core/localize/locales/en/cmd/rule.en.toml
@@ -181,6 +181,15 @@ one='Disabling "{{.RuleType}}" rule for artifact with ID "{{.ArtifactID}}"'
 [registry.rule.disable.log.info.disabling.artifactRules]
 one='Disabling all rules for artifact with ID "{{.ArtifactID}}"'
 
+[registry.rule.disable.flag.yes]
+one = 'Disable rule(s) without prompt'
+
+[registry.rule.disable.confirm]
+one='Do you want to disable specified rule(s)?'
+
+[registry.rule.disable.prompt.denied]
+one='User has chosen to not disable rule(s)'
+
 [registry.rule.disable.log.info.success]
 one='Successfully disabled'
 


### PR DESCRIPTION
Add confirmation for disable operation and remove spinners

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Disable rule with and without passing `--y` flag.
2. Run any rule command to check the help texts

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer