### PR TITLE
WIP: New produce command

### DIFF
--- a/docs/commands/rhoas_kafka_topic.md
+++ b/docs/commands/rhoas_kafka_topic.md
@@ -34,5 +34,6 @@ rhoas kafka topic list
 * [rhoas kafka topic delete](rhoas_kafka_topic_delete.md)	 - Delete a topic
 * [rhoas kafka topic describe](rhoas_kafka_topic_describe.md)	 - Describe a topic
 * [rhoas kafka topic list](rhoas_kafka_topic_list.md)	 - List all topics
+* [rhoas kafka topic produce](rhoas_kafka_topic_produce.md)	 - Produce to a topic
 * [rhoas kafka topic update](rhoas_kafka_topic_update.md)	 - Update configuration details for a Kafka topic
 

--- a/docs/commands/rhoas_kafka_topic_produce.md
+++ b/docs/commands/rhoas_kafka_topic_produce.md
@@ -1,0 +1,41 @@
+## rhoas kafka topic produce
+
+Produce to a topic
+
+### Synopsis
+
+Produce to a topic in the current Kafka instance. You can specify the partition, key, and value.
+
+
+```
+rhoas kafka topic produce [flags]
+```
+
+### Examples
+
+```
+# Produce to a topic
+$ rhoas kafka topic produce --name topic-1 --value "Hello world"
+
+```
+
+### Options
+
+```
+      --instance-id string   Kafka instance ID. Uses the current instance if not set 
+      --key string           The key associated with the value produced. Empty if not set
+      --name string          Topic name
+      --partition int32      The partition receiving the message
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas kafka topic](rhoas_kafka_topic.md)	 - Create, describe, update, list, and delete topics
+

--- a/docs/commands/rhoas_kafka_topic_produce.md
+++ b/docs/commands/rhoas_kafka_topic_produce.md
@@ -22,6 +22,7 @@ $ rhoas kafka topic produce --name topic-1 --value "Hello world"
 ### Options
 
 ```
+      --file string          Path to file containing value
       --instance-id string   Kafka instance ID. Uses the current instance if not set 
       --key string           The key associated with the value produced. Empty if not set
       --name string          Topic name

--- a/pkg/cmd/kafka/topic/produce/produce.go
+++ b/pkg/cmd/kafka/topic/produce/produce.go
@@ -1,0 +1,133 @@
+package produce
+
+import (
+	"context"
+	"os"
+
+	kafkaflagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
+	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1internal/client"
+
+	"bufio"
+	"io/ioutil"
+
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/kafkacmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	topicName string
+	kafkaID   string
+	key       string
+	partition int32
+
+	IO             *iostreams.IOStreams
+	Connection     factory.ConnectionFunc
+	Logger         logging.Logger
+	localizer      localize.Localizer
+	Context        context.Context
+	ServiceContext servicecontext.IContext
+}
+
+// NewProduceTopicCommand gets a new command for producing to a kafka topic.
+func NewProduceTopicCommand(f *factory.Factory) *cobra.Command {
+	opts := &options{
+		Connection:     f.Connection,
+		Logger:         f.Logger,
+		IO:             f.IOStreams,
+		localizer:      f.Localizer,
+		Context:        f.Context,
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "produce",
+		Short:   opts.localizer.MustLocalize("kafka.topic.produce.cmd.shortDescription"),
+		Long:    opts.localizer.MustLocalize("kafka.topic.produce.cmd.longDescription"),
+		Example: opts.localizer.MustLocalize("kafka.topic.produce.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			// if !opts.IO.CanPrompt() {
+			// 	return opts.localizer.MustLocalizeError("flag.error.requiredWhenNonInteractive", localize.NewEntry("Flag", "yes"))
+			// }
+
+			if opts.kafkaID == "" {
+
+				kafkaInstance, err := contextutil.GetCurrentKafkaInstance(f)
+				if err != nil {
+					return err
+				}
+
+				opts.kafkaID = kafkaInstance.GetId()
+			}
+
+			return runCmd(opts)
+		},
+	}
+
+	flags := kafkaflagutil.NewFlagSet(cmd, opts.localizer)
+
+	flags.StringVar(&opts.topicName, "name", "", opts.localizer.MustLocalize("kafka.topic.common.flag.name.description"))
+	flags.StringVar(&opts.key, "key", "", opts.localizer.MustLocalize("kafka.topic.produce.flag.key.description"))
+	flags.Int32Var(&opts.partition, "partition", 0, opts.localizer.MustLocalize("kafka.topic.produce.flag.partition.description"))
+
+	_ = cmd.MarkFlagRequired("name")
+
+	_ = cmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return kafkacmdutil.FilterValidTopicNameArgs(f, toComplete)
+	})
+
+	flags.AddInstanceID(&opts.kafkaID)
+
+	return cmd
+}
+
+// nolint:funlen
+func runCmd(opts *options) error {
+	conn, err := opts.Connection(connection.DefaultConfigRequireMasAuth)
+	if err != nil {
+		return err
+	}
+
+	api, _, err := conn.API().KafkaAdmin(opts.kafkaID)
+	if err != nil {
+		return err
+	}
+
+	var value string
+
+	// if value being piped then cannot have delimeter as \n
+	info, _ := os.Stdin.Stat()
+	if info.Mode()&os.ModeCharDevice == 0 {
+		bytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		value = string(bytes)
+	} else {
+		value, err = bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return err
+		}
+	}
+
+	record := kafkainstanceclient.Record{
+		Key:       &opts.key,
+		Value:     value,
+		Partition: &opts.partition,
+	}
+
+	_, _, err = api.RecordsApi.ProduceRecord(opts.Context, opts.topicName).Record(record).Execute()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/kafka/topic/topic.go
+++ b/pkg/cmd/kafka/topic/topic.go
@@ -5,6 +5,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic/describe"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic/produce"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic/update"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func NewTopicCommand(f *factory.Factory) *cobra.Command {
 		delete.NewDeleteTopicCommand(f),
 		describe.NewDescribeTopicCommand(f),
 		update.NewUpdateTopicCommand(f),
