### PR TITLE
Generic call

### DIFF
--- a/pkg/api/generic/api.go
+++ b/pkg/api/generic/api.go
@@ -1,0 +1,90 @@
+package generic
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type GenericAPI interface {
+	GET(ctx context.Context, path string) (*http.Response, error)
+	POST(ctx context.Context, path string, body string) (*http.Response, error)
+}
+
+// APIConfig defines the available configuration options
+// to customize the API client settings
+type Config struct {
+	// HTTPClient is a custom HTTP client
+	HTTPClient *http.Client
+	// Debug enables debug-level logging
+	Debug bool
+	// BaseURL sets a custom API server base URL
+	BaseURL string
+}
+
+func NewGenericAPIClient(cfg *Config) GenericAPI {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+
+	c := APIClient{
+		baseURL:    cfg.BaseURL,
+		httpClient: cfg.HTTPClient,
+	}
+
+	return &c
+}
+
+type APIClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func (c *APIClient) GET(ctx context.Context, path string) (*http.Response, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode > http.StatusBadRequest {
+		return resp, errors.New(resp.Status)
+	}
+	defer resp.Body.Close()
+
+	return resp, err
+}
+
+func (c *APIClient) POST(ctx context.Context, path string, body string) (*http.Response, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode > http.StatusBadRequest {
+		return resp, errors.New(resp.Status)
+	}
+	defer resp.Body.Close()
+
+	return resp, err
+}

