### PR TITLE
fix: build failing at test

### DIFF
--- a/docs/commands/rhoas_kafka_topic_create.md
+++ b/docs/commands/rhoas_kafka_topic_create.md
@@ -29,7 +29,7 @@ $ rhoas kafka topic create --name topic-1
   -o, --output string           Specify the output format. Choose from: "json", "yaml", "yml"
       --partitions int32        The number of partitions in the topic (default 1)
       --retention-bytes int     The maximum total size of a partition log segments before old log segments are deleted to free up space.
-                                Value of -1 is set by default indicating no retention size limits. (default -1)
+                                Value of -1 is set by default indicating no retention size limits (default -1)
       --retention-ms int        The period of time in milliseconds the broker will retain a partition log before deleting it (default 604800000)
 ```
 

--- a/docs/commands/rhoas_kafka_topic_update.md
+++ b/docs/commands/rhoas_kafka_topic_update.md
@@ -26,7 +26,7 @@ $ rhoas kafka topic update --name topic-1 --retention-ms -1
       --name string              Topic name
       --partitions string        The number of partitions in the topic
       --retention-bytes string   The maximum total size of a partition log segments before old log segments are deleted to free up space.
-                                 Value of -1 is set by default indicating no retention size limits.
+                                 Value of -1 is set by default indicating no retention size limits
       --retention-ms string      The period of time in milliseconds the broker will retain a partition log before deleting it
 ```
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -500,7 +500,7 @@ one = 'The period of time in milliseconds the broker will retain a partition log
 [kafka.topic.common.input.retentionBytes.description]
 description = 'Description for the Retention size input'
 one = '''The maximum total size of a partition log segments before old log segments are deleted to free up space.
-Value of -1 is set by default indicating no retention size limits.'''
+Value of -1 is set by default indicating no retention size limits'''
 
 [kafka.topic.common.input.cleanupPolicy.description]
 description = 'Description for the Cleanup policy input'


### PR DESCRIPTION
The build is currently failing as flag description for topic retention byte ends with a fullstop.
### Verification Steps
The build GitHub action should pass.

```
--- FAIL: Test_ValidateCommandsUsingCharmilValidator (0.01s)
    validator_test.go:56: validationErr was not empty, got length: 2; want 0
    validator_test.go:61: PUNCTUATION_RULE: cmd rhoas kafka topic create: full stop in the flag usage
    validator_test.go:61: PUNCTUATION_RULE: cmd rhoas kafka topic update: full stop in the flag usage
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [X] Documentation added for the feature
- [X] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer