### PR TITLE
feat(completion): add instruction for powershell completions

### DIFF
--- a/docs/commands/rhoas.md
+++ b/docs/commands/rhoas.md
@@ -38,7 +38,7 @@ $ rhoas cluster connect
 
 * [rhoas authtoken](rhoas_authtoken.md)	 - Output the current token
 * [rhoas cluster](rhoas_cluster.md)	 - View and perform operations on your Kubernetes or OpenShift cluster
-* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, or fish)
+* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, fish or powershell)
 * [rhoas connector](rhoas_connector.md)	 - Connectors instance commands
 * [rhoas context](rhoas_context.md)	 - Group, share and manage your rhoas services
 * [rhoas generate-config](rhoas_generate-config.md)	 - Generate configurations for the service context

--- a/docs/commands/rhoas_completion.md
+++ b/docs/commands/rhoas_completion.md
@@ -1,10 +1,10 @@
 ## rhoas completion
 
-Install command completion for your shell (bash, zsh, or fish)
+Install command completion for your shell (bash, zsh, fish or powershell)
 
 ### Synopsis
 
-Install rhoas command completion for your shell (bash, zsh, or fish).
+Install rhoas command completion for your shell (bash, zsh, fish, powershell).
 
 To find what shell you are currently running:
 
@@ -12,7 +12,7 @@ To find what shell you are currently running:
 
 For instructions on installing command completions for your shell:
 
-  $ rhoas completion [bash|zsh|fish] -h
+  $ rhoas completion [bash|zsh|fish|powershell] -h
 
 When you have installed the command completion script, restart your shell for the changes to take effect.
 
@@ -29,6 +29,9 @@ rhoas completion fish
 ## Generate command completion script for Zsh shell
 rhoas completion zsh
 
+## Generate command completion script for Powershell shell
+rhoas completion powershell
+
 ```
 
 ### Options inherited from parent commands
@@ -42,6 +45,7 @@ rhoas completion zsh
 
 * [rhoas](rhoas.md)	 - RHOAS CLI
 * [rhoas completion bash](rhoas_completion_bash.md)	 - Generate command completion script for Bash shell
-* [rhoas completion fish](rhoas_completion_fish.md)	 - Generate command completion script for fish shell
+* [rhoas completion fish](rhoas_completion_fish.md)	 - Generate command completion script for Fish shell
+* [rhoas completion powershell](rhoas_completion_powershell.md)	 - Generate command completion script for Powershell shell
 * [rhoas completion zsh](rhoas_completion_zsh.md)	 - Generate command completion script for Zsh shell
 

--- a/docs/commands/rhoas_completion_bash.md
+++ b/docs/commands/rhoas_completion_bash.md
@@ -51,5 +51,5 @@ rhoas completion bash
 
 ### SEE ALSO
 
-* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, or fish)
+* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, fish or powershell)
 

--- a/docs/commands/rhoas_completion_fish.md
+++ b/docs/commands/rhoas_completion_fish.md
@@ -1,10 +1,10 @@
 ## rhoas completion fish
 
-Generate command completion script for fish shell
+Generate command completion script for Fish shell
 
 ### Synopsis
 
-Install rhoas command completion for the fish shell.
+Install rhoas command completion for the Fish shell.
 
 1. Install fish completions:
 
@@ -33,5 +33,5 @@ rhoas completion fish
 
 ### SEE ALSO
 
-* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, or fish)
+* [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, fish or powershell)
 

--- a/docs/commands/rhoas_completion_powershell.md
+++ b/docs/commands/rhoas_completion_powershell.md
@@ -1,30 +1,28 @@
-## rhoas completion zsh
+## rhoas completion powershell
 
-Generate command completion script for Zsh shell
+Generate command completion script for Powershell shell
 
 ### Synopsis
 
-Install rhoas command completion  for the Zsh shell.
+Install rhoas command completion for the Powershell shell.
 
-1. Install the completion script:
+1. Create the script file:
 
-   $ rhoas completion zsh > "${fpath[1]}/_rhoas"
+   PS> rhoas completion powershell | Out-File -FilePath rhoas.ps1
 
-2. Unless already installed, enable shell completions for Zsh:
-
-   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+2. Source this file from your PowerShell profile.
 
 3. Restart your shell for the changes to take effect.
 
 
 ```
