### PR TITLE
feat(generate-config): add overwrite flag and change default env file

### DIFF
--- a/docs/commands/rhoas_generate-config.md
+++ b/docs/commands/rhoas_generate-config.md
@@ -37,6 +37,7 @@ $ rhoas generate-config --name qaprod --type secret
 ```
       --name string          Name of the context
       --output-file string   Sets a custom file location to save the configurations
+      --overwrite            Forcibly overwrite a configuration file if it already exists
       --type string          Type of configuration file to be generated
 ```
 

--- a/pkg/cmd/generate/build-configs.go
+++ b/pkg/cmd/generate/build-configs.go
@@ -115,7 +115,7 @@ func BuildConfiguration(svcConfig *servicecontext.ServiceConfig, opts *options) 
 	configurations.TokenURL = providerUrls.GetTokenUrl()
 	configurations.Name = configInstanceName
 
-	if err = WriteConfig(opts.configType, opts.fileName, configurations); err != nil {
+	if err = WriteConfig(opts, configurations); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/generate/generate-config.go
+++ b/pkg/cmd/generate/generate-config.go
@@ -27,6 +27,7 @@ type options struct {
 	name       string
 	fileName   string
 	configType string
+	overwrite  bool
 }
 
 // NewGenerateCommand creates configuration files for service context
@@ -61,6 +62,7 @@ func NewGenerateCommand(f *factory.Factory) *cobra.Command {
 	flags := contextcmdutil.NewFlagSet(cmd, f)
 	flags.AddContextName(&opts.name)
 	flags.StringVar(&opts.configType, "type", "", opts.localizer.MustLocalize("generate.flag.type"))
+	cmd.Flags().BoolVar(&opts.overwrite, "overwrite", false, opts.localizer.MustLocalize("generate.flag.overwrite.description"))
 	cmd.Flags().StringVar(&opts.fileName, "output-file", "", opts.localizer.MustLocalize("generate.common.flag.fileLocation.description"))
 	_ = cmd.MarkFlagRequired("type")
 

--- a/pkg/core/localize/locales/en/cmd/generate_config.en.toml
+++ b/pkg/core/localize/locales/en/cmd/generate_config.en.toml
@@ -28,10 +28,16 @@ $ rhoas generate-config --name qaprod --type secret
 [generate.flag.type]
 one='Type of configuration file to be generated'
 
+[generate.flag.overwrite.description]
+one = 'Forcibly overwrite a configuration file if it already exists'
+
 [generate.common.flag.fileLocation.description]
 description = 'Description for --output-file flag'
 one = 'Sets a custom file location to save the configurations'
 
+[generate.error.configFileAlreadyExists]
+description = 'Error message for when a configuration file alredy exists at a location'
+one = 'file {{.FilePath}} already exists. Use --overwrite to overwrite the file, or the --output-file flag to choose a different location'
 
 [generate.log.info.noSevices]
 one='No services available to generate configurations'


### PR DESCRIPTION
The default file to save configuration details in environment variables has been changed from `rhoas.env` to `.env`
A `--overwrite` flag has been added to warn of already existing file.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. The following command should save connection configurations in a `.env` file:
```
rhoas generate-config --type env
```
2. Running the command again should throw the following error:
```
File `.env` already exists. Use --overwrite to overwrite the file, or the --output-file flag to choose a different location.
```
3. The existing file can be overridden using the `--overwrite` flag.
```
rhoas generate-config --type env --overwrite
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
