### PR TITLE
fix(connector cluster): wrong sdk method used in delete cmd

### DIFF
--- a/pkg/cmd/connector/cluster/delete/delete.go
+++ b/pkg/cmd/connector/cluster/delete/delete.go
@@ -3,11 +3,10 @@ package delete
 import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
-	connectormgmtclient "github.com/redhat-developer/app-services-sdk-go/connectormgmt/apiv1/client"
 
 	"github.com/spf13/cobra"
 )
@@ -78,13 +77,9 @@ func runDelete(opts *options) error {
 
 	api := conn.API()
 
-	a := api.ConnectorsMgmt().ConnectorClustersApi.CreateConnectorCluster(f.Context)
-	a = a.ConnectorClusterRequest(connectormgmtclient.ConnectorClusterRequest{
-		Name: &opts.id,
-	})
-	a = a.Async(true)
+	a := api.ConnectorsMgmt().ConnectorClustersApi.DeleteConnectorCluster(f.Context, opts.id)
 
-	response, httpRes, err := a.Execute()
+	_, httpRes, err := a.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
@@ -93,11 +88,7 @@ func runDelete(opts *options) error {
 		return err
 	}
 
-	if err = dump.Formatted(f.IOStreams.Out, opts.outputFormat, response); err != nil {
-		return err
-	}
-
-	f.Logger.Info(f.Localizer.MustLocalize("connector.cluster.delete.info.success"))
+	f.Logger.Info(icon.SuccessPrefix(), f.Localizer.MustLocalize("connector.cluster.delete.info.success"))
 
 	return nil
 }

--- a/pkg/cmd/connector/delete/delete.go
+++ b/pkg/cmd/connector/delete/delete.go
@@ -4,7 +4,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/connector/connectorcmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
@@ -74,7 +74,7 @@ func runDelete(opts *options) error {
 
 	a := api.ConnectorsMgmt().ConnectorsApi.DeleteConnector(f.Context, opts.id)
 
-	response, httpRes, err := a.Execute()
+	_, httpRes, err := a.Execute()
 	if httpRes != nil {
 		defer httpRes.Body.Close()
 	}
@@ -83,11 +83,7 @@ func runDelete(opts *options) error {
 		return err
 	}
 
-	if err = dump.Formatted(f.IOStreams.Out, opts.outputFormat, response); err != nil {
-		return err
-	}
-
-	f.Logger.Info(f.Localizer.MustLocalize("connector.delete.info.success"))
+	f.Logger.Info(icon.SuccessPrefix(), f.Localizer.MustLocalize("connector.delete.info.success"))
 
 	return nil
 }


### PR DESCRIPTION
`rhoas connector cluster delete` was not able to delete the specified ID.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following command to delete a connector cluster through ID.
```
rhoas connector cluster delete --id <ID>
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
