### PR TITLE
fix: nil keys are now empty strings when consumed

### DIFF
--- a/pkg/cmd/kafka/topic/consume/consume.go
+++ b/pkg/cmd/kafka/topic/consume/consume.go
@@ -251,6 +251,16 @@ func consume(opts *options, api *kafkainstanceclient.APIClient, kafkaInstance *k
 		return nil, err
 	}
 
+	// fill in fields not set in message
+	for i := 0; i < len(list.Items); i++ {
+		record := &list.Items[i]
+
+		if record.Key == nil {
+			defaultKey := ""
+			record.Key = &defaultKey
+		}
+	}
+
 	return &list, nil
 }
 
@@ -277,6 +287,7 @@ func outputRecords(opts *options, records *kafkainstanceclient.RecordList) {
 			}
 		} else {
 			_ = dump.Formatted(opts.f.IOStreams.Out, format, row)
+			opts.f.Logger.Info("")
 		}
 	}
 }


### PR DESCRIPTION
Fixes bug where the cli was trying to get the value of a key when the message did not have one

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
