### PR TITLE
docs: edit command help for context commands

### DIFF
--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -3,7 +3,8 @@ one='Group, share and manage your rhoas services'
 
 [context.cmd.longDescription]
 one='''
-Group your application service instances into service contexts.
+Group your service instances into reusable contexts.
+Context can be used when running other rhoas commands or to generate service configuration.
 
 A service context is a group of application service instances and their service identifiers. By using service contexts, you can group together application service instances that you want to use together.
 

--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -5,14 +5,14 @@ one='Group, share and manage your rhoas services'
 one='''
 Group your application service instances into service contexts.
 
-A service context is a group of application service instances and their configuration details. By using service contexts, you can group together application service instances that you want to use together.
+A service context is a group of application service instances and their service identifiers. By using service contexts, you can group together application service instances that you want to use together.
 
 After creating a service context, you can share it with other developers so that they can use the same group of application service instances.
 
 You can also use the service context to automatically generate configuration files that you need to use those application service instances in other development platforms and tools. For example, the service context can generate the following types of configurations:
 
 - Standard environment variables for use in local development and tooling
-- Java properties files for use in Quarkus, Apache Kafka, and so on
+- Java properties files that can be used in Quarkus, Apache Kafka, and so on
 - Service binding configuration and service connections for the RHOAS Operator
 - Configuration for Helm Charts and Kubernetes
 
@@ -198,12 +198,7 @@ one='Generate configurations for the service context'
 one='''
 Generate configuration files to enable the application service instances in the service context to connect with other platforms and tools.
 
-This command generates configuration files that you need to use application service instances in other development platforms and tools. For example, the service context can generate the following types of configurations:
-
-- Standard environment variables for use in local development and tooling
-- Java properties files for use in Quarkus, Apache Kafka, and so on
-- Service binding configuration and service connections for the RHOAS Operator
-- Configuration for Helm Charts and Kubernetes
+This command generates a JSON configuration file that you can use to connect application service instances to other development platforms and tools.
 '''
 
 [context.generate.cmd.example]

--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -3,27 +3,33 @@ one='Group, share and manage your rhoas services'
 
 [context.cmd.longDescription]
 one='''
-rhoas context commands allow developers to:
+Group your application service instances into service contexts.
 
-  * Group services into contexts that can be used with a number of CLI commands.
-  * Manage different service contexts by switching, listing and removing service contexts 
-  * Share context with others to use the same set of services
+A service context is a group of application service instances and their configuration details. By using service contexts, you can group together application service instances that you want to use together.
 
-By default context is kept under users configuration folder. Users can view context location by executing "rhoas context status" command.
+After creating a service context, you can share it with other developers so that they can use the same group of application service instances.
 
-Additionally developers can specify custom location for contexts by setting $RHOAS_CONTEXT environment variable in their profile.
-Setting $RHOAS_CONTEXT to "./rhoas.json" will load contexts from the current folder.
+You can also use the service context to automatically generate configuration files that you need to use those application service instances in other development platforms and tools. For example, the service context can generate the following types of configurations:
+
+- Standard environment variables for use in local development and tooling
+- Java properties files for use in Quarkus, Apache Kafka, and so on
+- Service binding configuration and service connections for the RHOAS Operator
+- Configuration for Helm Charts and Kubernetes
+
+The service context is defined in a JSON file (`contexts.json`), and stored locally on your computer. To find the location of this file, use the "rhoas context status" command.
+
+Note: To specify a custom location for the `contexts.json` file, set the $RHOAS_CONTEXT environment variable to the location you want to use. If you set $RHOAS_CONTEXT to "./rhoas.json", service contexts will be loaded from the current directory.
 '''
 
 [context.cmd.example]
 one='''
-## Set the current context
+# Set the current context
 $ rhoas context use --name qa
 
-## List contexts
+# List contexts
 $ rhoas context list
 
-## Create context to represent development services
+# Create a context to represent a group of development services
 $ rhoas context create --name dev-env
 '''
 
@@ -35,12 +41,13 @@ one='Set the current context'
 [context.use.cmd.longDescription]
 one='''
 Select a service context to be used as the current context.
-When you set the context to be used, it is set as the current context for all service based commands.
+
+When you set the context to be used, it is set as the current context for all service-based rhoas commands.
 '''
 
 [context.use.cmd.example]
 one='''
-## Set the current context
+# Set the current context
 $ rhoas context use --name dev
 '''
 
@@ -51,7 +58,7 @@ one='Current context set to "{{.Name}}"'
 
 [context.status.cmd.longDescription]
 one = '''
-View the status of your application services. This command shows the status of each of your application services instances set in service context. 
+View the status of your application services. This command shows the status of each of the application services instances in the service context.
 
 To view the status of a specific application service, use "rhoas context status [service]".
 
@@ -95,14 +102,18 @@ rhoas context use-service-registry --id 1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 [context.list.cmd]
 
 [context.list.cmd.shortDescription]
-one='List contexts'
+one='List service contexts'
 
 [context.list.cmd.longDescription]
-one='List currently available service contexts'
+one='''
+List all service contexts. This command lists each service context, and indicates the context that is currently being used.
+
+To view the details of a service context, use the "rhoas context status" command.
+'''
 
 [context.list.cmd.example]
 one='''
