### PR TITLE
chore: skip sso refresh

### DIFF
--- a/pkg/shared/connection/kcconnection/builder.go
+++ b/pkg/shared/connection/kcconnection/builder.go
@@ -160,10 +160,6 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 		return nil, &AuthError{notLoggedInError()}
 	}
 
-	if b.connectionConfig.RequireMASAuth && b.masAccessToken == "" && b.masRefreshToken == "" {
-		return nil, &MasAuthError{notLoggedInMASError()}
-	}
-
 	if b.clientID == "" {
 		return nil, AuthErrorf("missing client ID")
 	}

--- a/pkg/shared/connection/kcconnection/keycloak_connection.go
+++ b/pkg/shared/connection/kcconnection/keycloak_connection.go
@@ -75,7 +75,7 @@ func (c *Connection) RefreshTokens(ctx context.Context) (err error) {
 		}
 	}
 
-	if c.connectionConfig.RequireMASAuth {
+	if c.connectionConfig.RequireMASAuth && c.MASToken.RefreshToken != "" {
 		c.logger.Debug("Refreshing MAS SSO tokens")
 		// nolint:govet
 		refreshedMasTk, err := c.masKeycloakClient.RefreshToken(ctx, c.MASToken.RefreshToken, c.clientID, "", c.masRealm)


### PR DESCRIPTION
We have been doing sso refresh as safety net to have fresh token for users in case we revert back to sso. This have started causing issues as some claims have been migrated. 

This PR stops refreshes