### PR TITLE
fix: add tech preview warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.1.0
 	github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.5.0
 	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0
-	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.4
+	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.6
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1
 	github.com/redhat-developer/service-binding-operator v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.5.0 h1:cf+K96kW
 github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.5.0/go.mod h1:JAedrXf/qLHd7lpOS+bOFh8nrOpp2j0sg4/VG/1um6c=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0 h1:ExEHQaihnPNxN2nKXB0q5nrmSv4p8b3Idzt7TChxv+Q=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0/go.mod h1:hMpejngP3BFnifCDH1gKRG9cU9Q4lr0WiQaW7A1LYo4=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.4 h1:piT2sSsH+gLDYLObUqRtm5Yd8LYDZ/Fl+nCHv5dIvw0=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.4/go.mod h1:NvNM4Gnw3dPMY6H+fsc1GHWev0ydSGsgjiCP10Bj2/M=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.6 h1:ElBvomSBaSKnX9kdvbY7rMLYjoXa2n6T8VnwZEw92do=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.11.6/go.mod h1:NvNM4Gnw3dPMY6H+fsc1GHWev0ydSGsgjiCP10Bj2/M=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1 h1:xRq5XJzRDs/Z7e/9SDt6zbNRIyesC4LTqN9ajHKwjHo=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1/go.mod h1:Z/gr/snlpsqYg4vftmcx97vCR3qMQJhALGelDHx4pMA=
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1 h1:3sUmQ3nAawsYWg7ZCO2Q8HF2J7MW6YA38h/YFL3ao6o=

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -103,7 +103,7 @@ func validateProviderRegion(input *ValidatorInput, selectedProvider kafkamgmtcli
 }
 
 func (input *ValidatorInput) ValidateSize() error {
-	// Size is not required and it will not be passed f
+	// Size is not required
 	if input.size == "" {
 		return nil
 	}

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -103,11 +103,12 @@ func validateProviderRegion(input *ValidatorInput, selectedProvider kafkamgmtcli
 }
 
 func (input *ValidatorInput) ValidateSize() error {
+	// Size is not required and it will not be passed f
 	if input.size == "" {
 		return nil
 	}
 
-	sizes, err := GetValidKafkaSizes(input.f, input.provider, input.region, *input.userAMSInstanceType)
+	sizes, err := FetchValidKafkaSizesLabels(input.f, input.provider, input.region, *input.userAMSInstanceType)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -49,7 +49,7 @@ func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionI
 	userInstanceType, _ := accountmgmtutil.GetUserSupportedInstanceType(f.Context, &constants.Kafka.Ams, conn)
 
 	// Not including quota in this request as it takes very long time to list quota for all regions in suggestion mode
-	validRegions, _ = GetValidKafkaSizes(f, providerID, regionId, *userInstanceType)
+	validRegions, _ = FetchValidKafkaSizesLabels(f, providerID, regionId, *userInstanceType)
 
 	return validRegions, cobra.ShellCompDirectiveNoSpace
 }

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -207,10 +207,10 @@ func runCreate(opts *options) error {
 				return err1
 			}
 
-			// err1 = validator.ValidateSize()
-			// if err1 != nil {
-			// 	return err1
-			// }
+			err1 = validator.ValidateSize()
+			if err1 != nil {
+				return err1
+			}
 		}
 
 		payload = &kafkamgmtclient.KafkaRequestPayload{
@@ -229,7 +229,7 @@ func runCreate(opts *options) error {
 		}
 	}
 
