### PR TITLE
docs: included info about org admin for connector cluster create

### DIFF
--- a/docs/commands/rhoas_connector_cluster_create.md
+++ b/docs/commands/rhoas_connector_cluster_create.md
@@ -4,7 +4,7 @@ Create a Connectors cluster
 
 ### Synopsis
 
-Create a Connectors cluster and specify its name
+Create a Connectors cluster and specify its name. You must be an org adminastrator for this to be successful
 
 ```
 rhoas connector cluster create [flags]

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -32,7 +32,7 @@ rhoas connector cluster list
 one = 'Create a Connectors cluster'
 
 [connector.cluster.create.cmd.longDescription]
-one = 'Create a Connectors cluster and specify its name'
+one = 'Create a Connectors cluster and specify its name. You must be an org adminastrator for this to be successful'
 
 [connector.cluster.create.cmd.example]
 one = '''


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->
You need to be an org administrator to create a cluster for connectors. This was not documented before.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
