### PR TITLE
fix(kafka create): completions should consider provider

### DIFF
--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -58,7 +58,7 @@ func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionI
 func GetMarketplaceAcctIdCompletionValues(f *factory.Factory) (validMarketplaceAcctIDs []string, directive cobra.ShellCompDirective) {
 	directive = cobra.ShellCompDirectiveNoSpace
 
-	validMarketplaceAcctIDs, _ = accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection)
+	validMarketplaceAcctIDs, _ = accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, "")
 
 	return validMarketplaceAcctIDs, directive
 }

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -404,7 +404,7 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 	f := opts.f
 
 	accountIDNullable := kafkamgmtclient.NullableString{}
-	cloudProviderIDNullable := kafkamgmtclient.NullableString{}
+	marketplaceProviderNullable := kafkamgmtclient.NullableString{}
 
 	validator := &kafkacmdutil.Validator{
 		Localizer:  f.Localizer,
@@ -496,7 +496,7 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		}
 
 		accountIDNullable.Set(&answers.MarketplaceAcctID)
-		cloudProviderIDNullable.Set(&answers.Marketplace)
+		marketplaceProviderNullable.Set(&answers.Marketplace)
 	}
 
 	payload := &kafkamgmtclient.KafkaRequestPayload{
@@ -504,7 +504,7 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		Region:                &answers.Region,
 		CloudProvider:         &answers.CloudProvider,
 		BillingCloudAccountId: accountIDNullable,
-		Marketplace:           cloudProviderIDNullable,
+		Marketplace:           marketplaceProviderNullable,
 	}
 	printSizeWarningIfNeeded(opts.f, answers.Size, sizes)
 	payload.SetPlan(mapAmsTypeToBackendType(&userQuotaType) + "." + answers.Size)

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -93,6 +93,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				}
 			}
 
+			if opts.bypassChecks && (opts.marketplace != "" || opts.marketplaceAcctId != "") {
+				return f.Localizer.MustLocalizeError("kafka.create.error.bypassChecks.marketplace")
+			}
+
 			if !f.IOStreams.CanPrompt() && opts.name == "" {
 				return f.Localizer.MustLocalizeError("kafka.create.argument.name.error.requiredWhenNonInteractive")
 			} else if opts.name == "" {
@@ -107,22 +111,24 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return flagutil.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
-			validMarketplaces, err := accountmgmtutil.GetValidMarketplaces(f.Context, f.Connection)
-			if err != nil {
-				return err
-			}
+			if !opts.bypassChecks {
+				validMarketplaces, err := accountmgmtutil.GetValidMarketplaces(f.Context, f.Connection)
+				if err != nil {
+					return err
+				}
 
-			if opts.marketplace != "" && !flagutil.IsValidInput(opts.marketplace, validMarketplaces...) {
-				return flagutil.InvalidValueError(FlagMarketPlace, opts.marketplace, validMarketplaces...)
-			}
+				if opts.marketplace != "" && !flagutil.IsValidInput(opts.marketplace, validMarketplaces...) {
+					return flagutil.InvalidValueError(FlagMarketPlace, opts.marketplace, validMarketplaces...)
+				}
 
-			validMarketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, opts.marketplace)
-			if err != nil {
-				return err
-			}
+				validMarketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, opts.marketplace)
+				if err != nil {
+					return err
+				}
 
-			if opts.marketplaceAcctId != "" && !flagutil.IsValidInput(opts.marketplaceAcctId, validMarketplaceAcctIDs...) {
-				return flagutil.InvalidValueError(FlagMarketPlaceAcctID, opts.marketplaceAcctId, validMarketplaceAcctIDs...)
+				if opts.marketplaceAcctId != "" && !flagutil.IsValidInput(opts.marketplaceAcctId, validMarketplaceAcctIDs...) {
+					return flagutil.InvalidValueError(FlagMarketPlaceAcctID, opts.marketplaceAcctId, validMarketplaceAcctIDs...)
+				}
 			}
 
 			return runCreate(opts)
@@ -397,6 +403,9 @@ type promptAnswers struct {
 func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) (*kafkamgmtclient.KafkaRequestPayload, error) {
 	f := opts.f
 
+	accountIDNullable := kafkamgmtclient.NullableString{}
+	cloudProviderIDNullable := kafkamgmtclient.NullableString{}
+
 	validator := &kafkacmdutil.Validator{
 		Localizer:  f.Localizer,
 		Connection: f.Connection,
@@ -470,7 +479,7 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		return nil, err
 	}
 
-	if len(marketplaces) > 0 {
+	if !opts.bypassChecks && len(marketplaces) > 0 {
 		if err = promptMarketplaceSelect(f.Localizer, marketplaces, answers); err != nil {
 			return nil, err
 		}
@@ -485,13 +494,10 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 				return nil, err
 			}
 		}
+
+		accountIDNullable.Set(&answers.MarketplaceAcctID)
+		cloudProviderIDNullable.Set(&answers.Marketplace)
 	}
