### PR TITLE
fix: add server side backed up metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0
-	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.5.0
+	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0
 	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/redhat-developer/app-services-sdk-go v0.10.0 h1:zI0X5FR0NOj6IwBWk3y1T
 github.com/redhat-developer/app-services-sdk-go v0.10.0/go.mod h1:enn8Zz6IT0HZYzS6LSttiME2apwnvfVWZnGRS81A4rk=
 github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0 h1:MOljVN8AKTM72Yed8ioAwhdW0KdWEhBZjjam3lY2lyY=
 github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0/go.mod h1:0LX7ZCEmMKAbncO05/zRYsV0K5wsds7AGPpOFC7KWGo=
-github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.5.0 h1:1FMsZfo2xCtYimrBcR+s0O0b0MzxdxiStY8A78oTGBA=
-github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.5.0/go.mod h1:UYJgMZWmd238bk6l464U1g8I3YWcEE9PGnjvNRi5Lqw=
+github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0 h1:ExEHQaihnPNxN2nKXB0q5nrmSv4p8b3Idzt7TChxv+Q=
+github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0/go.mod h1:hMpejngP3BFnifCDH1gKRG9cU9Q4lr0WiQaW7A1LYo4=
 github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0 h1:wb335WbgyhFZRIHOwqHJm+D877l50MPMacrONCmknnw=
 github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.9.0/go.mod h1:Bs/YQI9ZuZLzBoeBAWV6KmkO8Jwm8NcrUn3VFp8eleo=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1 h1:xRq5XJzRDs/Z7e/9SDt6zbNRIyesC4LTqN9ajHKwjHo=
