### PR TITLE
Consume now uses separate time flags for date and Unix

### DIFF
--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -610,10 +610,10 @@ $ rhoas kafka topic consume --name=topic-1 --format=yaml
 $ rhoas kafka topic consume --name=topic-1 --wait
 
 # Consume from a topic starting from a certain time using the default ISO time format
-$ rhoas kafka topic consume --name=topic-1 --from=2022-06-17T07:05:34+00:00Z
+$ rhoas kafka topic consume --name=topic-1 --from-date=2022-06-17T07:05:34.0000Z
 
 # Consume from a topic starting from a certain time using unix time format
-$ rhoas kafka topic consume --name=topic-1 --wait --unix-time --from=1656346796
+$ rhoas kafka topic consume --name=topic-1 --wait --from-timestamp=1656346796
 
 # Consume from a topic starting from an offset
 $ rhoas kafka topic consume --name=topic-1 --offset=15
@@ -628,8 +628,11 @@ $ rhoas kafka topic consume --name=topic-1 --format=json | jq -rc .value
 [kafka.topic.consume.flag.partition.description]
 one = 'The partition number used for consumer. Positive integer'
 
-[kafka.topic.consume.flag.from.description]
-one = 'Only messages with a timestamp after this time will be consumed, time format required is YYYY-MM-DDThh:mm:ss.ssssZ'
+[kafka.topic.consume.flag.date.description]
+one = 'Messages with a date after this date will be consumed, time format required is YYYY-MM-DDThh:mm:ss.ssssZ'
+
+[kafka.topic.consume.flag.timestamp.description]
+one = 'Messages with a timestamp after this time will be consumed, time format required is the Unix timestamp'
 
 [kafka.topic.consume.flag.wait.description]
 one = 'Waiting for records to consume'
@@ -660,9 +663,13 @@ one = 'Invalid offset given, offset must be a positive integer'
 description = 'Error message when the offset given is not a number'
 one = 'Invalid offset given, the value "{{.Offset}}" is not a number'
 
+[kafka.topic.consume.error.dateAndTimestampConflict]
+description = 'Error message when the date and timestamp are both set'
+one = 'Cannot set date and timestamp'
+
 [kafka.topic.consume.error.offsetAndFromConflict]
 description = 'Error message when the offset and from flags are both set'
-one = 'Cannot use offset and from flags to filter messages'
+one = 'Cannot use offset with timestamp or date flags to filter messages'
 
 [kafka.topic.common.input.partitions.description]
 description = 'help for the Partitions input'


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->
Removes the old --from and --unix flags to separate time into two commands. Also updated examples to reflect this change in the API.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. `rhoas kafka topic consume --name=topic --format=json --offset=1` should work normal
2. `rhoas kafka topic consume --name=topic --wait` should work normal with time being the current, any new messages should be seen here.
3. `rhoas kafka topic consume --name=topic --from-date=2021-01-01T01:01:01.0000Z --wait` any messages you created passed this time should be displayed
4. `rhoas kafka topic consume --name=topic --from-timestamp=290384 --wait` any messages you created passed this time should be displayed
5. `rhoas kafka topic consume --name=topic --from-timestamp=290384 --from-date=2021-01-01T01:01:01.0000Z` should give you an error as you are setting both time filters

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
