### PR TITLE
fix: refactor status command

### DIFF
--- a/pkg/cmd/status/statusBuilder.go
+++ b/pkg/cmd/status/statusBuilder.go
@@ -1,26 +1,21 @@
 package status
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/redhat-developer/app-services-cli/pkg/shared/kafkautil"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/servicespec"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/svcstatus"
+	registrymgmtclient "github.com/redhat-developer/app-services-sdk-go/registrymgmt/apiv1/client"
 
-	kafkamgmtv1errors "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/error"
+	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
 
-	"github.com/redhat-developer/app-services-cli/pkg/core/config"
-	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
-	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
-	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 
 	"github.com/openconfig/goyang/pkg/indent"
 )
@@ -28,10 +23,14 @@ import (
 const tagTitle = "title"
 
 type serviceStatus struct {
-	Name     string          `json:"name,omitempty" title:"Name"`
-	Location string          `json:"location,omitempty" title:"Location"`
+	Name     string          `json:"name,omitempty" title:"Service Context Name"`
+	Location string          `json:"location,omitempty" title:"Context File Location"`
 	Kafka    *kafkaStatus    `json:"kafka,omitempty" title:"Kafka"`
 	Registry *registryStatus `json:"registry,omitempty" title:"Service Registry"`
+}
+
+func (s serviceStatus) hasStatus() bool {
+	return s.Kafka != nil || s.Registry != nil
 }
 
 type kafkaStatus struct {
@@ -50,20 +49,12 @@ type registryStatus struct {
 }
 
 type clientConfig struct {
-	context       context.Context
-	config        config.IConfig
-	Logger        logging.Logger
-	connection    connection.Connection
-	localizer     localize.Localizer
+	f             *factory.Factory
 	serviceConfig *servicecontext.ServiceConfig
 }
 
 type statusClient struct {
-	context       context.Context
-	config        config.IConfig
-	Logger        logging.Logger
-	conn          connection.Connection
-	localizer     localize.Localizer
+	f             *factory.Factory
 	serviceConfig *servicecontext.ServiceConfig
 }
 
@@ -71,70 +62,36 @@ type statusClient struct {
 // and build it into a service status config object
 func newStatusClient(cfg *clientConfig) *statusClient {
 	return &statusClient{
-		config:        cfg.config,
-		Logger:        cfg.Logger,
-		conn:          cfg.connection,
-		localizer:     cfg.localizer,
+		f:             cfg.f,
 		serviceConfig: cfg.serviceConfig,
 	}
 }
 
 // BuildStatus gets the status of all services currently set in the service context
-func (c *statusClient) BuildStatus(ctxName string, services []string) (status *serviceStatus, ok bool, err error) {
+func (c *statusClient) BuildStatus(services []string) (*serviceStatus, error) {
+	factory := c.f
 
-	status = &serviceStatus{}
-
-	status.Name = ctxName
-
-	if rhoasContext := os.Getenv("RHOAS_CONTEXT"); rhoasContext != "" {
-		status.Location = rhoasContext
-	} else {
-		ctxDirLocation, _ := servicecontext.DefaultDir()
-		status.Location = filepath.Join(ctxDirLocation, "contexts.json")
-	}
+	status := &serviceStatus{}
 
 	if stringInSlice(servicespec.KafkaServiceName, services) {
-		if c.serviceConfig.KafkaID != "" {
-			// nolint:govet
-			kafkaStatus, err := c.getKafkaStatus(c.context, c.serviceConfig.KafkaID)
-			if err != nil {
-				if kafkamgmtv1errors.IsAPIError(err, kafkamgmtv1errors.ERROR_7) {
-					err = kafkautil.NotFoundByIDError(c.serviceConfig.KafkaID)
-					c.Logger.Error(err)
-					c.Logger.Info(c.localizer.MustLocalize("status.log.info.rhoasKafkaUse"))
-				}
-			} else {
-				status.Kafka = kafkaStatus
-				ok = true
-			}
-		} else {
-			c.Logger.Debug("No Kafka instance is currently used, skipping status check")
+		kafkaResponse, err := contextutil.GetKafkaForServiceConfig(c.serviceConfig, factory)
+		if err != nil {
+			return status, err
 		}
+		status.Kafka = c.getKafkaStatus(kafkaResponse)
 	}
 
 	if stringInSlice(servicespec.ServiceRegistryServiceName, services) {
-		if c.serviceConfig.ServiceRegistryID != "" {
-			// nolint:govet
-			registry, newErr := c.getRegistryStatus(c.context, c.serviceConfig.ServiceRegistryID)
-			if newErr != nil {
-				return status, ok, newErr
-			}
-			status.Registry = registry
-			ok = true
-		} else {
-			c.Logger.Debug("No service registry is currently used, skipping status check")
+		registryResponse, err := contextutil.GetRegistryForServiceConfig(c.serviceConfig, factory)
+		if err != nil {
+			return status, err
 		}
+		status.Registry = c.getRegistryStatus(registryResponse)
 	}
-
-	return status, ok, err
+	return status, nil
 }
 
-func (c *statusClient) getKafkaStatus(ctx context.Context, id string) (status *kafkaStatus, err error) {
-	kafkaResponse, _, err := c.conn.API().KafkaMgmt().GetKafkaById(ctx, id).Execute()
-	if err != nil {
-		return nil, err
-	}
-
+func (c *statusClient) getKafkaStatus(kafkaResponse *kafkamgmtclient.KafkaRequest) (status *kafkaStatus) {
 	status = &kafkaStatus{
 		ID:                  kafkaResponse.GetId(),
 		Name:                kafkaResponse.GetName(),
@@ -146,15 +103,10 @@ func (c *statusClient) getKafkaStatus(ctx context.Context, id string) (status *k
 		status.FailedReason = kafkaResponse.GetFailedReason()
 	}
 
-	return status, err
+	return status
 }
 
-func (c *statusClient) getRegistryStatus(ctx context.Context, id string) (status *registryStatus, err error) {
-	registry, _, err := c.conn.API().ServiceRegistryMgmt().GetRegistry(ctx, id).Execute()
-	if err != nil {
-		return nil, err
-	}
-
+func (c *statusClient) getRegistryStatus(registry *registrymgmtclient.Registry) (status *registryStatus) {
 	status = &registryStatus{
 		ID:          registry.GetId(),
 		Name:        registry.GetName(),
@@ -162,7 +114,7 @@ func (c *statusClient) getRegistryStatus(ctx context.Context, id string) (status
 		Status:      string(registry.GetStatus()),
 	}
 
-	return status, err
+	return status
 }
 
 // Print prints the status information of all set services

--- a/pkg/core/localize/locales/en/cmd/status.en.toml
+++ b/pkg/core/localize/locales/en/cmd/status.en.toml
@@ -33,6 +33,3 @@ one = 'No services set in context. To set a service in context, run "rhoas conte
 
 [status.log.debug.noKafkaSelected]
 one = 'No Kafka instance is currently used, skipping status check'
-
-[status.log.info.rhoasKafkaUse]
-one = 'Run "rhoas context use-kafka" to use another Kafka instance.'

--- a/pkg/core/servicecontext/file.go
+++ b/pkg/core/servicecontext/file.go
@@ -20,7 +20,7 @@ type File struct{}
 
 const errorFormat = "%v: %w"
 
-const envName = "RHOAS_CONTEXT"
+const ContextEnvName = "RHOAS_CONTEXT"
 
 // Load loads the profiles from the context file. If the context file doesn't exist
 // it will return an empty context object.
@@ -97,7 +97,7 @@ func (c *File) Remove() error {
 // Location gets the path to the context file
 func (c *File) Location() (path string, err error) {
 
-	if rhoasContext := os.Getenv(envName); rhoasContext != "" {
+	if rhoasContext := os.Getenv(ContextEnvName); rhoasContext != "" {
 
 		_, err := os.Stat(rhoasContext)
 		if os.IsNotExist(err) {
@@ -120,7 +120,7 @@ func (c *File) Location() (path string, err error) {
 
 // Checks if context has custom location
 func HasCustomLocation() bool {
-	rhoasContext := os.Getenv(envName)
+	rhoasContext := os.Getenv(ContextEnvName)
 	return rhoasContext != ""
 }
 

--- a/pkg/shared/contextutil/util.go
+++ b/pkg/shared/contextutil/util.go
@@ -58,6 +58,7 @@ func GetCurrentKafkaInstance(f *factory.Factory) (*kafkamgmtclient.KafkaRequest,
 	return GetKafkaForServiceConfig(currCtx, f)
 }
 
+// GetKafkaForServiceConfig fetching kafka service data using ServiceConfig
 func GetKafkaForServiceConfig(currCtx *servicecontext.ServiceConfig, f *factory.Factory) (*kafkamgmtclient.KafkaRequest, error) {
 	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
@@ -92,6 +93,7 @@ func GetCurrentRegistryInstance(f *factory.Factory) (*registrymgmtclient.Registr
 
 }
 
+// GetRegistryForServiceConfig fetching registry data for provided service config
 func GetRegistryForServiceConfig(currCtx *servicecontext.ServiceConfig, f *factory.Factory) (*registrymgmtclient.Registry, error) {
 	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {

--- a/pkg/shared/contextutil/util.go
+++ b/pkg/shared/contextutil/util.go
@@ -50,16 +50,19 @@ func GetCurrentKafkaInstance(f *factory.Factory) (*kafkamgmtclient.KafkaRequest,
 		return nil, err
 	}
 
-	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
-	if err != nil {
-		return nil, err
-	}
-
 	currCtx, err := GetCurrentContext(svcContext, f.Localizer)
 	if err != nil {
 		return nil, err
 	}
 
+	return GetKafkaForServiceConfig(currCtx, f)
+}
+
+func GetKafkaForServiceConfig(currCtx *servicecontext.ServiceConfig, f *factory.Factory) (*kafkamgmtclient.KafkaRequest, error) {
+	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return nil, err
+	}
 	if currCtx.KafkaID == "" {
 		return nil, f.Localizer.MustLocalizeError("context.common.error.noKafkaID")
 	}
@@ -70,7 +73,6 @@ func GetCurrentKafkaInstance(f *factory.Factory) (*kafkamgmtclient.KafkaRequest,
 	}
 
 	return &kafkaInstance, err
-
 }
 
 // GetCurrentRegistryInstance returns the Service Registry instance set in the currently selected context
@@ -81,12 +83,17 @@ func GetCurrentRegistryInstance(f *factory.Factory) (*registrymgmtclient.Registr
 		return nil, err
 	}
 
-	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
+	currCtx, err := GetCurrentContext(svcContext, f.Localizer)
 	if err != nil {
 		return nil, err
 	}
 
-	currCtx, err := GetCurrentContext(svcContext, f.Localizer)
+	return GetRegistryForServiceConfig(currCtx, f)
+
+}
+
+func GetRegistryForServiceConfig(currCtx *servicecontext.ServiceConfig, f *factory.Factory) (*registrymgmtclient.Registry, error) {
+	conn, err := f.Connection(connection.DefaultConfigRequireMasAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -101,5 +108,4 @@ func GetCurrentRegistryInstance(f *factory.Factory) (*registrymgmtclient.Registr
 	}
 
 	return &registryInstance, err
-
 }


### PR DESCRIPTION
## Motivation

I really do think that doing some form of factory object mapping to custom opts structure is total waste of time and doesn't fit much of purpose. Factory is good abstraction on it's own. Removed it from this command specifically.

Added support for name and location

Added common handling for services missing so we can now reuse it. 