@@ -910,7 +910,6 @@ golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a h1:qfl7ob3DIEs3Ml9oLuPwY2N04gymzAW04WsUQHIClgM=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/groupcmdutil"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/shared/kafkautil"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
@@ -188,10 +187,11 @@ func mapConsumerGroupDescribeToTableFormat(consumers []kafkainstanceclient.Consu
 func printConsumerGroupDetails(w io.Writer, consumerGroupData kafkainstanceclient.ConsumerGroup, localizer localize.Localizer) {
 	fmt.Fprintln(w, "")
 	consumers := consumerGroupData.GetConsumers()
+	metrics := consumerGroupData.GetMetrics()
 
-	activeMembersCount := groupcmdutil.GetActiveConsumersCount(consumers)
-	partitionsWithLagCount := groupcmdutil.GetPartitionsWithLag(consumers)
-	unassignedPartitions := groupcmdutil.GetUnassignedPartitions(consumers)
+	activeMembersCount := metrics.GetActiveConsumers()
+	partitionsWithLagCount := metrics.GetLaggingPartitions()
+	unassignedPartitions := metrics.GetUnassignedPartitions()
 
 	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unassignedPartitions")), unassignedPartitions)
 	fmt.Fprintln(w, "")

--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -38,9 +38,9 @@ type consumerRow struct {
 	MemberID      string `json:"memberId,omitempty" header:"Consumer ID"`
 	Partition     int    `json:"partition,omitempty" header:"Partition"`
 	Topic         string `json:"topic,omitempty" header:"Topic"`
-	LogEndOffset  int    `json:"logEndOffset,omitempty" header:"Log end offset"`
-	CurrentOffset int    `json:"offset,omitempty" header:"Current offset"`
-	OffsetLag     int    `json:"lag,omitempty" header:"Offset lag"`
+	LogEndOffset  int64  `json:"logEndOffset,omitempty" header:"Log end offset"`
+	CurrentOffset int64  `json:"offset,omitempty" header:"Current offset"`
+	OffsetLag     int64  `json:"lag,omitempty" header:"Offset lag"`
 }
 
 // NewDescribeConsumerGroupCommand gets a new command for describing a consumer group.
@@ -163,9 +163,9 @@ func mapConsumerGroupDescribeToTableFormat(consumers []kafkainstanceclient.Consu
 			Partition:     int(consumer.GetPartition()),
 			Topic:         consumer.GetTopic(),
 			MemberID:      consumer.GetMemberId(),
-			LogEndOffset:  int(consumer.GetLogEndOffset()),
-			CurrentOffset: int(consumer.GetOffset()),
-			OffsetLag:     int(consumer.GetLag()),
+			LogEndOffset:  consumer.GetLogEndOffset(),
+			CurrentOffset: consumer.GetOffset(),
+			OffsetLag:     consumer.GetLag(),
 		}
 
 		if consumer.GetMemberId() == "" {

--- a/pkg/cmd/kafka/consumergroup/groupcmdutil/util.go
+++ b/pkg/cmd/kafka/consumergroup/groupcmdutil/util.go
@@ -13,32 +13,3 @@ const (
 )
 
 var ValidOffsets = []string{OffsetAbsolute, OffsetEarliest, OffsetTimestamp, OffsetLatest}
-
-// GetPartitionsWithLag returns the number of partitions having lag for a consumer group
-func GetPartitionsWithLag(consumers []kafkainstanceclient.Consumer) (partitionsWithLag int) {
-	for _, consumer := range consumers {
-		if consumer.Lag > 0 {
-			partitionsWithLag++
-		}
-	}
-
-	return partitionsWithLag
-}
-
-func GetActiveConsumersCount(consumers []kafkainstanceclient.Consumer) (count int) {
-	for _, c := range consumers {
-		if c.Partition != -1 {
-			count++
-		}
-	}
-	return count
-}
-
-func GetUnassignedPartitions(consumers []kafkainstanceclient.Consumer) (unassignedPartitions int) {
-	for _, c := range consumers {
-		if c.GetMemberId() == "" {
-			unassignedPartitions++
-		}
-	}
-	return unassignedPartitions
-}

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup/groupcmdutil"
 	kafkacmdutil "github.com/redhat-developer/app-services-cli/pkg/shared/kafkautil"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
@@ -179,11 +178,11 @@ func mapConsumerGroupResultsToTableFormat(consumerGroups []kafkainstanceclient.C
 	rows := make([]consumerGroupRow, len(consumerGroups))
 
 	for i, t := range consumerGroups {
-		consumers := t.GetConsumers()
+		metrics := t.GetMetrics()
 		row := consumerGroupRow{
 			ConsumerGroupID:   t.GetGroupId(),
-			ActiveMembers:     groupcmdutil.GetActiveConsumersCount(consumers),
-			PartitionsWithLag: groupcmdutil.GetPartitionsWithLag(consumers),
+			ActiveMembers:     int(metrics.GetActiveConsumers()),
+			PartitionsWithLag: int(metrics.GetLaggingPartitions()),
 		}
 		rows[i] = row
 	}

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -40,8 +40,8 @@ type options struct {
 
 type consumerGroupRow struct {
 	ConsumerGroupID   string `json:"groupId,omitempty" header:"Consumer group ID"`
-	ActiveMembers     int    `json:"active_members,omitempty" header:"Active members"`
-	PartitionsWithLag int    `json:"lag,omitempty" header:"Partitions with lag"`
+	ActiveMembers     int32  `json:"active_members,omitempty" header:"Active members"`
+	PartitionsWithLag int32  `json:"lag,omitempty" header:"Partitions with lag"`
 }
 
 // NewListConsumerGroupCommand creates a new command to list consumer groups
@@ -181,8 +181,8 @@ func mapConsumerGroupResultsToTableFormat(consumerGroups []kafkainstanceclient.C
 		metrics := t.GetMetrics()
 		row := consumerGroupRow{
 			ConsumerGroupID:   t.GetGroupId(),
-			ActiveMembers:     int(metrics.GetActiveConsumers()),
-			PartitionsWithLag: int(metrics.GetLaggingPartitions()),
+			ActiveMembers:     metrics.GetActiveConsumers(),
+			PartitionsWithLag: metrics.GetLaggingPartitions(),
 		}
 		rows[i] = row
 	}


### PR DESCRIPTION
## Motivation

This change uses backend compiled metrics for consumer groups. 
This have been in production for quite a while and have been extensively tested.

## Verification

1. Get Kafka
2. Create new topic `test`
3. Create kcat.properties based of the kcat guide
4. kcat -b <yourhostname -F ./kcat.properties -P -t test`
5. run rhoas kafka consumer-group list 
6. run rhoas kafka consumer-group describe 
