### PR TITLE
fix: do not reuse connection for the commands

### DIFF
--- a/pkg/shared/factory/defaultfactory/default.go
+++ b/pkg/shared/factory/defaultfactory/default.go
@@ -37,10 +37,6 @@ func New(localizer localize.Localizer) *factory.Factory {
 	ctx := context.Background()
 
 	connectionFunc := func(connectionCfg *connection.Config) (connection.Connection, error) {
-		if conn != nil {
-			return conn, nil
-		}
-
 		cfg, err := cfgFile.Load()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR disables connection reuse. 
In previous change I have noticed that we always refresh mas-sso tokens even when we do control plane commands only:

https://github.com/redhat-developer/app-services-cli/pull/1599/files

That would obviously cause problems in long term and was removed. As results we noticed 401 with tokens failing. Reason was that we had cache for connection function that was undocumented. I think we should disable this cache. This will create connection object couple times for 2-3 commands but overall it doesn't cause any extra problems and enables us to mix mas-sso commands

Note that mas-sso goes away so this is only temporary change anyway.

## Verification

```
// wait 5 min after any command
rhoas kafka topic list
```