### PR TITLE
feat(service-account): enable credentials to be saved as secret

### DIFF
--- a/pkg/cmd/serviceaccount/svcaccountcmdutil/credentials/credentials.go
+++ b/pkg/cmd/serviceaccount/svcaccountcmdutil/credentials/credentials.go
@@ -3,10 +3,11 @@ package credentials
 import (
 	"errors"
 	"fmt"
-	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/color"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/color"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
@@ -16,6 +17,7 @@ const (
 	EnvFormat        = "env"
 	JSONFormat       = "json"
 	PropertiesFormat = "properties"
+	SecretFormat     = "secret"
 )
 
 // Templates
@@ -40,6 +42,18 @@ var (
 		"clientSecret":"%v",
 		"oauthTokenUrl":"%v"
 	}`)
+
+	templateSecret = heredoc.Doc(`
+		apiVersion: v1
+		kind: Secret
+		metadata:
+    name: service-account-credentials
+		type: Opaque
+		stringData:
+		  RHOAS_SERVICE_ACCOUNT_CLIENT_ID: %v
+		  RHOAS_SERVICE_ACCOUNT_CLIENT_SECRET: %v
+		  RHOAS_SERVICE_ACCOUNT_OAUTH_TOKEN_URL: %v
+	`)
 )
 
 // Credentials is a type which represents the credentials
@@ -59,6 +73,8 @@ func GetDefaultPath(outputFormat string) (filePath string) {
 		filePath = "credentials.properties"
 	case JSONFormat:
 		filePath = "credentials.json"
+	case SecretFormat:
+		filePath = "credentials.yaml"
 	}
 
 	pwd, err := os.Getwd()
@@ -94,6 +110,8 @@ func getFileFormat(output string) (format string) {
 		format = templateProperties
 	case JSONFormat:
 		format = templateJSON
+	case SecretFormat:
+		format = templateSecret
 	}
 
 	return format

--- a/pkg/cmd/serviceaccount/svcaccountcmdutil/svcaccount_util.go
+++ b/pkg/cmd/serviceaccount/svcaccountcmdutil/svcaccount_util.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	CredentialsOutputFormats = []string{credentials.EnvFormat, credentials.JSONFormat, credentials.PropertiesFormat}
+	CredentialsOutputFormats = []string{credentials.EnvFormat, credentials.JSONFormat, credentials.PropertiesFormat, credentials.SecretFormat}
 )
 
 // Method fetches authentication details for providers


### PR DESCRIPTION
Enable kubernetes secret output for service-accounts.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create service-account with `output-format` 
```
./rhoas service-account create --short-description k8s-secret --file-format secret
```
2. Reset credentials for a service-account
```
./rhoas service-account reset-credentials
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
