### PR TITLE
feat(consumer-group): display state

### DIFF
--- a/pkg/cmd/kafka/consumergroup/describe/describe.go
+++ b/pkg/cmd/kafka/consumergroup/describe/describe.go
@@ -189,7 +189,8 @@ func printConsumerGroupDetails(w io.Writer, consumerGroupData kafkainstanceclien
 	partitionsWithLagCount := metrics.GetLaggingPartitions()
 	unassignedPartitions := metrics.GetUnassignedPartitions()
 
-	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unassignedPartitions")), unassignedPartitions)
+	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.activeMembers")), activeMembersCount, "\t", color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.partitionsWithLag")), partitionsWithLagCount, "\t")
+	fmt.Fprintln(w, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.unassignedPartitions")), unassignedPartitions, color.Bold(localizer.MustLocalize("kafka.consumerGroup.describe.output.state")), consumerGroupData.GetState())
 	fmt.Fprintln(w, "")
 
 	rows := mapConsumerGroupDescribeToTableFormat(consumers)

--- a/pkg/cmd/kafka/consumergroup/list/list.go
+++ b/pkg/cmd/kafka/consumergroup/list/list.go
@@ -41,9 +41,10 @@ type options struct {
 }
 
 type consumerGroupRow struct {
-	ConsumerGroupID   string `json:"groupId,omitempty" header:"Consumer group ID"`
-	ActiveMembers     int32  `json:"active_members,omitempty" header:"Active members"`
-	PartitionsWithLag int32  `json:"lag,omitempty" header:"Partitions with lag"`
+	ConsumerGroupID   string                                 `json:"groupId,omitempty" header:"Consumer group ID"`
+	ActiveMembers     int32                                  `json:"active_members,omitempty" header:"Active members"`
+	PartitionsWithLag int32                                  `json:"lag,omitempty" header:"Partitions with lag"`
+	State             kafkainstanceclient.ConsumerGroupState `json:"state,omitempty" header:"State"`
 }
 
 // NewListConsumerGroupCommand creates a new command to list consumer groups
@@ -185,6 +186,7 @@ func mapConsumerGroupResultsToTableFormat(consumerGroups []kafkainstanceclient.C
 			ConsumerGroupID:   t.GetGroupId(),
 			ActiveMembers:     metrics.GetActiveConsumers(),
 			PartitionsWithLag: metrics.GetLaggingPartitions(),
+			State:             t.GetState(),
 		}
 		rows[i] = row
 	}

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -190,6 +190,9 @@ one = 'ACTIVE MEMBERS:'
 [kafka.consumerGroup.describe.output.partitionsWithLag]
 one = 'PARTITIONS WITH LAG:'
 
+[kafka.consumerGroup.describe.output.state]
+one = 'STATE:'
+
 [kafka.consumerGroup.describe.output.unassignedPartitions]
 one = 'UNASSIGNED PARTITIONS:'
 


### PR DESCRIPTION
The commands `rhoas kafka consumer-group list` and `rhoas kafka consumer-group` describe should display `STATE`.

Describe consumer group:
```
ACTIVE MEMBERS: 0        PARTITIONS WITH LAG: 0 
UNASSIGNED PARTITIONS: 1 STATE: EMPTY

  CONSUMER ID   PARTITION   TOPIC    LOG END OFFSET   CURRENT OFFSET   OFFSET LAG  
 ------------- ----------- -------- ---------------- ---------------- ------------ 
  unassigned            0   quotes             1.7K             1.7K            0
```

List consumer groups:
```
CONSUMER GROUP ID                              ACTIVE MEMBERS   PARTITIONS WITH LAG   STATE  
 ---------------------------------------------- ---------------- --------------------- ------- 
  quarkus-service-registry-quickstart-consumer                0                     0   EMPTY 
```


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
After creating consumer groups, run the following commands to check for state:
1. List consumer groups:
```
./rhoas kafka consumer-group list
``` 
2. Describe consumer group:
```
./rhoas kafka consumer-group describe --id quarkus-service-registry-quickstart-consumer
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
