### PR TITLE
refactor(context): rename use-service to set-service

### DIFF
--- a/docs/commands/rhoas_context.md
+++ b/docs/commands/rhoas_context.md
@@ -50,8 +50,8 @@ $ rhoas context create --name dev-env
 * [rhoas context create](rhoas_context_create.md)	 - Create a service context
 * [rhoas context delete](rhoas_context_delete.md)	 - Permanently delete a service context.
 * [rhoas context list](rhoas_context_list.md)	 - List service contexts
+* [rhoas context set-kafka](rhoas_context_set-kafka.md)	 - Set the current Kafka instance
+* [rhoas context set-service-registry](rhoas_context_set-service-registry.md)	 - Use a Service Registry instance
 * [rhoas context status](rhoas_context_status.md)	 - View the status of application services in a service context
 * [rhoas context use](rhoas_context_use.md)	 - Set the current context
-* [rhoas context use-kafka](rhoas_context_use-kafka.md)	 - Set the current Kafka instance
-* [rhoas context use-service-registry](rhoas_context_use-service-registry.md)	 - Use a Service Registry instance
 

--- a/docs/commands/rhoas_context_create.md
+++ b/docs/commands/rhoas_context_create.md
@@ -8,7 +8,7 @@ Create a service context and assign associated service identifiers.
 
 A service context is a group of application service instances and their configuration details. By creating a service context, you can group together application service instances that you want to use together.
 
-After creating the service context, add application service instances to it by using the "rhoas context use-[service]" commands.
+After creating the service context, add application service instances to it by using the "rhoas context set-[service]" commands.
 
 
 ```

--- a/docs/commands/rhoas_context_set-kafka.md
+++ b/docs/commands/rhoas_context_set-kafka.md
@@ -1,4 +1,4 @@
-## rhoas context use-kafka
+## rhoas context set-kafka
 
 Set the current Kafka instance
 
@@ -10,17 +10,17 @@ You can select a  Kafka instance by name or ID.
 
 
 ```
-rhoas context use-kafka [flags]
+rhoas context set-kafka [flags]
 ```
 
 ### Examples
 
 ```
 # Select a Kafka instance by name to be set in the current context
-$ rhoas context use-kafka --name=my-kafka
+$ rhoas context set-kafka --name=my-kafka
 
 # Select a Kafka instance by ID to be set in the current context
-$ rhoas context use-kafka --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
+$ rhoas context set-kafka --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 
 ```
 

--- a/docs/commands/rhoas_context_set-service-registry.md
+++ b/docs/commands/rhoas_context_set-service-registry.md
@@ -1,4 +1,4 @@
-## rhoas context use-service-registry
+## rhoas context set-service-registry
 
 Use a Service Registry instance
 
@@ -11,17 +11,17 @@ When you set the Service Registry instance to be used, it is set as the current 
 
 
 ```
-rhoas context use-service-registry [flags]
+rhoas context set-service-registry [flags]
 ```
 
 ### Examples
 
 ```
 # Select a Service Registry instance by name to be set in the current context
-rhoas context use-service-registry --name my-service-registry
+rhoas context set-service-registry --name my-service-registry
 
 # Select a Service Registry instance by ID to be set in the current context
