### PR TITLE
Added a "none" option to the Validity rule config options (Service Registry)

### DIFF
--- a/pkg/cmd/registry/rule/rulecmdutil/mappings.go
+++ b/pkg/cmd/registry/rule/rulecmdutil/mappings.go
@@ -45,5 +45,5 @@ func GetMappedConfigValue(config string) string {
 
 var ValidRuleConfigs = map[string][]string{
 	CompatibilityRule: {ConfigBACKWARD, ConfigBACKWARD_TRANSITIVE, ConfigFORWARD, ConfigFORWARD_TRANSITIVE, ConfigFULL, ConfigFULL_TRANSITIVE, ConfigNONE},
-	ValidityRule:      {ConfigFULL, ConfigSYNTAX_ONLY},
+	ValidityRule:      {ConfigFULL, ConfigSYNTAX_ONLY, ConfigNONE},
 }


### PR DESCRIPTION
See https://github.com/Apicurio/apicurio-tasks/issues/154

Closes https://github.com/Apicurio/apicurio-tasks/issues/154

### Verification Steps
Configure a global validity rule like this:

`rhoas service-registry rule enable --config none --rule-type validity`

The action should succeed.  Then confirm using:

```
$ rhoas service-registry rule describe --rule-type validity
Fetching global validity rule for artifacts in the Service Registry instance with ID "123xyz"
{
  "config": "NONE",
  "type": "VALIDITY"
}
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