-
-	accountIDNullable := kafkamgmtclient.NullableString{}
-	accountIDNullable.Set(&answers.MarketplaceAcctID)
-
-	cloudProviderIDNullable := kafkamgmtclient.NullableString{}
-	cloudProviderIDNullable.Set(&answers.Marketplace)
 
 	payload := &kafkamgmtclient.KafkaRequestPayload{
 		Name:                  answers.Name,

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -107,15 +107,6 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return flagutil.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
-			validMarketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection)
-			if err != nil {
-				return err
-			}
-
-			if opts.marketplaceAcctId != "" && !flagutil.IsValidInput(opts.marketplaceAcctId, validMarketplaceAcctIDs...) {
-				return flagutil.InvalidValueError(FlagMarketPlaceAcctID, opts.marketplaceAcctId, validMarketplaceAcctIDs...)
-			}
-
 			validMarketplaces, err := accountmgmtutil.GetValidMarketplaces(f.Context, f.Connection)
 			if err != nil {
 				return err
@@ -123,6 +114,15 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 
 			if opts.marketplace != "" && !flagutil.IsValidInput(opts.marketplace, validMarketplaces...) {
 				return flagutil.InvalidValueError(FlagMarketPlace, opts.marketplace, validMarketplaces...)
+			}
+
+			validMarketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, opts.marketplace)
+			if err != nil {
+				return err
+			}
+
+			if opts.marketplaceAcctId != "" && !flagutil.IsValidInput(opts.marketplaceAcctId, validMarketplaceAcctIDs...) {
+				return flagutil.InvalidValueError(FlagMarketPlaceAcctID, opts.marketplaceAcctId, validMarketplaceAcctIDs...)
 			}
 
 			return runCreate(opts)
@@ -474,16 +474,16 @@ func promptKafkaPayload(opts *options, userQuotaType accountmgmtutil.QuotaSpec) 
 		if err = promptMarketplaceSelect(f.Localizer, marketplaces, answers); err != nil {
 			return nil, err
 		}
-	}
 
-	marketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(marketplaceAcctIDs) > 0 {
-		if err = promptMarketplaceAcctIDSelect(f.Localizer, marketplaceAcctIDs, answers); err != nil {
+		marketplaceAcctIDs, err := accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, answers.Marketplace)
+		if err != nil {
 			return nil, err
+		}
+
+		if len(marketplaceAcctIDs) > 0 {
+			if err = promptMarketplaceAcctIDSelect(f.Localizer, marketplaceAcctIDs, answers); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -523,7 +523,7 @@ func promptMarketplaceSelect(localizer localize.Localizer, marketplaceAcctIDs []
 func promptMarketplaceAcctIDSelect(localizer localize.Localizer, accountIDs []string, answers *promptAnswers) error {
 
 	accountIDPrompt := &survey.Select{
-		Message: localizer.MustLocalize("kafka.create.input.accountID.message"),
+		Message: localizer.MustLocalize("kafka.create.input.accountID.message", localize.NewEntry("Marketplace", answers.Marketplace)),
 		Options: accountIDs,
 	}
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -347,6 +347,9 @@ one = "Geographical region where the Kafka instance will be deployed"
 [kafka.create.argument.name.error.requiredWhenNonInteractive]
 one = 'name is required. Run "rhoas kafka create --name my-kafka"'
 
+[kafka.create.error.bypassChecks.marketplace]
+one = 'marketplace is not supported with "--bypass-checks" flag'
+
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -332,7 +332,7 @@ one = 'Instance type:'
 one = 'Select a marketplace:'
 
 [kafka.create.input.accountID.message]
-one = 'Select a cloud account ID for the marketplace:'
+one = 'Select a cloud provider ID associated with "{{.Marketplace}}" marketplace'
 
 [kafka.create.log.info.sizeUnit]
 one = 'Kafka instance with size {{.DisplaySize}} is being created. (Size id: {{.Size}})'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -348,7 +348,7 @@ one = "Geographical region where the Kafka instance will be deployed"
 one = 'name is required. Run "rhoas kafka create --name my-kafka"'
 
 [kafka.create.error.bypassChecks.marketplace]
-one = 'marketplace is not supported with "--bypass-checks" flag'
+one = '"--marketplace" and "--marketplace-account-id" flags are not supported with "--bypass-checks" flag'
 
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -146,7 +146,7 @@ func GetOrganizationID(ctx context.Context, conn connection.Connection) (account
 	return account.Organization.GetId(), nil
 }
 
-func GetValidMarketplaceAcctIDs(ctx context.Context, connectionFunc factory.ConnectionFunc) (marketplaceAcctIDs []string, err error) {
+func GetValidMarketplaceAcctIDs(ctx context.Context, connectionFunc factory.ConnectionFunc, marketplace string) (marketplaceAcctIDs []string, err error) {
 
 	conn, err := connectionFunc(connection.DefaultConfigSkipMasAuth)
 	if err != nil {
@@ -161,7 +161,13 @@ func GetValidMarketplaceAcctIDs(ctx context.Context, connectionFunc factory.Conn
 	for _, quota := range quotaCostGet.GetItems() {
 		if len(quota.GetCloudAccounts()) > 0 {
 			for _, cloudAccount := range quota.GetCloudAccounts() {
-				marketplaceAcctIDs = append(marketplaceAcctIDs, cloudAccount.GetCloudAccountId())
+				if marketplace != "" {
+					if cloudAccount.GetCloudProviderId() == marketplace {
+						marketplaceAcctIDs = append(marketplaceAcctIDs, cloudAccount.GetCloudAccountId())
+					}
+				} else {
+					marketplaceAcctIDs = append(marketplaceAcctIDs, cloudAccount.GetCloudAccountId())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Completion and validation of cloud account IDs should take care of the cloud_provider wherever possible.

### Verification step

1. Run `rhoas kafka create` in interactive mode.
2. Selecting marketplace should show Account IDs for that marketplace only.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [X] Enhancement