+		produce.NewProduceTopicCommand(f),
 	)
 
 	return cmd

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -528,6 +528,12 @@ one = 'Format in which to display the Kafka topic (choose from: "json", "yml", "
 [kafka.topic.list.flag.output.description]
 one = 'Format in which to display the Kafka topic (choose from: "json", "yml", "yaml")'
 
+[kafka.topic.produce.flag.key.description]
+one = 'The key associated with the value produced. Empty if not set'
+
+[kafka.topic.produce.flag.partition.description]
+one = 'The partition receiving the message'
+
 [kafka.topic.common.input.partitions.description]
 description = 'help for the Partitions input'
 one = 'The number of partitions in the topic'
@@ -633,6 +639,20 @@ The replicas are preconfigured. The number of partition replicas for the topic i
 one = '''
 # Create a topic
 $ rhoas kafka topic create --name topic-1
+'''
+
+[kafka.topic.produce.cmd.shortDescription]
+one = 'Produce to a topic'
+
+[kafka.topic.produce.cmd.longDescription]
+one = '''
+Produce to a topic in the current Kafka instance. You can specify the partition, key, and value.
+'''
+
+[kafka.topic.produce.cmd.example]
+one = '''
+# Produce to a topic
+$ rhoas kafka topic produce --name topic-1 --value "Hello world"
 '''
 
 [kafka.topic.create.error.topicNameIsRequired]

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -531,6 +531,9 @@ one = 'Format in which to display the Kafka topic (choose from: "json", "yml", "
 [kafka.topic.produce.flag.key.description]
 one = 'The key associated with the value produced. Empty if not set'
 
+[kafka.topic.produce.flag.key.file]
+one = 'Path to file containing value'
+
 [kafka.topic.produce.flag.partition.description]
 one = 'The partition receiving the message'
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -537,6 +537,10 @@ one = 'Path to file containing value'
 [kafka.topic.produce.flag.partition.description]
 one = 'The partition receiving the message'
 
+[kafka.topic.produce.info.produceSuccess]
+description = 'Produce success message'
+one = 'Record successfully produced to "{{.Topic}}"'
+
 [kafka.topic.common.input.partitions.description]
 description = 'help for the Partitions input'
 one = 'The number of partitions in the topic'


### PR DESCRIPTION
This PR adds a produce command to a kafka topic to allow the user to produce messages for a topic. Flags like the partition and key are optional. This is useful for debugging purposes and currently you need another thrid-party kafka cli for this feature.   

*Still not complying with design guidelines yet*

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a kafka instance with a topic
2. Run `echo text | rhoas kafka topic produce --name=<topic-name>`
3. Go to `console.redhat.com -> kafka instances -> instance -> topics -> topic-name -> messages` and confirm message is being seen
4. Try other flags like `--key` and `--partition` and check if message has these correct values set

### Type of change
- [x] New feature (non-breaking change which adds functionality)