-rhoas completion zsh
+rhoas completion powershell
 ```
 
 ### Examples
 
 ```
-rhoas completion zsh
+rhoas completion powershell
 
 ```
 

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,11 +1,13 @@
 package completion
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/completion/bash"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/completion/fish"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/completion/powershell"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/completion/zsh"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
-	"github.com/spf13/cobra"
 )
 
 func NewCompletionCommand(f *factory.Factory) *cobra.Command {
@@ -21,6 +23,7 @@ func NewCompletionCommand(f *factory.Factory) *cobra.Command {
 		bash.NewCommand(f),
 		zsh.NewCommand(f),
 		fish.NewCommand(f),
+		powershell.NewCommand(f),
 	)
 
 	return cmd

--- a/pkg/cmd/completion/powershell/powershell.go
+++ b/pkg/cmd/completion/powershell/powershell.go
@@ -1,0 +1,23 @@
+package powershell
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+)
+
+func NewCommand(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "powershell",
+		Short:                 f.Localizer.MustLocalize("completion.powershell.cmd.shortDescription"),
+		Long:                  f.Localizer.MustLocalize("completion.powershell.cmd.longDescription"),
+		Example:               f.Localizer.MustLocalize("completion.powershell.cmd.example"),
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Parent().Parent().GenPowerShellCompletion(f.IOStreams.Out)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/core/localize/locales/en/cmd/completion.en.toml
+++ b/pkg/core/localize/locales/en/cmd/completion.en.toml
@@ -1,11 +1,11 @@
 [completion.cmd.shortDescription]
 description = "Short description for command"
-one = "Install command completion for your shell (bash, zsh, or fish)"
+one = "Install command completion for your shell (bash, zsh, fish or powershell)"
 
 [completion.cmd.longDescription]
 description = "Long description for command"
 one = '''
-Install rhoas command completion for your shell (bash, zsh, or fish).
+Install rhoas command completion for your shell (bash, zsh, fish, powershell).
 
 To find what shell you are currently running:
 
@@ -13,7 +13,7 @@ To find what shell you are currently running:
 
 For instructions on installing command completions for your shell:
 
-  $ rhoas completion [bash|zsh|fish] -h
+  $ rhoas completion [bash|zsh|fish|powershell] -h
 
 When you have installed the command completion script, restart your shell for the changes to take effect.
 '''
@@ -28,10 +28,13 @@ rhoas completion fish
 
 ## Generate command completion script for Zsh shell
 rhoas completion zsh
+
+## Generate command completion script for Powershell shell
+rhoas completion powershell
 '''
 
 [completion.cmd.error.subcommandRequired]
-one = 'a subcommand of either "bash", "zsh", "fish" is required'
+one = 'a subcommand of either "bash", "zsh", "fish", "powershell" is required'
 
 [completion.bash.cmd.shortDescription]
 description = "Short description for command"
@@ -98,11 +101,11 @@ rhoas completion zsh
 
 [completion.fish.cmd.shortDescription]
 description = "Short description for command"
-one = "Generate command completion script for fish shell"
+one = "Generate command completion script for Fish shell"
 
 [completion.fish.cmd.longDescription]
 one = '''
-Install rhoas command completion for the fish shell.
+Install rhoas command completion for the Fish shell.
 
 1. Install fish completions:
 
@@ -114,4 +117,26 @@ Install rhoas command completion for the fish shell.
 [completion.fish.cmd.example]
 one = '''
 rhoas completion fish
+'''
+
+[completion.powershell.cmd.shortDescription]
+description = "Short description for command"
+one = "Generate command completion script for Powershell shell"
+
+[completion.powershell.cmd.longDescription]
+one = '''
+Install rhoas command completion for the Powershell shell.
+
+1. Create the script file:
+
+   PS> rhoas completion powershell | Out-File -FilePath rhoas.ps1
+
+2. Source this file from your PowerShell profile.
+
+3. Restart your shell for the changes to take effect.
+'''
+
+[completion.powershell.cmd.example]
+one = '''
+rhoas completion powershell
 '''


### PR DESCRIPTION
The rhoas completion command instructions to enable command completions Powershell as well.

Closes #1595 


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