-	f.Logger.Debug("Creating kafka instance", payload.Name, payload.Plan)
+	f.Logger.Debug("Creating kafka instance", payload.Name, payload.GetPlan())
 
 	if opts.dryRun {
 		f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.dryRun.success"))

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -65,7 +65,6 @@ var (
 // NewCreateCommand creates a new command for creating kafkas.
 func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	opts := &options{
-
 		f: f,
 	}
 
@@ -208,10 +207,10 @@ func runCreate(opts *options) error {
 				return err1
 			}
 
-			err1 = validator.ValidateSize()
-			if err1 != nil {
-				return err1
-			}
+			// err1 = validator.ValidateSize()
+			// if err1 != nil {
+			// 	return err1
+			// }
 		}
 
 		payload = &kafkamgmtclient.KafkaRequestPayload{
@@ -221,11 +220,17 @@ func runCreate(opts *options) error {
 		}
 
 		if opts.size != "" {
+			sizes, err1 := FetchValidKafkaSizes(opts.f, opts.provider, opts.region, *userInstanceType)
+			if err1 != nil {
+				return err1
+			}
+			printSizeWarningIfNeeded(opts.f, opts.size, sizes)
 			payload.SetPlan(mapAmsTypeToBackendType(userInstanceType) + "." + opts.size)
 		}
 	}
 
 	f.Logger.Debug("Creating kafka instance", payload.Name, payload.Plan)
+
 	if opts.dryRun {
 		f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.dryRun.success"))
 		return nil
@@ -392,18 +397,18 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		return nil, err
 	}
 
-	sizes, err := GetValidKafkaSizes(opts.f, answers.CloudProvider, answers.Region, userQuotaType)
+	sizes, err := FetchValidKafkaSizes(opts.f, answers.CloudProvider, answers.Region, userQuotaType)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(sizes) == 1 {
-		answers.Size = sizes[0]
+		answers.Size = sizes[0].GetId()
 	} else {
+		sizeLabels := GetValidKafkaSizesLabels(sizes)
 		planPrompt := &survey.Select{
 			Message: f.Localizer.MustLocalize("kafka.create.input.plan.message"),
-			Options: sizes,
-			Help:    "",
+			Options: sizeLabels,
 		}
 
 		err = survey.AskOne(planPrompt, &answers.Size)
@@ -417,7 +422,18 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		Region:        &answers.Region,
 		CloudProvider: &answers.CloudProvider,
 	}
+	printSizeWarningIfNeeded(opts.f, answers.Size, sizes)
 	payload.SetPlan(mapAmsTypeToBackendType(&userQuotaType) + "." + answers.Size)
 
 	return payload, nil
+}
+
+func printSizeWarningIfNeeded(f *factory.Factory, selectedSize string, sizes []kafkamgmtclient.SupportedKafkaSize) {
+	for i := range sizes {
+		if sizes[i].GetId() == selectedSize {
+			if sizes[i].GetMaturityStatus() == "preview" {
+				f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.sizePreview"))
+			}
+		}
+	}
 }

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -431,6 +431,8 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 func printSizeWarningIfNeeded(f *factory.Factory, selectedSize string, sizes []kafkamgmtclient.SupportedKafkaSize) {
 	for i := range sizes {
 		if sizes[i].GetId() == selectedSize {
+			f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.sizeUnit",
+				localize.NewEntry("DisplaySize", sizes[i].GetDisplayName()), localize.NewEntry("Size", sizes[i].GetId())))
 			if sizes[i].GetMaturityStatus() == "preview" {
 				f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.sizePreview"))
 			}

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -323,7 +323,7 @@ one = "Cloud Region:"
 one = 'Instance type:'
 
 [kafka.create.log.info.sizePreview]
-one = 'Selected Kafka size is available under technology preview'
+one = 'Selected Kafka instance size is a Technology Preview feature. Do not use it for production workloads. For more information, see https://access.redhat.com/support/offerings/techpreview'
 
 [kafka.create.input.cloudRegion.help]
 description = 'Help text for Cloud Region'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -322,6 +322,9 @@ one = "Cloud Region:"
 [kafka.create.input.plan.message]
 one = 'Instance type:'
 
+[kafka.create.log.info.sizePreview]
+one = 'Selected Kafka size is available under technology preview'
+
 [kafka.create.input.cloudRegion.help]
 description = 'Help text for Cloud Region'
 one = "Geographical region where the Kafka instance will be deployed"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -322,6 +322,9 @@ one = "Cloud Region:"
 [kafka.create.input.plan.message]
 one = 'Instance type:'
 
+[kafka.create.log.info.sizeUnit]
+one = 'Kafka instance with size {{.DisplaySize}} is being created. (Size id: {{.Size}})'
+
 [kafka.create.log.info.sizePreview]
 one = 'Selected Kafka instance size is a Technology Preview feature. Do not use it for production workloads. For more information, see https://access.redhat.com/support/offerings/techpreview'
 


### PR DESCRIPTION
Adding warning for size x2 of standard instances (subject to change dynamically in near future)
Warning is displayed only when user specifies size (no default sizes are included)

## Verification 
```
[wtrocki@graphapi app-services-cli (add-warning-kafka-size ✗)]$ rhoas kafka create --name=test --provider=aws --region us-east-1 --dry-run  --size=x2 
Selected Kafka size is available under technology preview
Dry run successful, arguments are valid
[wtrocki@graphapi app-services-cli (add-warning-kafka-size ✗)]$ rhoas kafka create --name=test --provider=aws --region us-east-1 --dry-run  --size=x1 
Dry run successful, arguments are valid
[wtrocki@graphapi app-services-cli (add-warning-kafka-size ✗)]$ 

[wtrocki@graphapi app-services-cli (add-warning-kafka-size)]$ rhoas kafka create --dry-run
? Name: test
? Cloud Provider: aws
? Cloud Region: us-east-1
? Instance type: x2
Selected Kafka size is available under technology preview
Dry run successful, arguments are valid
[wtrocki@graphapi app-services-cli (add-warning-kafka-size)]$ 
```