### PR TITLE
ci: notify tools repo when there is a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Release
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
       -
@@ -73,3 +73,19 @@ jobs:
           repository: redhat-developer/app-services-guides
           event-type: rhoas-cli-release
           client-payload: '{"version": steps.set-version.outputs.version }'
+  quay-release:
+    depends-on: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Notify tools repo
+        uses: actions/github-script@v6
+        with: 
+          script: |
+            github.request('POST /repos/redhat-developer/app-services-tools/actions/workflows/42/dispatches', {
+              workflow_id: 42,
+              ref: 'ref',
+              inputs: {
+                rhoasVersion: context.ref.replace(/^refs\/tags\//, '')
+              }
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,9 @@ jobs:
           repository: redhat-developer/app-services-guides
           event-type: rhoas-cli-release
           client-payload: '{"version": steps.set-version.outputs.version }'
-  quay-release:
-    depends-on: release
+  tools-release:
+    if: steps.check-tag.outputs.prerelease == 'false'
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -82,8 +83,8 @@ jobs:
         uses: actions/github-script@v6
         with: 
           script: |
-            github.request('POST /repos/redhat-developer/app-services-tools/actions/workflows/42/dispatches', {
-              workflow_id: 42,
+            github.request('POST /repos/redhat-developer/app-services-tools/actions/workflows/20880234/dispatches', {
+              workflow_id: 20880234,
               ref: 'ref',
               inputs: {
                 rhoasVersion: context.ref.replace(/^refs\/tags\//, '')


### PR DESCRIPTION
Sends a workflow dispatch event to https://github.com/redhat-developer/app-services-tools to initiate a new image release to Quay.

There is no way to verify this until our next release.