### PR TITLE
fix(context): improve error message for invalid Kafka instance

### DIFF
--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -239,7 +239,9 @@ You can update your context by creating a new instance or by using the "rhoas co
 
 [context.common.error.kafka.notFound]
 one='''
-Kafka instance doesn't exist, you must set a valid Kafka instance ID by using the "rhoas context set-kafka" command
+Kafka instance in your context doesn't exist.
+Your instance might have been removed.
+You can update your context by creating a new instance or by using the "rhoas context set-kafka" command
 '''
 
 [context.common.error.context.notFound]


### PR DESCRIPTION
Improves error message displayed when Kafka Instance set in context doesn't exist.

Current error message:
```
Kafka instance doesn't exist, you must set a valid Kafka instance ID by using the "rhoas context set-kafka" command
```

Changed error message:
```
Kafka instance in your context doesn't exist.
Your instance might have been removed.
You can update your context by creating a new instance or by using the "rhoas context set-kafka" command
``` 

This also keeps it consistent with error message displayed for Service Registry instance.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [X] Enhancement