--- a/pkg/api/generic/api.go
+++ b/pkg/api/generic/api.go
@@ -10,7 +10,7 @@ import (
 
 type GenericAPI interface {
 	GET(ctx context.Context, path string) (interface{}, *http.Response, error)
-	POST(ctx context.Context, path string, body string) (interface{}, *http.Response, error)
+	POST(ctx context.Context, path string, body io.Reader) (interface{}, *http.Response, error)
 }
 
 // APIConfig defines the available configuration options
@@ -71,10 +71,15 @@ func (c *APIClient) GET(ctx context.Context, path string) (interface{}, *http.Re
 	return string(b), resp, err
 }
 
-func (c *APIClient) POST(ctx context.Context, path string, body string) (interface{}, *http.Response, error) {
+func (c *APIClient) POST(ctx context.Context, path string, body io.Reader) (interface{}, *http.Response, error) {
 	url := c.baseURL + path
+	bodyBinary, err := io.ReadAll(body)
 
-	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return err, nil, err
+	}
+	requestBody := strings.NewReader(string(bodyBinary))
+	req, err := http.NewRequest("POST", url, requestBody)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/api/rbac/api.go
+++ b/pkg/api/rbac/api.go
@@ -68,9 +68,8 @@ func NewPrincipalAPIClient(cfg *Config) PrincipalAPI {
 }
 
 type APIClient struct {
-	httpClient  *http.Client
-	baseURL     *url.URL
-	AccessToken string
+	httpClient *http.Client
+	baseURL    *url.URL
 }
 
 // GetPrincipals returns the list of user's in the current users organization/tenant

--- a/pkg/cmd/request/request.go
+++ b/pkg/cmd/request/request.go
@@ -3,6 +3,7 @@ package request
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/artifact/util"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
@@ -34,8 +35,14 @@ func NewCallCmd(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:    "request",
-		Short:  "Allows you to perform API requests against the API server",
+		Use:   "request",
+		Short: "Allows you to perform API requests against the API server",
+		Example: `
+		  # Perform a GET request to the specified path
+		  rhoas request --path /api/kafkas_mgmt/v1/kafkas
+		  
+		  # Perform a POST request to the specified path
+		  cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post `,
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -62,13 +69,12 @@ func runCmd(opts *options) (err error) {
 	var response interface{}
 	if opts.method == "post" {
 		opts.Logger.Info("POST request. Reading file from standard input")
-		specifiedFile, err := util.CreateFileFromStdin()
-		if err != nil {
+		specifiedFile, err1 := util.CreateFileFromStdin()
+		if err1 != nil {
 			return err
 		}
 		data, response, err = conn.API().GenericAPI().POST(opts.Context, opts.urlPath, specifiedFile)
 	} else {
-		opts.Logger.Info("Get request")
 		data, response, err = conn.API().GenericAPI().GET(opts.Context, opts.urlPath)
 	}
 
@@ -77,6 +83,6 @@ func runCmd(opts *options) (err error) {
 		return err
 	}
 
-	opts.Logger.Info("Response:", data)
+	fmt.Fprint(opts.IO.Out, data)
 	return nil
 }

--- a/pkg/cmd/request/request.go
+++ b/pkg/cmd/request/request.go
@@ -1,0 +1,77 @@
+package request
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	IO         *iostreams.IOStreams
+	Logger     logging.Logger
+	localizer  localize.Localizer
+	Context    context.Context
+	Connection factory.ConnectionFunc
+
+	urlPath string
+	body    string
+}
+
+func NewCallCmd(f *factory.Factory) *cobra.Command {
+	opts := &options{
+		IO:         f.IOStreams,
+		Logger:     f.Logger,
+		localizer:  f.Localizer,
+		Context:    f.Context,
+		Connection: f.Connection,
+	}
+
+	cmd := &cobra.Command{
+		Use:    "request",
+		Short:  "Allows you to perform API requests against the API server",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCmd(opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.urlPath, "path", "", "Path to send request. For example /api/kafkas_mgmt/v1/kafkas?async=true")
+	cmd.Flags().StringVar(&opts.body, "body", "", "If body present then it will be used as request body for post request")
+	return cmd
+}
+
+func runCmd(opts *options) (err error) {
+	if opts.urlPath == "" {
+		return errors.New("--path is required")
+	}
+	opts.Logger.Info("Performing request to", opts.urlPath)
+	conn, err := opts.Connection(connection.DefaultConfigSkipMasAuth)
+
+	if err != nil {
+		return err
+	}
+
+	var response *http.Response
+	if opts.body == "" {
+		response, err = conn.API().GenericAPI().GET(opts.Context, opts.urlPath)
+	} else {
+		response, err = conn.API().GenericAPI().POST(opts.Context, opts.urlPath, opts.body)
+	}
+
+	if err != nil || response == nil {
+		opts.Logger.Info("Fetching data failed", err)
+		return nil
+	}
+
+	defer response.Body.Close()
+
+	opts.Logger.Info("Response:", response.Body)
+	return nil
+}

--- a/pkg/cmd/request/request.go
+++ b/pkg/cmd/request/request.go
@@ -3,7 +3,6 @@ package request
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
@@ -58,20 +57,18 @@ func runCmd(opts *options) (err error) {
 		return err
 	}
 
-	var response *http.Response
+	var data interface{}
 	if opts.body == "" {
-		response, err = conn.API().GenericAPI().GET(opts.Context, opts.urlPath)
+		data, _, err = conn.API().GenericAPI().GET(opts.Context, opts.urlPath)
 	} else {
-		response, err = conn.API().GenericAPI().POST(opts.Context, opts.urlPath, opts.body)
+		data, _, err = conn.API().GenericAPI().POST(opts.Context, opts.urlPath, opts.body)
 	}
 
-	if err != nil || response == nil {
+	if err != nil || data == nil {
 		opts.Logger.Info("Fetching data failed", err)
 		return nil
 	}
 
-	defer response.Body.Close()
-
-	opts.Logger.Info("Response:", response.Body)
+	opts.Logger.Info("Response:", data)
 	return nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/login"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/logout"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/request"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/serviceaccount"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/status"
 	cliversion "github.com/redhat-developer/app-services-cli/pkg/cmd/version"
@@ -53,6 +54,7 @@ func NewRootCommand(f *factory.Factory, version string) *cobra.Command {
 	cmd.AddCommand(registry.NewServiceRegistryCommand(f))
 
 	cmd.AddCommand(docs.NewDocsCmd(f))
+	cmd.AddCommand(request.NewCallCmd(f))
 
 	return cmd
 }

--- a/pkg/shared/connection/api/api.go
+++ b/pkg/shared/connection/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/redhat-developer/app-services-cli/pkg/api/generic"
 	"github.com/redhat-developer/app-services-cli/pkg/api/rbac"
 	amsclient "github.com/redhat-developer/app-services-sdk-go/accountmgmt/apiv1/client"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
@@ -17,4 +18,5 @@ type API interface {
 	ServiceRegistryInstance(instanceID string) (*registryinstanceclient.APIClient, *registrymgmtclient.Registry, error)
 	AccountMgmt() amsclient.AppServicesApi
 	RBAC() rbac.RbacAPI
+	GenericAPI() generic.GenericAPI
 }

--- a/pkg/shared/connection/api/defaultapi/default_client.go
+++ b/pkg/shared/connection/api/defaultapi/default_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/shared/kafkautil"
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
+	"github.com/redhat-developer/app-services-cli/pkg/api/generic"
 	"github.com/redhat-developer/app-services-cli/pkg/api/rbac"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection/api"
@@ -229,6 +230,17 @@ func (a *defaultAPI) ServiceRegistryInstance(instanceID string) (*registryinstan
 	})
 
 	return client, &instance, nil
+}
+
+func (a *defaultAPI) GenericAPI() generic.GenericAPI {
+	tc := a.createOAuthTransport(a.AccessToken)
+	client := generic.NewGenericAPIClient(&generic.Config{
+		BaseURL:    a.ApiURL.String(),
+		Debug:      a.Logger.DebugEnabled(),
+		HTTPClient: tc,
+	})
+
+	return client
 }
 
 // AccountMgmt returns a new Account Management API client instance


### PR DESCRIPTION
Fixes #1494 

Adding number of things to the CLI:

- Ability to call any API without defining it  in the code (was requested by support)
- Adding command for supporting generic api calls with fresh tokens

## Verification

```
rhoas request --path=/api/kafkas_mgmt/v1/kafkas
```
  
  