### PR TITLE
docs(generate-config): show valid output types in examples

### DIFF
--- a/docs/commands/rhoas_generate-config.md
+++ b/docs/commands/rhoas_generate-config.md
@@ -6,6 +6,14 @@ Generate configurations for the service context
 
 Generate configuration files for the service context to connect with to be used with various tools and platforms
 
+You must specify an output format into which the credentials will be stored:
+
+- env (default): Store configurations in an env file as environment variables
+- json: Store configurations in a JSON file
+- properties: Store configurations in a properties file, which is typically used in Java-related technologies
+- secret: Store configurations in a Kubernetes secret file
+
+
 ```
 rhoas generate-config [flags]
 ```
@@ -15,6 +23,12 @@ rhoas generate-config [flags]
 ```
 ## Generate configurations for the current service context in json format
 $ rhoas generate-config --type json
+
+## Generate configurations for the current service context in env format and save it in specified path
+$ rhoas generate-config --type env --output-file ./configs/.env
+
+## Generate configurations for a specified context as Kubernetes secret
+$ rhoas generate-config --name qaprod --type secret
 
 ```
 

--- a/pkg/core/localize/locales/en/cmd/generate_config.en.toml
+++ b/pkg/core/localize/locales/en/cmd/generate_config.en.toml
@@ -2,12 +2,27 @@
 one='Generate configurations for the service context'
 
 [generate.cmd.longDescription]
-one='Generate configuration files for the service context to connect with to be used with various tools and platforms'
+one='''
+Generate configuration files for the service context to connect with to be used with various tools and platforms
+
+You must specify an output format into which the credentials will be stored:
+
+- env (default): Store configurations in an env file as environment variables
+- json: Store configurations in a JSON file
+- properties: Store configurations in a properties file, which is typically used in Java-related technologies
+- secret: Store configurations in a Kubernetes secret file
+'''
 
 [generate.cmd.example]
 one='''
 ## Generate configurations for the current service context in json format
 $ rhoas generate-config --type json
+
+## Generate configurations for the current service context in env format and save it in specified path
+$ rhoas generate-config --type env --output-file ./configs/.env
+
+## Generate configurations for a specified context as Kubernetes secret
+$ rhoas generate-config --name qaprod --type secret
 '''
 
 [generate.flag.type]


### PR DESCRIPTION
Added text to describe supported file formats supported by `rhoas generate-config`. It is similar to what we have for `rhoas service-account create`.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following command to see the description and help text of `generate-config`. It should explain each of the file format supported:
```
./rhoas generate-config -h
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [ ] Other (please specify)