-## List contexts
+# List contexts
 $ rhoas context list
 '''
 
@@ -121,11 +132,17 @@ Run the following command to create a service context:
 one='Create a service context'
 
 [context.create.cmd.longDescription]
-one='Create a service context and assign associated service identifiers'
+one='''
+Create a service context and assign associated service identifiers.
+
+A service context is a group of application service instances and their configuration details. By creating a service context, you can group together application service instances that you want to use together.
+
+After creating the service context, add application service instances to it by using the "rhoas context use-[service]" commands.
+'''
 
 [context.create.cmd.example]
 one='''
-## Create context
+# Create context
 $ rhoas context create --name dev
 '''
 
@@ -150,68 +167,103 @@ one='Context with name "{{.Name}}" already exists'
 [context.delete.cmd]
 
 [context.delete.cmd.shortDescription]
-one='Delete a service context'
+one='Permanently delete a service context.'
 
 [context.delete.cmd.longDescription]
-one='Delete a service context and assign associated service identifiers'
+one='Delete a service context.'
 
 [context.delete.cmd.example]
 one='''
-## Delete the currently selected service context
+# Delete the currently-selected service context
 $ rhoas context delete
 
-## Delete a service context by name
+# Delete a service context by name
 $ rhoas context delete --name dev
 '''
 
 [context.delete.log.warning.currentUnset]
-one='Warning: this removed your current service context, use "rhoas context use" to select a different one'
+one='Warning: Your current service context has been removed, use "rhoas context use" to select a different context'
 
 [context.delete.log.successMessage]
 one='Context deleted successfully'
 
+<<<<<<< HEAD
+=======
+[context.generate.cmd]
+
+[context.generate.cmd.shortDescription]
+one='Generate configurations for the service context'
+
+[context.generate.cmd.longDescription]
+one='''
+Generate configuration files to enable the application service instances in the service context to connect with other platforms and tools.
+
+This command generates configuration files that you need to use application service instances in other development platforms and tools. For example, the service context can generate the following types of configurations:
+
+- Standard environment variables for use in local development and tooling
+- Java properties files for use in Quarkus, Apache Kafka, and so on
+- Service binding configuration and service connections for the RHOAS Operator
+- Configuration for Helm Charts and Kubernetes
+'''
+
+[context.generate.cmd.example]
+one='''
+# Generate configurations for the current service context in JSON format
+$ rhoas context generate-config --type json
+'''
+
+[context.generate.flag.type]
+one='Type of configuration file to be generated'
+
+[context.generate.log.info.noSevices]
+one='No services available to generate configurations'
+
+[context.generate.log.info.credentialsSaved]
+one='Configurations successfully saved'
+
+>>>>>>> d1bdfe6c (docs: edit command help for context commands)
 [context.common.flag.name]
 one='Name of the context'
 
 [context.common.error.noRegistryID]
 one='''
-context doesn't have a Service Registry ID.
-Use `rhoas context use-service-registry` command to select a Service registry instance for your context
+The context doesn't have a Service Registry ID.
+Use the "rhoas context use-service-registry" command to select a Service Registry instance for your context
 '''
 
 [context.common.error.noKafkaID]
 one='''
-context doesn't have a Kafka Instance ID.
-Use `rhoas context use-kafka` command to select a Kafka instance for your context
+The context doesn't have a Kafka instance ID.
+Use the "rhoas context use-kafka" command to select a Kafka instance for your context
 '''
 
 [context.common.error.registry.notFound]
 one='''
-Service registry instance in your context doesnt exist.
+Service registry instance in your context doesn't exist.
 Your instance might have been removed.
-You can update your context by creating new instance or using `rhoas context use-service-registry` command
+You can update your context by creating a new instance or by using the "rhoas context use-service-registry" command
 '''
 
 [context.common.error.kafka.notFound]
 one='''
-Kafka instance doesn't exist, you need to set valid instance id using "rhoas context use-kafka" command
+Kafka instance doesn't exist, you must set a valid Kafka instance ID by using the "rhoas context use-kafka" command
 '''
 
 [context.common.error.context.notFound]
 one='''
 context with name "{{.Name}}" does not exist
 
-Run `rhoas context list` to view available contexts
+Run "rhoas context list" to view available contexts
 '''
 
 [context.common.error.notSet]
 one='''
-Command you have been trying to execute requires an service context.
-Current context has not been set. 
-You need to run "rhoas context use" or "rhoas context create" commands to set a context.
+The command you have been trying to execute requires a service context.
+Current context has not been set.
+Run either "rhoas context use" or "rhoas context create" to set a context.
 For example:
 
-  rhoas context use --name default
+  $ rhoas context use --name default
 '''
 
 [context.common.validation.name.error.required]

--- a/pkg/core/localize/locales/en/cmd/status.en.toml
+++ b/pkg/core/localize/locales/en/cmd/status.en.toml
@@ -1,9 +1,9 @@
 [status.cmd.shortDescription]
-one = 'View the status of application services set in service context'
+one = 'View the status of application services in a service context'
 
 [status.cmd.longDescription]
 one = '''
-View the status of your application services. This command shows the status of each of your application services instances set in service context. 
+View the status of your application services. This command shows the status of each of your application services instances that belong to a service context.
 
 To view the status of a specific application service, use "rhoas status [service]".
 


### PR DESCRIPTION
Edited the command help for the "rhoas context" commands.

I'm not sure about the generate-config command. I tried to include everything that it's potentially supposed to generate, but I'm not sure that all of the functionality is actually in place yet. So we might need to scale back the help text accordingly.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
