### PR TITLE
fix(service-registry create): fetch registry URL after creation

### DIFF
--- a/pkg/cmd/registry/create/create.go
+++ b/pkg/cmd/registry/create/create.go
@@ -151,10 +151,6 @@ func runCreate(opts *options) error {
 		return opts.localizer.MustLocalizeError("registry.cmd.create.error.limitreached")
 	}
 
-	if err != nil {
-		return err
-	}
-
 	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("registry.cmd.create.info.successMessage"))
 
 	registry, _, err := serviceregistryutil.GetServiceRegistryByID(opts.Context, conn.API().ServiceRegistryMgmt(), response.GetId())
@@ -166,14 +162,18 @@ func runCreate(opts *options) error {
 		return err
 	}
 
-	compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(registry.GetRegistryUrl())
+	if registry.GetRegistryUrl() != "" {
+		compatibleEndpoints := registrycmdutil.GetCompatibilityEndpoints(registry.GetRegistryUrl())
 
-	opts.Logger.Info(opts.localizer.MustLocalize(
-		"registry.common.log.message.compatibleAPIs",
-		localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
-		localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),
-		localize.NewEntry("CncfSchemaRegistryAPI", compatibleEndpoints.CncfSchemaRegistry),
-	))
+		opts.Logger.Info(opts.localizer.MustLocalize(
+			"registry.common.log.message.compatibleAPIs",
+			localize.NewEntry("CoreRegistryAPI", compatibleEndpoints.CoreRegistry),
+			localize.NewEntry("SchemaRegistryAPI", compatibleEndpoints.SchemaRegistry),
+			localize.NewEntry("CncfSchemaRegistryAPI", compatibleEndpoints.CncfSchemaRegistry),
+		))
+	} else {
+		opts.Logger.Info(opts.localizer.MustLocalize("registry.cmd.create.info.compatibilityEndpointHint"))
+	}
 
 	if opts.autoUse {
 		opts.Logger.Debug("Auto-use is set, updating the current instance")

--- a/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
@@ -48,7 +48,7 @@ one = 'Creating Service Registry instance with name: {{.Name}}'
 
 [registry.cmd.create.info.compatibilityEndpointHint]
 one = '''
-Run the following command to view compatible endpoints:
+Run the following command to view service status
 
   $ rhoas service-registry describe
 '''

--- a/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
+++ b/pkg/core/localize/locales/en/cmd/registry_crud.en.toml
@@ -46,6 +46,13 @@ one = 'Successfully created Service Registry instance'
 [registry.cmd.create.info.action]
 one = 'Creating Service Registry instance with name: {{.Name}}'
 
+[registry.cmd.create.info.compatibilityEndpointHint]
+one = '''
+Run the following command to view compatible endpoints:
+
+  $ rhoas service-registry describe
+'''
+
 [registry.cmd.delete.shortDescription]
 one = 'Delete a Service Registry instance'
 


### PR DESCRIPTION
`rhoas service-registry create` now fetches registry URL and shows correct compatibility endpoints.

Closes #1574 

### Verification Steps
1. Run the following command to create a registry:
```
rhoas service-registry create
```
2. You should be able to see the registry URL along with compatibility endpoints once creation is successful.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
