### PR TITLE
fix(context generate-config): remove hard codings

### DIFF
--- a/pkg/cmd/context/contextcmdutil/validator.go
+++ b/pkg/cmd/context/contextcmdutil/validator.go
@@ -16,7 +16,7 @@ type Validator struct {
 }
 
 const (
-	legalNameChars = "^[a-zA-Z0-9._-]+$"
+	legalNameChars = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
 )
 
 // ValidateName validates the name of the context

--- a/pkg/cmd/context/generate/build-configs.go
+++ b/pkg/cmd/context/generate/build-configs.go
@@ -87,7 +87,7 @@ func BuildConfiguration(svcConfig *servicecontext.ServiceConfig, opts *options) 
 		return opts.localizer.MustLocalizeError("context.generate.log.info.noSevices")
 	}
 
-	serviceAccount, err := createServiceAccount(opts, fmt.Sprintf("rhoascli-%v", time.Now().Unix()))
+	serviceAccount, err := createServiceAccount(opts, fmt.Sprintf("%s-%v", opts.name, time.Now().Unix()))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/context/generate/build-configs.go
+++ b/pkg/cmd/context/generate/build-configs.go
@@ -1,6 +1,9 @@
 package generate
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
@@ -84,7 +87,7 @@ func BuildConfiguration(svcConfig *servicecontext.ServiceConfig, opts *options) 
 		return opts.localizer.MustLocalizeError("context.generate.log.info.noSevices")
 	}
 
-	serviceAccount, err := createServiceAccount(opts, "to-do-generate-description")
+	serviceAccount, err := createServiceAccount(opts, fmt.Sprintf("rhoascli-%v", time.Now().Unix()))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/context/generate/configurations.go
+++ b/pkg/cmd/context/generate/configurations.go
@@ -8,10 +8,19 @@ import (
 	"path/filepath"
 )
 
+// configuration types for generate-config command
+const (
+	envFormat        = "env"
+	jsonFormat       = "json"
+	propertiesFormat = "properties"
+)
+
+var configurationTypes = []string{envFormat, jsonFormat, propertiesFormat}
+
 var (
-	envConfig        = template.Must(template.New("env").Parse(templateEnv))
-	jsonConfig       = template.Must(template.New("json").Parse(templateJSON))
-	propertiesConfig = template.Must(template.New("properties").Parse(templateProperties))
+	envConfig        = template.Must(template.New(envFormat).Parse(templateEnv))
+	jsonConfig       = template.Must(template.New(jsonFormat).Parse(templateJSON))
+	propertiesConfig = template.Must(template.New(propertiesFormat).Parse(templateProperties))
 )
 
 // WriteConfig saves the configurations to a file
@@ -34,11 +43,11 @@ func WriteConfig(configType string, config *configValues) error {
 // getDefaultPath returns the default absolute path for the configuration file
 func getDefaultPath(configType string) (filePath string) {
 	switch configType {
-	case "env":
+	case envFormat:
 		filePath = "rhoas.env"
-	case "properties":
+	case propertiesFormat:
 		filePath = "rhoas.properties"
-	case "json":
+	case jsonFormat:
 		filePath = "rhoas.json"
 	}
 
@@ -52,14 +61,16 @@ func getDefaultPath(configType string) (filePath string) {
 	return filePath
 }
 
-func getFileFormat(configType string) *template.Template {
+func getFileFormat(configType string) (template *template.Template) {
 
 	switch configType {
-	case "env":
-		return envConfig
-	case "properties":
-		return propertiesConfig
-	default:
-		return jsonConfig
+	case envFormat:
+		template = envConfig
+	case propertiesFormat:
+		template = propertiesConfig
+	case jsonFormat:
+		template = jsonConfig
 	}
+
+	return template
 }

--- a/pkg/cmd/context/generate/generate-config.go
+++ b/pkg/cmd/context/generate/generate-config.go
@@ -79,6 +79,7 @@ func runGenerate(opts *options) error {
 		if err != nil {
 			return err
 		}
+		opts.name = svcContext.CurrentContext
 	} else {
 		svcConfig, err = contextutil.GetContext(svcContext, opts.localizer, opts.name)
 		if err != nil {

--- a/pkg/cmd/context/generate/generate-config.go
+++ b/pkg/cmd/context/generate/generate-config.go
@@ -45,8 +45,10 @@ func NewGenerateCommand(f *factory.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if !opts.IO.CanPrompt() && opts.name == "" {
-				return flagutil.RequiredWhenNonInteractiveError("name")
+			// check that a valid type is provided
+			validType := flagutil.IsValidInput(opts.configType, configurationTypes...)
+			if !validType {
+				return flagutil.InvalidValueError("type", opts.configType, configurationTypes...)
 			}
 
 			return runGenerate(opts)
@@ -56,6 +58,9 @@ func NewGenerateCommand(f *factory.Factory) *cobra.Command {
 	flags := contextcmdutil.NewFlagSet(cmd, f)
 	flags.AddContextName(&opts.name)
 	flags.StringVar(&opts.configType, "type", "", opts.localizer.MustLocalize("context.generate.flag.type"))
+	_ = cmd.MarkFlagRequired("type")
+
+	flagutil.EnableStaticFlagCompletion(cmd, "type", configurationTypes)
 
 	return cmd
 }

--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -242,4 +242,4 @@ For example:
 one = 'context name is required'
 
 [context.common.validation.name.error.invalidChars]
-one = 'invalid context name "{{.Name}}"; only letters (Aa-Zz), numbers, "_", "." and "-" are accepted'
+one = 'invalid context name "{{.Name}}"; only lowercase letters (a-z), numbers, and "-" are accepted'


### PR DESCRIPTION
Add short description for created service account.
Removed hard coded strings, added flag validation and completion for `--type`.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. The following command should create a service account with short description with prefix "rhoascli-"
`./rhoas context generate-config --type properties`
2. The following command should throw an error indicating invalid flag value.
`./rhoas context generate-config --type propertiees`

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
