### PR TITLE
feat(service-registry): display compatibile API endpoints

### DIFF
--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -158,8 +158,12 @@ func runCreate(opts *options) error {
 
 	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(response.GetRegistryUrl())
 
-	opts.Logger.Error(opts.localizer.MustLocalize("registry.common.log.message.compatibleAPIs"))
-	_ = dump.Formatted(opts.IO.ErrOut, opts.outputFormat, compatibleEndpoints)
+	opts.Logger.Error(opts.localizer.MustLocalize(
+		"registry.common.log.message.compatibleAPIs",
+		localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
+		localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),
+		localize.NewEntry("CncfSchemaRegistryAPI", compatibleEndpoints.CncfSchemaRegistry),
+	))
 
 	if err = dump.Formatted(opts.IO.Out, opts.outputFormat, response); err != nil {
 		return err

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -158,7 +158,7 @@ func runCreate(opts *options) error {
 
 	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(response.GetRegistryUrl())
 
-	opts.Logger.Error(opts.localizer.MustLocalize(
+	opts.Logger.Info(opts.localizer.MustLocalize(
 		"registry.common.log.message.compatibleAPIs",
 		localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
 		localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),

--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -156,6 +156,11 @@ func runCreate(opts *options) error {
 
 	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
 
+	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(response.GetRegistryUrl())
+
+	opts.Logger.Error(opts.localizer.MustLocalize("registry.common.log.message.compatibleAPIs"))
+	_ = dump.Formatted(opts.IO.ErrOut, opts.outputFormat, compatibleEndpoints)
+
 	if err = dump.Formatted(opts.IO.Out, opts.outputFormat, response); err != nil {
 		return err
 	}

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -111,10 +111,12 @@ func runDescribe(opts *options) error {
 
 	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(registry.GetRegistryUrl())
 
-	opts.logger.Error(opts.localizer.MustLocalize("registry.common.log.message.compatibleAPIs"))
-	if err := dump.Formatted(opts.IO.ErrOut, opts.outputFormat, compatibleEndpoints); err != nil {
-		return err
-	}
+	opts.logger.Error(opts.localizer.MustLocalize(
+		"registry.common.log.message.compatibleAPIs",
+		localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
+		localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),
+		localize.NewEntry("CncfSchemaRegistryAPI", compatibleEndpoints.CncfSchemaRegistry),
+	))
 
 	return nil
 }

--- a/pkg/cmd/registry/describe/describe.go
+++ b/pkg/cmd/registry/describe/describe.go
@@ -111,7 +111,7 @@ func runDescribe(opts *options) error {
 
 	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(registry.GetRegistryUrl())
 
-	opts.logger.Error(opts.localizer.MustLocalize(
+	opts.logger.Info(opts.localizer.MustLocalize(
 		"registry.common.log.message.compatibleAPIs",
 		localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
 		localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),

--- a/pkg/cmd/registry/registrycmdutil/registry_util.go
+++ b/pkg/cmd/registry/registrycmdutil/registry_util.go
@@ -9,6 +9,12 @@ import (
 
 var validNameRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
 
+type compatibilityEndpoints struct {
+	CoreRegistry       string `json:"coreRegistryAPI"`
+	SchemaRegistry     string `json:"schemaRegistryCompatAPI"`
+	CncfSchemaRegistry string `json:"cncfSchemaRegistryAPI"`
+}
+
 // ValidateName validates the proposed name of a Kafka instance
 func ValidateName(val interface{}) error {
 	name, ok := val.(string)
@@ -28,4 +34,16 @@ func ValidateName(val interface{}) error {
 	}
 
 	return errors.New("invalid service registry name: " + name)
+}
+
+// GetCompatibilityEndpoints returns the compatible API endpoints
+func GetCompatibilityEndpoints(url string) *compatibilityEndpoints {
+
+	endpoints := &compatibilityEndpoints{
+		CoreRegistry:       url + "/apis/registry/v2",
+		SchemaRegistry:     url + "/apis/ccompat/v6",
+		CncfSchemaRegistry: url + "/apis/cncf/v0",
+	}
+
+	return endpoints
 }

--- a/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
@@ -212,7 +212,15 @@ description = 'Info message when no Registry instances were found'
 one = 'No Service Registry instances were found.'
 
 [registry.common.log.message.compatibleAPIs]
-one = 'Compatible API endpoints:'
+one='''
+You can connect to the Service Registry instance using following options:
+ - For native Apicurio API and SerDes - Core Registry API:
+    {{.CoreRegistryAPI}}
+ - For any upstream tools - Confluent Schema Registry API:  
+    {{.SchemaRegistryAPI}}
+ - For tools compatible with CNCF API - CNCF Schema Registry API
+    {{.CncfSchemaRegistryAPI}}
+'''
 
 [registry.use.flag.id]
 description = 'Description for the --id flag'

--- a/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
@@ -214,11 +214,11 @@ one = 'No Service Registry instances were found.'
 [registry.common.log.message.compatibleAPIs]
 one='''
 You can connect to the Service Registry instance using following options:
- - For native Apicurio API and SerDes - Core Registry API:
+ - For Apicurio Service Registry API:
     {{.CoreRegistryAPI}}
- - For any upstream tools - Confluent Schema Registry API:  
+ - For tools supporting Confluent Schema Registry API:  
     {{.SchemaRegistryAPI}}
- - For tools compatible with CNCF API - CNCF Schema Registry API
+ - For CNCF Schema Registry API:
     {{.CncfSchemaRegistryAPI}}
 '''
 

--- a/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
@@ -211,6 +211,9 @@ one = 'Filtering Service Registry instances with the query "{{.Search}}".'
 description = 'Info message when no Registry instances were found'
 one = 'No Service Registry instances were found.'
 
+[registry.common.log.message.compatibleAPIs]
+one = 'Compatible API endpoints:'
+
 [registry.use.flag.id]
 description = 'Description for the --id flag'
 one = 'Unique ID of the Service Registry instance you want to set as the current instance'


### PR DESCRIPTION
Display compatibility APIs for service registry instances in create an describe command that will be used to connect an application or tool to instances.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following command to display compatibility endpoints for the registry instance in current context.
```
rhoas service-registry describe --name my-registry
```
2. Expected output:
```
{
  "browserUrl": "https://console.redhat.com/application-services/service-registry/t/c9f1ad77-377c-41f0-baa1-8b9103783893",
  "created_at": "2022-02-14T10:47:42Z",
  "href": "/api/serviceregistry_mgmt/v1/registries/c9f1ad77-377c-41f0-baa1-8b9103783893",
  "id": "c9f1ad77-377c-41f0-baa1-8b9103783893",
  "instance_type": "standard",
  "kind": "ServiceRegistry",
  "name": "enda-dev",
  "owner": "ephelan_kafka_devexp",
  "registryDeploymentId": 1,
  "registryUrl": "https://bu98.serviceregistry.rhcloud.com/t/c9f1ad77-377c-41f0-baa1-8b9103783893",
  "status": "ready",
  "updated_at": "2022-02-14T10:47:42Z"
}
Compatible API endpoints:
{
  "coreRegistryAPI": "https://bu98.serviceregistry.rhcloud.com/t/c9f1ad77-377c-41f0-baa1-8b9103783893/apis/registry/v2",
  "schemaRegistryCompatAPI": "https://bu98.serviceregistry.rhcloud.com/t/c9f1ad77-377c-41f0-baa1-8b9103783893/apis/ccompat/v6",
  "cncfSchemaRegistryAPI": "https://bu98.serviceregistry.rhcloud.com/t/c9f1ad77-377c-41f0-baa1-8b9103783893/apis/cncf/v0"
}
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
