### PR TITLE
Added topic name as a hint when confirming deletion of topic

### DIFF
--- a/pkg/cmd/kafka/topic/delete/delete.go
+++ b/pkg/cmd/kafka/topic/delete/delete.go
@@ -114,7 +114,7 @@ func runCmd(opts *options) error {
 
 	if !opts.force {
 		promptConfirmName := &survey.Input{
-			Message: opts.localizer.MustLocalize("kafka.topic.delete.input.name.message"),
+			Message: opts.localizer.MustLocalize("kafka.topic.delete.input.name.message", localize.NewEntry("TopicName", opts.topicName)),
 		}
 		var userConfirmedName string
 		if err = survey.AskOne(promptConfirmName, &userConfirmedName); err != nil {

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -678,7 +678,7 @@ $ rhoas kafka topic delete --name topic-1
 one = 'Skip confirmation to forcibly delete a topic'
 
 [kafka.topic.delete.input.name.message]
-one = 'Confirm the name of the topic you want to delete:'
+one = 'Confirm the name of the topic you want to delete ({{.TopicName}}):'
 
 [kafka.topic.delete.error.mismatchedNameConfirmation]
 one = 'topic name entered "{{.ConfirmedName}}" does not match the name of the topic you tried to delete "{{.ActualName}}"'


### PR DESCRIPTION
The prompt the user gets when confirming the deletion of a topic now also contains the name of that topic.

When topic name is `prices`

Before:
```
Confirm the name of the topic you want to delete: 
```

Now:
```
Confirm the name of the topic you want to delete (prices): 
```

### Verification Steps
1. Clone repo and checkout branch `topic-delete-prompt-change`
2. `go run ./cmd/rhoas kafka topic delete --name prices`
3. Confirm prompt is `Confirm the name of the topic you want to delete (prices): `

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
