### PR TITLE
feat(context): add unset command

### DIFF
--- a/docs/commands/rhoas_context.md
+++ b/docs/commands/rhoas_context.md
@@ -53,5 +53,6 @@ $ rhoas context create --name dev-env
 * [rhoas context set-kafka](rhoas_context_set-kafka.md)	 - Set the current Kafka instance
 * [rhoas context set-service-registry](rhoas_context_set-service-registry.md)	 - Use a Service Registry instance
 * [rhoas context status](rhoas_context_status.md)	 - View the status of application services in a service context
+* [rhoas context unset](rhoas_context_unset.md)	 - Unset services in context
 * [rhoas context use](rhoas_context_use.md)	 - Set the current context
 

--- a/docs/commands/rhoas_context_unset.md
+++ b/docs/commands/rhoas_context_unset.md
@@ -1,0 +1,44 @@
+## rhoas context unset
+
+Unset services in context
+
+### Synopsis
+
+Unset services in context
+
+When you unset a service in context, it will no longer point to any instance of that service.
+
+
+```
+rhoas context unset [flags]
+```
+
+### Examples
+
+```
+# Unset services for current context
+$ rhoas context unset --services kafka,service-registry
+
+# Unset service-registry for a specific context
+$ rhoas context unset --name dev --services service-registry
+
+```
+
+### Options
+
+```
+      --name string        Name of the context
+      --services strings   context.unset.flag.services.description
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas context](rhoas_context.md)	 - Group, share and manage your rhoas services
+

--- a/pkg/cmd/context/context.go
+++ b/pkg/cmd/context/context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/create"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/unset"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/use"
 	kafkaUse "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/use"
 	registryUse "github.com/redhat-developer/app-services-cli/pkg/cmd/registry/use"
@@ -44,6 +45,7 @@ func NewContextCmd(f *factory.Factory) *cobra.Command {
 		list.NewListCommand(f),
 		create.NewCreateCommand(f),
 		delete.NewDeleteCommand(f),
+		unset.NewUnsetCommand(f),
 
 		// reused sub-commands
 		kafkaUseCmd,

--- a/pkg/cmd/context/unset/unset.go
+++ b/pkg/cmd/context/unset/unset.go
@@ -1,0 +1,103 @@
+package unset
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/context/contextcmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/servicespec"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	f *factory.Factory
+
+	services []string
+	name     string
+}
+
+// NewUnsetCommand creates a new command to unset services in current command
+func NewUnsetCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		f: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "unset",
+		Short:   f.Localizer.MustLocalize("context.unset.cmd.shortDescription"),
+		Long:    f.Localizer.MustLocalize("context.unset.cmd.longDescription"),
+		Example: f.Localizer.MustLocalize("context.unset.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(opts.services) == 0 {
+				return opts.f.Localizer.MustLocalizeError("context.unset.cmd.error.noServices")
+			}
+
+			for _, s := range opts.services {
+				if !flagutil.IsValidInput(s, servicespec.AllServiceLabels...) {
+					return f.Localizer.MustLocalizeError("common.error.args.error.unknownServiceError", localize.NewEntry("ServiceName", s))
+				}
+			}
+
+			return runUnset(opts)
+		},
+	}
+
+	flags := contextcmdutil.NewFlagSet(cmd, f)
+
+	flags.AddContextName(&opts.name)
+	flags.StringSliceVar(&opts.services, "services", []string{}, "context.unset.flag.services.description")
+
+	return cmd
+
+}
+
+func runUnset(opts *options) error {
+
+	svcContext, err := opts.f.ServiceContext.Load()
+	if err != nil {
+		return err
+	}
+
+	var svcConfig *servicecontext.ServiceConfig
+	var ctxName string
+
+	if opts.name == "" {
+		svcConfig, err = contextutil.GetCurrentContext(svcContext, opts.f.Localizer)
+		if err != nil {
+			return err
+		}
+		ctxName = svcContext.CurrentContext
+	} else {
+		svcConfig, err = contextutil.GetContext(svcContext, opts.f.Localizer, opts.name)
+		if err != nil {
+			return err
+		}
+		ctxName = opts.name
+	}
+
+	if flagutil.StringInSlice(servicespec.KafkaServiceName, opts.services) {
+		svcConfig.KafkaID = ""
+	}
+
+	if flagutil.StringInSlice(servicespec.ServiceRegistryServiceName, opts.services) {
+		svcConfig.ServiceRegistryID = ""
+	}
+
+	svcContext.Contexts[ctxName] = *svcConfig
+
+	err = opts.f.ServiceContext.Save(svcContext)
+	if err != nil {
+		return err
+	}
+
+	opts.f.Logger.Info(icon.SuccessPrefix(), opts.f.Localizer.MustLocalize("context.unset.log.info.success"))
+
+	return nil
+
+}

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -36,7 +36,7 @@ func NewStatusCommand(f *factory.Factory) *cobra.Command {
 			if len(args) > 0 {
 				for _, s := range args {
 					if !flagutil.IsValidInput(s, servicespec.AllServiceLabels...) {
-						return f.Localizer.MustLocalizeError("status.error.args.error.unknownServiceError", localize.NewEntry("ServiceName", s))
+						return f.Localizer.MustLocalizeError("common.error.args.error.unknownServiceError", localize.NewEntry("ServiceName", s))
 					}
 				}
 

--- a/pkg/cmd/status/statusBuilder.go
+++ b/pkg/cmd/status/statusBuilder.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/servicespec"
@@ -73,7 +74,7 @@ func (c *statusClient) BuildStatus(services []string) (status *serviceStatus, er
 
 	status = &serviceStatus{}
 
-	if stringInSlice(servicespec.KafkaServiceName, services) && c.serviceConfig.KafkaID != "" {
+	if flagutil.StringInSlice(servicespec.KafkaServiceName, services) && c.serviceConfig.KafkaID != "" {
 		kafkaResponse, err1 := contextutil.GetKafkaForServiceConfig(c.serviceConfig, factory)
 		if err1 != nil {
 			return status, err1
@@ -82,7 +83,7 @@ func (c *statusClient) BuildStatus(services []string) (status *serviceStatus, er
 		status.Kafka = kafkaStatus
 	}
 
-	if stringInSlice(servicespec.ServiceRegistryServiceName, services) && c.serviceConfig.ServiceRegistryID != "" {
+	if flagutil.StringInSlice(servicespec.ServiceRegistryServiceName, services) && c.serviceConfig.ServiceRegistryID != "" {
 		registryResponse, err1 := contextutil.GetRegistryForServiceConfig(c.serviceConfig, factory)
 		if err1 != nil {
 			return status, err1
@@ -212,13 +213,4 @@ func createDivider(n int) string {
 	}
 
 	return b
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/core/cmdutil/flagutil/util.go
+++ b/pkg/core/cmdutil/flagutil/util.go
@@ -2,8 +2,9 @@ package flagutil
 
 import (
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"sort"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 )
 
 // IsValidInput checks if the input value is in the range of valid values
@@ -40,4 +41,15 @@ func FlagDescription(localizer localize.Localizer, messageID string, validOption
 	}
 
 	return fmt.Sprintf("%v %v", description, chooseFrom)
+}
+
+// StringInSlice checks if a string is in a slice.
+// It is used when array of strings is passed as flag value or argument
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -55,6 +55,36 @@ $ rhoas context use --name dev
 [context.use.successMessage]
 one='Current context set to "{{.Name}}"'
 
+[context.unset.cmd]
+
+[context.unset.cmd.shortDescription]
+one='Unset services in context'
+
+[context.unset.cmd.longDescription]
+one='''
+Unset services in context
+
+When you unset a service in context, it will no longer point to any instance of that service.
+'''
+
+[context.unset.cmd.example]
+one='''
+# Unset services for current context
+$ rhoas context unset --services kafka,service-registry
+
+# Unset service-registry for a specific context
+$ rhoas context unset --name dev --services service-registry
+'''
+
+[context.unset.flag.services.description]
+one='The name of the services to unset'
+
+[context.unset.log.info.success]
+one='Service(s) have been unset'
+
+[context.unset.cmd.error.noServices]
+one='no service specified to unset'
+
 [context.status.cmd]
 
 [context.status.cmd.longDescription]

--- a/pkg/core/localize/locales/en/cmd/status.en.toml
+++ b/pkg/core/localize/locales/en/cmd/status.en.toml
@@ -22,9 +22,6 @@ $ rhoas status kafka
 $ rhoas status -o json
 '''
 
-[status.error.args.error.unknownServiceError]
-one = 'unknown service "{{.ServiceName}}"'
-
 [status.log.debug.requestingStatusOfServices]
 one = 'Requesting status of the following services:'
 

--- a/pkg/core/localize/locales/en/common.en.toml
+++ b/pkg/core/localize/locales/en/common.en.toml
@@ -32,3 +32,6 @@ NOTE: You might need to run command as root to update RHOAS CLI binary.
 
 [common.selfupdate.success]
 one = 'RHOAS CLI updated to version {{.Version}}'
+
+[common.error.args.error.unknownServiceError]
+one = 'unknown service "{{.ServiceName}}"'


### PR DESCRIPTION
`rhoas context unset` command can be used to unset services in the contexts.

### Verification Steps
1. Set a Kafka instance in the context using:
```
rhoas context set-kafka
``` 
2. Check the status of the kafka instance. It should print the kafka details
```
rhoas context status kafka
```
3. Unset Kafka instance for the context
```
rhoas context unset --services kafka
```
4. Check status of Kafka instance again, it should throw error.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
