### PR TITLE
fix(service-registry use): erroneous message thrown for no instances

### DIFF
--- a/pkg/cmd/registry/list/list.go
+++ b/pkg/cmd/registry/list/list.go
@@ -109,7 +109,7 @@ func runList(opts *options) error {
 		return err
 	}
 
-	if len(response.Items) == 0 && opts.outputFormat == "" {
+	if response.Total == 0 && opts.outputFormat == "" {
 		opts.Logger.Info(opts.localizer.MustLocalize("registry.common.log.info.noInstances"))
 		return nil
 	}

--- a/pkg/shared/serviceregistryutil/interactive.go
+++ b/pkg/shared/serviceregistryutil/interactive.go
@@ -27,7 +27,7 @@ func InteractiveSelect(ctx context.Context, connection connection.Connection, lo
 		return nil, fmt.Errorf("unable to list Service Registry instances: %w", err)
 	}
 
-	if response.Size == 0 {
+	if response.Total == 0 {
 		logger.Info("No Service Registry instances were found.")
 		return nil, nil
 	}


### PR DESCRIPTION
Show proper error message for `rhoas service-registry use` when no Service Registry instances are present.

### Verification Steps
1. Run command to use a Service registry instance when no instance is present.
```
./rhoas context set-service-registry
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
