### PR TITLE
docs(service-account): add secret option to file format descriptions

### DIFF
--- a/docs/commands/rhoas_service-account_create.md
+++ b/docs/commands/rhoas_service-account_create.md
@@ -12,7 +12,8 @@ You must specify an output format into which the credentials will be stored.
 
 - env (default): Store credentials in an env file as environment variables
 - json: Store credentials in a JSON file
-- properties: Store credentials in a properties file, which is typically used in Java-related technologies.
+- properties: Store credentials in a properties file, which is typically used in Java-related technologies
+- secret: Store credentials in a Kubernetes secret file
 
 
 ```
@@ -39,7 +40,7 @@ $ rhoas service-account create --output-file=./service-acct-credentials.json
 ### Options
 
 ```
-      --file-format string         Format in which to save the service account credentials (choose from: "env", "json", "properties")
+      --file-format string         Format in which to save the service account credentials (choose from: "env", "json", "properties", "secret")
       --output-file string         Sets a custom file location to save the credentials
       --overwrite                  Forcibly overwrite a credentials file if it already exists
       --short-description string   Short description of the service account

--- a/docs/commands/rhoas_service-account_reset-credentials.md
+++ b/docs/commands/rhoas_service-account_reset-credentials.md
@@ -12,7 +12,8 @@ You must specify an output format into which the credentials will be stored.
 
 - env (default): Store credentials in an env file as environment variables
 - json: Store credentials in a JSON file
-- properties: Store credentials in a properties file, which is typically used in Java-related technologies.
+- properties: Store credentials in a properties file, which is typically used in Java-related technologies
+- secret: Store credentials in a Kubernetes secret file
 
 
 ```
@@ -33,7 +34,7 @@ $ rhoas service-account reset-credentials --id 173c1ad9-932d-4007-ae0f-4da74f4d2
 ### Options
 
 ```
-      --file-format string   Format in which to save the service account credentials (choose from: "env", "json", "properties")
+      --file-format string   Format in which to save the service account credentials (choose from: "env", "json", "properties", "secret")
       --id string            The unique ID of the service account for which you want to reset the credentials
       --output-file string   Sets a custom file location to save the credentials
       --overwrite            Forcibly overwrite a credentials file if it already exists

--- a/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
@@ -80,7 +80,7 @@ one = 'you must specify a file to save the service account credentials'
 
 [serviceAccount.common.flag.fileFormat.description]
 description = 'Description for the --file-format flag'
-one = 'Format in which to save the service account credentials (choose from: "env", "json", "properties")'
+one = 'Format in which to save the service account credentials (choose from: "env", "json", "properties", "secret")'
 
 [serviceAccount.common.flag.overwrite.description]
 description = 'Description for --overwrite flag'

--- a/pkg/core/localize/locales/en/cmd/serviceaccount_create.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount_create.en.toml
@@ -13,7 +13,8 @@ You must specify an output format into which the credentials will be stored.
 
 - env (default): Store credentials in an env file as environment variables
 - json: Store credentials in a JSON file
-- properties: Store credentials in a properties file, which is typically used in Java-related technologies.
+- properties: Store credentials in a properties file, which is typically used in Java-related technologies
+- secret: Store credentials in a Kubernetes secret file
 '''
 
 [serviceAccount.create.cmd.example]

--- a/pkg/core/localize/locales/en/cmd/serviceaccount_reset_credentials.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount_reset_credentials.en.toml
@@ -13,7 +13,8 @@ You must specify an output format into which the credentials will be stored.
 
 - env (default): Store credentials in an env file as environment variables
 - json: Store credentials in a JSON file
-- properties: Store credentials in a properties file, which is typically used in Java-related technologies.
+- properties: Store credentials in a properties file, which is typically used in Java-related technologies
+- secret: Store credentials in a Kubernetes secret file
 '''
 
 [serviceAccount.resetCredentials.cmd.example]


### PR DESCRIPTION
Help texts for `service-account` commands didn't show "secret" as a valid file format in multiple places.

### Verification Steps
1. Descriptions for the command `rhoas service-account create` and `rhoas service-account reset-credentials` should mention "secret" along with other valid file formats for output.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [ ] Other (please specify)
