### PR TITLE
fix: remove redundant kafka admin slash

### DIFF
--- a/pkg/shared/connection/api/defaultapi/default_client.go
+++ b/pkg/shared/connection/api/defaultapi/default_client.go
@@ -139,7 +139,7 @@ func (a *defaultAPI) KafkaAdmin(instanceID string) (*kafkainstanceclient.APIClie
 		apiHost := fmt.Sprintf("admin-server-%v", host)
 		apiURL, _ = url.Parse(apiHost)
 		apiURL.Scheme = "https"
-		apiURL.Path = "/"
+		apiURL.Path = ""
 		apiURL.Host = fmt.Sprintf("admin-server-%v", host)
 	}
 


### PR DESCRIPTION
Before
```
Making request to https://admin-server-tesaddstas-calbu-ccff-bdd-jsg-a.kas.mk-cakn1ba87d5o.1e0z.s1.devshift.org
2022/06/16 09:13:53 
GET //api/v1/topics?page=1&size=10 HTTP/1.1
Host: admin-server-tesaddstas-calbu-ccff-bdd-jsg-a.kas.mk-cakn1ba87d5o.1e0z.s1.devshift.org
User-Agent: rhoas-cli_dev
Accept: application/json
Accept-Encoding: gzip
```
After

```
Making request to https://admin-server-tesaddstas-calbu-ccff-bdd-jsg-a.kas.mk-cakn1ba87d5o.1e0z.s1.devshift.org
2022/06/16 09:13:53 
GET /api/v1/topics?page=1&size=10 HTTP/1.1
Host: admin-server-tesaddstas-calbu-ccff-bdd-jsg-a.kas.mk-cakn1ba87d5o.1e0z.s1.devshift.org
User-Agent: rhoas-cli_dev
Accept: application/json
Accept-Encoding: gzip
```