-rhoas context use-service-registry --id 1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
+rhoas context set-service-registry --id 1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 
 ```
 

--- a/pkg/cmd/context/context.go
+++ b/pkg/cmd/context/context.go
@@ -24,20 +24,20 @@ func NewContextCmd(f *factory.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 	}
 
-	// The implementation of `rhoas kafka use` command has been aliased here as `rhoas context use-kafka`
+	// The implementation of `rhoas kafka use` command has been aliased here as `rhoas context set-kafka`
 	kafkaUseCmd := kafkaUse.NewUseCommand(f)
-	kafkaUseCmd.Use = "use-kafka"
-	kafkaUseCmd.Example = f.Localizer.MustLocalize("context.useKafka.cmd.example")
+	kafkaUseCmd.Use = "set-kafka"
+	kafkaUseCmd.Example = f.Localizer.MustLocalize("context.setKafka.cmd.example")
 
 	// `rhoas status` cmd has been re-used as `rhoas context status`
 	statusCmd := status.NewStatusCommand(f)
 	statusCmd.Long = f.Localizer.MustLocalize("context.status.cmd.longDescription")
 	statusCmd.Example = f.Localizer.MustLocalize("context.status.cmd.example")
 
-	// The implementation of `rhoas service-registry use` command has been aliased here as `rhoas context use-service-registry`
+	// The implementation of `rhoas service-registry use` command has been aliased here as `rhoas context set-service-registry`
 	registryUseCmd := registryUse.NewUseCommand(f)
-	registryUseCmd.Use = "use-service-registry"
-	registryUseCmd.Example = f.Localizer.MustLocalize("context.useRegistry.cmd.example")
+	registryUseCmd.Use = "set-service-registry"
+	registryUseCmd.Example = f.Localizer.MustLocalize("context.setRegistry.cmd.example")
 
 	cmd.AddCommand(
 		use.NewUseCommand(f),

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -244,7 +244,7 @@ func runCreate(opts *options) error {
 		svcContext.Contexts[svcContext.CurrentContext] = *currCtx
 
 		if err = opts.ServiceContext.Save(svcContext); err != nil {
-			return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("kafka.common.error.couldNotsetKafka"), err)
+			return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("kafka.common.error.couldNotUseKafka"), err)
 		}
 	} else {
 		opts.Logger.Debug("Auto-use is not set, skipping updating the current instance")

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -244,7 +244,7 @@ func runCreate(opts *options) error {
 		svcContext.Contexts[svcContext.CurrentContext] = *currCtx
 
 		if err = opts.ServiceContext.Save(svcContext); err != nil {
-			return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("kafka.common.error.couldNotUseKafka"), err)
+			return fmt.Errorf("%v: %w", opts.localizer.MustLocalize("kafka.common.error.couldNotsetKafka"), err)
 		}
 	} else {
 		opts.Logger.Debug("Auto-use is not set, skipping updating the current instance")

--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -81,23 +81,23 @@ $ rhoas context status kafka
 $ rhoas context status -o json
 '''
 
-[context.useKafka.cmd.example]
+[context.setKafka.cmd.example]
 description = 'Examples of how to use the command'
 one = '''
 # Select a Kafka instance by name to be set in the current context
-$ rhoas context use-kafka --name=my-kafka
+$ rhoas context set-kafka --name=my-kafka
 
 # Select a Kafka instance by ID to be set in the current context
-$ rhoas context use-kafka --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
+$ rhoas context set-kafka --id=1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 '''
 
-[context.useRegistry.cmd.example]
+[context.setRegistry.cmd.example]
 one = '''
 # Select a Service Registry instance by name to be set in the current context
-rhoas context use-service-registry --name my-service-registry
+rhoas context set-service-registry --name my-service-registry
 
 # Select a Service Registry instance by ID to be set in the current context
-rhoas context use-service-registry --id 1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
+rhoas context set-service-registry --id 1iSY6RQ3JKI8Q0OTmjQFd3ocFRg
 '''
 
 [context.list.cmd]
@@ -138,7 +138,7 @@ Create a service context and assign associated service identifiers.
 
 A service context is a group of application service instances and their configuration details. By creating a service context, you can group together application service instances that you want to use together.
 
-After creating the service context, add application service instances to it by using the "rhoas context use-[service]" commands.
+After creating the service context, add application service instances to it by using the "rhoas context set-[service]" commands.
 '''
 
 [context.create.cmd.example]
@@ -159,7 +159,7 @@ Context created successfully
 
 Run the following commands to set service instances in the created context:
 
-  $ rhoas context use-[service]
+  $ rhoas context set-[service]
 '''
 
 [context.create.log.alreadyExists]
@@ -221,25 +221,25 @@ one='Name of the context'
 [context.common.error.noRegistryID]
 one='''
 The context doesn't have a Service Registry ID.
-Use the "rhoas context use-service-registry" command to select a Service Registry instance for your context
+Use the "rhoas context set-service-registry" command to select a Service Registry instance for your context
 '''
 
 [context.common.error.noKafkaID]
 one='''
 The context doesn't have a Kafka instance ID.
-Use the "rhoas context use-kafka" command to select a Kafka instance for your context
+Use the "rhoas context set-kafka" command to select a Kafka instance for your context
 '''
 
 [context.common.error.registry.notFound]
 one='''
 Service registry instance in your context doesn't exist.
 Your instance might have been removed.
-You can update your context by creating a new instance or by using the "rhoas context use-service-registry" command
+You can update your context by creating a new instance or by using the "rhoas context set-service-registry" command
 '''
 
 [context.common.error.kafka.notFound]
 one='''
-Kafka instance doesn't exist, you must set a valid Kafka instance ID by using the "rhoas context use-kafka" command
+Kafka instance doesn't exist, you must set a valid Kafka instance ID by using the "rhoas context set-kafka" command
 '''
 
 [context.common.error.context.notFound]

--- a/pkg/core/localize/locales/en/cmd/status.en.toml
+++ b/pkg/core/localize/locales/en/cmd/status.en.toml
@@ -29,7 +29,7 @@ one = 'unknown service "{{.ServiceName}}"'
 one = 'Requesting status of the following services:'
 
 [status.log.info.noStatusesAreUsed]
-one = 'No services set in context. To set a service in context, run "rhoas context use-[service] [args]".'
+one = 'No services set in context. To set a service in context, run "rhoas context set-[service] [args]".'
 
 [status.log.debug.noKafkaSelected]
 one = 'No Kafka instance is currently used, skipping status check'


### PR DESCRIPTION
BREAKING CHANGE: rename rhoas context use-<service> to rhoas context set-<service>

Command has been renamed after getting feedbacks.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following command to set Kafka instance for the current context
```
rhoas context set-kafka
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
