### PR TITLE
Custom provider

### DIFF
--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -357,7 +357,7 @@ one = 'Kafka instance "{{.Name}}" already exists'
 one = 'Cannot fetch user allowed instance type'
 
 [kafka.create.error.noInteractiveMode]
-one = 'Interactive mode is not supported when using --skip-checks flag'
+one = 'Interactive mode is not supported when using --bypass-checks flag'
 
 [kafka.create.error.quota.exceeded]
 one = 'your accout exceeded quota for Kafka instances. Please refer to https://console.redhat.com/application-services/subscriptions/streams for more information' 

--- a/pkg/shared/hacks/temp.go
+++ b/pkg/shared/hacks/temp.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
@@ -17,7 +18,13 @@ import (
 // Temporary hack that we use to determine if
 // Our CLI needs to use mas-sso token
 func ShouldUseMasSSO(logger logging.Logger, apiUrl string) bool {
-	req, err := http.NewRequest("GET", apiUrl+"/api/kafkas_mgmt/v1/sso_providers", nil)
+	finalUrl := apiUrl + "/api/kafkas_mgmt/v1/sso_providers"
+	externalUrl := os.Getenv("RHOAS_CUSTOM_SSO_PROVIDER_URL")
+	if externalUrl != "" {
+		finalUrl = externalUrl
+	}
+
+	req, err := http.NewRequest("GET", finalUrl, nil)
 	if err != nil {
 		logger.Debug("Error when fetching auth config", err)
 		return true


### PR DESCRIPTION
Enable using env var to override behaviour for fetching sso providers

## Verification
```
RHOAS_CUSTOM_SSO_PROVIDER_URL ="https://gist.githubusercontent.com/wtrocki/6eed975bf32e5de9ec68f16f59f819e0/raw/38052cf5c2eafd17d86a5a54e5d80a0e10a5bc81/sso_provider.json" rhoas service-registry artifact list
```

