### PR TITLE
fix: add prerelease support for documentation sync

### DIFF
--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -4,7 +4,7 @@ name: Downstream docs publish
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
       
 jobs:
   build:


### PR DESCRIPTION
Point here is to make sync of the documentation also on prereleases so we can include content downstream faster and give time to adapt the changes. 
CLI is released slowly right now (once per month).

Problem with this is that synced changes would reflect future versions of CLI so they never can be merged. I'm not sure if we want that.