### PR TITLE
feat(kafka create): add billing model logic

### DIFF
--- a/docs/commands/rhoas_kafka_create.md
+++ b/docs/commands/rhoas_kafka_create.md
@@ -30,6 +30,7 @@ $ rhoas kafka create -o yaml
 ### Options
 
 ```
+      --billing-model string            Billing model to be used
       --dry-run                         Validate all user provided arguments without creating the Kafka instance
       --marketplace string              Name of the marketplace where the instance is purchased on
       --marketplace-account-id string   Cloud Account ID for the marketplace

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/redhat-developer/app-services-sdk-go/accountmgmt v0.2.0
 	github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.7.0
 	github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0
-	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.0
+	github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.1
 	github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1
 	github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1
 	github.com/redhat-developer/service-binding-operator v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.7.0 h1:GcbNg/Ad
 github.com/redhat-developer/app-services-sdk-go/connectormgmt v0.7.0/go.mod h1:0WB4LlMmesjBlGKvnMXQ7twPxeSr27f5a+w4QnMoSdQ=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0 h1:ExEHQaihnPNxN2nKXB0q5nrmSv4p8b3Idzt7TChxv+Q=
 github.com/redhat-developer/app-services-sdk-go/kafkainstance v0.6.0/go.mod h1:hMpejngP3BFnifCDH1gKRG9cU9Q4lr0WiQaW7A1LYo4=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.0 h1:63UhOYB8TozKdnkkws2pXc0D1lEB+K3qX63/OxkjDas=
-github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.0/go.mod h1:m+m7d6xkC9WbSxemslyhjv0jVhquWLysRfdh+RQ5hH0=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.1 h1:Gcyn2kLlslsVT6T8qoiCJpJFPrnD2i2KIFeKQJrXkTY=
+github.com/redhat-developer/app-services-sdk-go/kafkamgmt v0.12.1/go.mod h1:RoPo3tyHjv8apStFNVjChwWYdlWhg6hMzi1IrH3yQX8=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1 h1:xRq5XJzRDs/Z7e/9SDt6zbNRIyesC4LTqN9ajHKwjHo=
 github.com/redhat-developer/app-services-sdk-go/registryinstance v0.3.1/go.mod h1:Z/gr/snlpsqYg4vftmcx97vCR3qMQJhALGelDHx4pMA=
 github.com/redhat-developer/app-services-sdk-go/registrymgmt v0.6.1 h1:3sUmQ3nAawsYWg7ZCO2Q8HF2J7MW6YA38h/YFL3ao6o=
@@ -933,6 +933,7 @@ golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 h1:+jnHzr9VPj32ykQVai5DNahi9+NSp7yYuCsl5eAQtL0=
 golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -3,6 +3,7 @@ package create
 import (
 	"strings"
 
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/accountmgmtutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
@@ -23,6 +24,8 @@ type ValidatorInput struct {
 	constants *remote.DynamicServiceConstants
 	conn      connection.Connection
 }
+
+var validBillingModels []string = []string{accountmgmtutil.QuotaMarketplaceType, accountmgmtutil.QuotaStandardType}
 
 func (input *ValidatorInput) ValidateProviderAndRegion() error {
 	f := input.f
@@ -118,4 +121,20 @@ func (input *ValidatorInput) ValidateSize() error {
 	}
 
 	return nil
+}
+
+// ValidateBillingModel validates if user provided a supported billing model
+func ValidateBillingModel(billingModel string) error {
+
+	if billingModel == "" {
+		return nil
+	}
+
+	isValid := flagutil.IsValidInput(billingModel, validBillingModels...)
+
+	if isValid {
+		return nil
+	}
+
+	return flagutil.InvalidValueError("billing-model", billingModel, validBillingModels...)
 }

--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -1,10 +1,7 @@
 package create
 
 import (
-	"github.com/redhat-developer/app-services-cli/pkg/shared/accountmgmtutil"
-	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
-	"github.com/redhat-developer/app-services-cli/pkg/shared/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -25,49 +22,4 @@ func GetCloudProviderRegionCompletionValues(f *factory.Factory, providerID strin
 	validRegions, _ = GetEnabledCloudRegionIDs(f, providerID, nil)
 
 	return validRegions, cobra.ShellCompDirectiveNoSpace
-}
-
-// GetKafkaSizeCompletionValues returns a list of valid kafka sizes for the specified region and ams instance types
-func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionId string) (validRegions []string, directive cobra.ShellCompDirective) {
-	directive = cobra.ShellCompDirectiveNoSpace
-
-	// We need both values to provide a valid list of sizes
-	if providerID == "" || regionId == "" {
-		return nil, directive
-	}
-
-	err, constants := remote.GetRemoteServiceConstants(f.Context, f.Logger)
-	if err != nil {
-		return nil, directive
-	}
-
-	conn, err := f.Connection(connection.DefaultConfigSkipMasAuth)
-	if err != nil {
-		return nil, directive
-	}
-
-	userInstanceType, _ := accountmgmtutil.GetUserSupportedInstanceType(f.Context, &constants.Kafka.Ams, conn)
-
-	// Not including quota in this request as it takes very long time to list quota for all regions in suggestion mode
-	validRegions, _ = FetchValidKafkaSizesLabels(f, providerID, regionId, *userInstanceType)
-
-	return validRegions, cobra.ShellCompDirectiveNoSpace
-}
-
-// GetMarketplaceAcctIdCompletionValues returns a list of valid marketplace account IDs for the organization
-func GetMarketplaceAcctIdCompletionValues(f *factory.Factory) (validMarketplaceAcctIDs []string, directive cobra.ShellCompDirective) {
-	directive = cobra.ShellCompDirectiveNoSpace
-
-	validMarketplaceAcctIDs, _ = accountmgmtutil.GetValidMarketplaceAcctIDs(f.Context, f.Connection, "")
-
-	return validMarketplaceAcctIDs, directive
-}
-
-// GetMarketplaceCompletionValues returns a list of valid marketplaces for the organization
-func GetMarketplaceCompletionValues(f *factory.Factory) (validMarketplaces []string, directive cobra.ShellCompDirective) {
-	directive = cobra.ShellCompDirectiveNoSpace
-
-	validMarketplaces, _ = accountmgmtutil.GetValidMarketplaces(f.Context, f.Connection)
-
-	return validMarketplaces, directive
 }

--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -40,7 +40,7 @@ func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionI
 		return nil, directive
 	}
 
-	orgQuota, err := accountmgmtutil.GetUserSupportedInstanceType(f, &constants.Kafka.Ams)
+	orgQuota, err := accountmgmtutil.GetOrgQuotas(f, &constants.Kafka.Ams)
 	if err != nil {
 		return nil, directive
 	}

--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -52,3 +52,45 @@ func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionI
 
 	return validSizes, cobra.ShellCompDirectiveNoSpace
 }
+
+func GetMarketplaceCompletionValues(f *factory.Factory) (validSizes []string, directive cobra.ShellCompDirective) {
+
+	directive = cobra.ShellCompDirectiveNoSpace
+
+	err, constants := remote.GetRemoteServiceConstants(f.Context, f.Logger)
+	if err != nil {
+		return nil, directive
+	}
+
+	orgQuota, err := accountmgmtutil.GetOrgQuotas(f, &constants.Kafka.Ams)
+	if err != nil {
+		return nil, directive
+	}
+
+	validMarketPlaces := FetchValidMarketplaces(orgQuota.MarketplaceQuotas)
+
+	return validMarketPlaces, cobra.ShellCompDirectiveNoSpace
+}
+
+func GetMarketplaceAccountCompletionValues(f *factory.Factory, marketplace string) (validMarketplaceAcctIDs []string, directive cobra.ShellCompDirective) {
+
+	directive = cobra.ShellCompDirectiveNoSpace
+
+	if marketplace == "" {
+		return validMarketplaceAcctIDs, directive
+	}
+
+	err, constants := remote.GetRemoteServiceConstants(f.Context, f.Logger)
+	if err != nil {
+		return nil, directive
+	}
+
+	orgQuota, err := accountmgmtutil.GetOrgQuotas(f, &constants.Kafka.Ams)
+	if err != nil {
+		return nil, directive
+	}
+
+	validMarketplaceAcctIDs = FetchValidMarketplaceAccounts(orgQuota.MarketplaceQuotas, marketplace)
+
+	return validMarketplaceAcctIDs, cobra.ShellCompDirectiveNoSpace
+}

--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -94,3 +94,22 @@ func GetMarketplaceAccountCompletionValues(f *factory.Factory, marketplace strin
 
 	return validMarketplaceAcctIDs, cobra.ShellCompDirectiveNoSpace
 }
+
+func GetBillingModelCompletionValues(f *factory.Factory) (availableBillingModels []string, directive cobra.ShellCompDirective) {
+
+	directive = cobra.ShellCompDirectiveNoSpace
+
+	err, constants := remote.GetRemoteServiceConstants(f.Context, f.Logger)
+	if err != nil {
+		return nil, directive
+	}
+
+	orgQuota, err := accountmgmtutil.GetOrgQuotas(f, &constants.Kafka.Ams)
+	if err != nil {
+		return nil, directive
+	}
+
+	availableBillingModels = FetchSupportedBillingModels(orgQuota)
+
+	return availableBillingModels, directive
+}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -111,7 +111,8 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 			if !f.IOStreams.CanPrompt() && opts.name == "" {
 				return f.Localizer.MustLocalizeError("kafka.create.argument.name.error.requiredWhenNonInteractive")
 			} else if opts.name == "" {
-				if opts.provider != "" || opts.region != "" {
+				if opts.provider != "" || opts.region != "" || opts.marketplaceAcctId != "" ||
+					opts.marketplace != "" || opts.size != "" || opts.billingModel != "" {
 					return f.Localizer.MustLocalizeError("kafka.create.argument.name.error.requiredWhenNonInteractive")
 				}
 				opts.interactive = true

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -104,7 +103,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 			}
 
 			if opts.billingModel == accountmgmtutil.QuotaStandardType && (opts.marketplaceAcctId != "" || opts.marketplace != "") {
-				return errors.New("marketplace cannot be standard if marketplace-account-id or billing-model are set")
+				return f.Localizer.MustLocalizeError("kafka.create.error.standard.invalidFlags")
 			}
 
 			if !f.IOStreams.CanPrompt() && opts.name == "" {

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -99,7 +99,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return f.Localizer.MustLocalizeError("kafka.create.error.bypassChecks.marketplace")
 			}
 
-			if opts.billingModel == "standard" && (opts.marketplaceAcctId != "" || opts.marketplace != "") {
+			if opts.billingModel == accountmgmtutil.QuotaStandardType && (opts.marketplaceAcctId != "" || opts.marketplace != "") {
 				return errors.New("marketplace cannot be standard if marketplace-account-id or billing-model are set")
 			}
 
@@ -225,7 +225,7 @@ func runCreate(opts *options) error {
 			CloudProvider: &opts.provider,
 		}
 
-		if userInstanceType.BillingModel == "marketplace" {
+		if userInstanceType.BillingModel == accountmgmtutil.QuotaMarketplaceType && userInstanceType.CloudAccounts != nil {
 
 			payload.Marketplace = kafkamgmtclient.NullableString{}
 			payload.Marketplace.Set((*userInstanceType.CloudAccounts)[0].CloudProviderId)
@@ -264,7 +264,7 @@ func runCreate(opts *options) error {
 
 	}
 
-	if userInstanceType.BillingModel == "standard" || userInstanceType.BillingModel == "marketplace" {
+	if userInstanceType.BillingModel == accountmgmtutil.QuotaStandardType || userInstanceType.BillingModel == accountmgmtutil.QuotaMarketplaceType {
 		payload.BillingModel = kafkamgmtclient.NullableString{}
 		payload.BillingModel.Set(&userInstanceType.BillingModel)
 	}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -148,6 +148,14 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		return GetKafkaSizeCompletionValues(f, opts.provider, opts.region)
 	})
 
+	_ = cmd.RegisterFlagCompletionFunc(FlagMarketPlace, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return GetMarketplaceCompletionValues(f)
+	})
+
+	_ = cmd.RegisterFlagCompletionFunc(FlagMarketPlaceAcctID, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return GetMarketplaceAccountCompletionValues(f, opts.marketplace)
+	})
+
 	return cmd
 }
 
@@ -454,7 +462,7 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		answers.BillingModel = availableBillingModels[0]
 	} else {
 		billingModelPrompt := &survey.Select{
-			Message: "billing model:",
+			Message: f.Localizer.MustLocalize("kafka.create.input.billingModel.message"),
 			Options: availableBillingModels,
 		}
 		err = survey.AskOne(billingModelPrompt, &answers.BillingModel)
@@ -469,7 +477,7 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 			answers.Marketplace = validMarketPlaces[0]
 		} else {
 			marketplacePrompt := &survey.Select{
-				Message: "marketplace:",
+				Message: f.Localizer.MustLocalize("kafka.create.input.marketplace.message"),
 				Options: validMarketPlaces,
 			}
 			err = survey.AskOne(marketplacePrompt, &answers.Marketplace)
@@ -486,7 +494,7 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 				answers.MarketplaceAcctID = validMarketplaceAcctIDs[0]
 			} else {
 				marketplaceAccountPrompt := &survey.Select{
-					Message: "marketplace account ID:",
+					Message: f.Localizer.MustLocalize("kafka.create.input.marketplaceAccountID.message"),
 					Options: validMarketplaceAcctIDs,
 				}
 				err = survey.AskOne(marketplaceAccountPrompt, &answers.MarketplaceAcctID)

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -498,9 +498,9 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 	}
 
 	marketplaceInfo := accountmgmtutil.MarketplaceInfo{
-		BillingModel:   opts.billingModel,
-		Provider:       opts.marketplace,
-		CloudAccountID: opts.marketplaceAcctId,
+		BillingModel:   answers.BillingModel,
+		Provider:       answers.Marketplace,
+		CloudAccountID: answers.MarketplaceAcctID,
 	}
 
 	userQuota, err := accountmgmtutil.SelectQuotaForUser(f, orgQuota, marketplaceInfo)

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -42,6 +42,8 @@ const (
 	FlagMarketPlaceAcctID = "marketplace-account-id"
 	// FlagMarketPlace is a flag representing marketplace where the instance is purchased on
 	FlagMarketPlace = "marketplace"
+	// FlagMarketPlace is a flag representing billing model of the instance
+	FlagBillingModel = "billing-model"
 )
 
 type options struct {
@@ -136,7 +138,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	flags.BoolVar(&opts.autoUse, "use", true, f.Localizer.MustLocalize("kafka.create.flag.autoUse.description"))
 	flags.BoolVarP(&opts.wait, "wait", "w", false, f.Localizer.MustLocalize("kafka.create.flag.wait.description"))
 	flags.BoolVarP(&opts.dryRun, "dry-run", "", false, f.Localizer.MustLocalize("kafka.create.flag.dryrun.description"))
-	flags.StringVar(&opts.billingModel, "billing-model", "", f.Localizer.MustLocalize("kafka.create.flag.billingModel.description"))
+	flags.StringVar(&opts.billingModel, FlagBillingModel, "", f.Localizer.MustLocalize("kafka.create.flag.billingModel.description"))
 	flags.AddBypassTermsCheck(&opts.bypassChecks)
 
 	_ = cmd.RegisterFlagCompletionFunc(FlagProvider, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -157,6 +159,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc(FlagMarketPlaceAcctID, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return GetMarketplaceAccountCompletionValues(f, opts.marketplace)
+	})
+
+	_ = cmd.RegisterFlagCompletionFunc(FlagBillingModel, func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return GetBillingModelCompletionValues(f)
 	})
 
 	return cmd

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -99,6 +99,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return f.Localizer.MustLocalizeError("kafka.create.error.bypassChecks.marketplace")
 			}
 
+			if (opts.marketplace != "") != (opts.marketplaceAcctId != "") {
+				return f.Localizer.MustLocalizeError("kafka.create.error.insufficientMarketplaceInfo")
+			}
+
 			if opts.billingModel == accountmgmtutil.QuotaStandardType && (opts.marketplaceAcctId != "" || opts.marketplace != "") {
 				return errors.New("marketplace cannot be standard if marketplace-account-id or billing-model are set")
 			}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -461,16 +461,18 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 
 	availableBillingModels := FetchSupportedBillingModels(orgQuota)
 
-	if len(availableBillingModels) == 1 {
-		answers.BillingModel = availableBillingModels[0]
-	} else {
-		billingModelPrompt := &survey.Select{
-			Message: f.Localizer.MustLocalize("kafka.create.input.billingModel.message"),
-			Options: availableBillingModels,
-		}
-		err = survey.AskOne(billingModelPrompt, &answers.BillingModel)
-		if err != nil {
-			return nil, err
+	if len(availableBillingModels) > 0 {
+		if len(availableBillingModels) == 1 {
+			answers.BillingModel = availableBillingModels[0]
+		} else {
+			billingModelPrompt := &survey.Select{
+				Message: f.Localizer.MustLocalize("kafka.create.input.billingModel.message"),
+				Options: availableBillingModels,
+			}
+			err = survey.AskOne(billingModelPrompt, &answers.BillingModel)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -304,7 +305,9 @@ func runCreate(opts *options) error {
 
 	}
 
-	f.Logger.Debug("Creating kafka instance", payload.Name, payload.GetPlan())
+	f.Logger.Debug("Creating kafka instance", payload.Name)
+	data, _ := json.MarshalIndent(payload, "", "  ")
+	f.Logger.Debug(string(data))
 
 	if opts.dryRun {
 		f.Logger.Info(f.Localizer.MustLocalize("kafka.create.log.info.dryRun.success"))
@@ -565,11 +568,13 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 			return nil, err
 		}
 	}
-
+	billingNullable := kafkamgmtclient.NullableString{}
+	billingNullable.Set(&answers.BillingModel)
 	payload := &kafkamgmtclient.KafkaRequestPayload{
 		Name:                  answers.Name,
 		Region:                &answers.Region,
 		CloudProvider:         &answers.CloudProvider,
+		BillingModel:          billingNullable,
 		BillingCloudAccountId: accountIDNullable,
 		Marketplace:           marketplaceProviderNullable,
 	}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -245,7 +245,9 @@ func runCreate(opts *options) error {
 			return err
 		}
 
-		f.Logger.Debug(fmt.Sprintf("Selected quota object: %#v", userQuota))
+		userQuotaJSON, _ := json.MarshalIndent(userQuota, "", "  ")
+		f.Logger.Debug("Selected Quota object:")
+		f.Logger.Debug(string(userQuotaJSON))
 
 		if opts.provider == "" {
 			opts.provider = defaultProvider
@@ -429,9 +431,6 @@ type promptAnswers struct {
 func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants) (*kafkamgmtclient.KafkaRequestPayload, error) {
 	f := opts.f
 
-	accountIDNullable := kafkamgmtclient.NullableString{}
-	marketplaceProviderNullable := kafkamgmtclient.NullableString{}
-
 	validator := &kafkacmdutil.Validator{
 		Localizer:  f.Localizer,
 		Connection: f.Connection,
@@ -531,7 +530,9 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		return nil, err
 	}
 
-	f.Logger.Debug(fmt.Sprintf("Selected quota object: %#v", userQuota))
+	userQuotaJSON, _ := json.MarshalIndent(userQuota, "", "  ")
+	f.Logger.Debug("Selected Quota object:")
+	f.Logger.Debug(string(userQuotaJSON))
 
 	regionIDs, err := GetEnabledCloudRegionIDs(opts.f, answers.CloudProvider, userQuota)
 	if err != nil {
@@ -568,8 +569,23 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 			return nil, err
 		}
 	}
+
+	accountIDNullable := kafkamgmtclient.NullableString{}
+	marketplaceProviderNullable := kafkamgmtclient.NullableString{}
 	billingNullable := kafkamgmtclient.NullableString{}
-	billingNullable.Set(&answers.BillingModel)
+
+	if answers.BillingModel != "" {
+		billingNullable.Set(&answers.BillingModel)
+	}
+
+	if answers.Marketplace != "" {
+		marketplaceProviderNullable.Set(&answers.Marketplace)
+	}
+
+	if answers.MarketplaceAcctID != "" {
+		accountIDNullable.Set(&answers.MarketplaceAcctID)
+	}
+
 	payload := &kafkamgmtclient.KafkaRequestPayload{
 		Name:                  answers.Name,
 		Region:                &answers.Region,

--- a/pkg/cmd/kafka/create/data.go
+++ b/pkg/cmd/kafka/create/data.go
@@ -28,6 +28,8 @@ func mapAmsTypeToBackendType(amsType *accountmgmtutil.QuotaSpec) CloudProviderId
 	switch amsType.Name {
 	case accountmgmtutil.QuotaStandardType:
 		return StandardType
+	case accountmgmtutil.QuotaMarketplaceType:
+		return StandardType
 	case accountmgmtutil.QuotaTrialType:
 		return DeveloperType
 	default:

--- a/pkg/cmd/kafka/create/data.go
+++ b/pkg/cmd/kafka/create/data.go
@@ -94,9 +94,9 @@ func FetchValidMarketplaceAccounts(amsTypes []accountmgmtutil.QuotaSpec, marketp
 				if marketplace != "" {
 					if cloudAccount.GetCloudProviderId() == marketplace {
 						validAccounts = append(validAccounts, cloudAccount.GetCloudAccountId())
-					} else {
-						validAccounts = append(validAccounts, cloudAccount.GetCloudAccountId())
 					}
+				} else {
+					validAccounts = append(validAccounts, cloudAccount.GetCloudAccountId())
 				}
 			}
 		}

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -366,6 +366,9 @@ one = 'name is required. Run "rhoas kafka create --name my-kafka"'
 [kafka.create.error.bypassChecks.marketplace]
 one = '"--billing-model", "--marketplace", "--marketplace-account-id" flags are not supported with "--bypass-checks" flag'
 
+[kafka.create.error.insufficientMarketplaceInfo]
+one = '"--marketplace" and "--marketplace-account-id" flags should be supplied together'
+
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -369,6 +369,9 @@ one = '"--billing-model", "--marketplace", "--marketplace-account-id" flags are 
 [kafka.create.error.insufficientMarketplaceInfo]
 one = '"--marketplace" and "--marketplace-account-id" flags should be supplied together'
 
+[kafka.create.error.standard.invalidFlags]
+one = 'billing model cannot be standard if "--marketplace-account-id" or "--marketplace" are set'
+
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -435,7 +435,7 @@ one = 'multiple quota types found, please specify "--billing-model"'
 one = 'multiple marketplace quota types found, please specify "--marketplace" and "--marketplace-account-id"'
 
 [kafka.create.quota.error.cloudAccountNotFound]
-one = 'no marketplace quota found with the specified marketplace provider or account id'
+one = 'no marketplace quota found with the specified marketplace provider and account id'
 
 [kafka.create.quota.error.multipleCloudAccounts]
 one = 'multiple cloud accounts found, please specify "--marketplace" and "--marketplace-account-id"'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -355,13 +355,10 @@ one = "Geographical region where the Kafka instance will be deployed"
 one = 'name is required. Run "rhoas kafka create --name my-kafka"'
 
 [kafka.create.error.bypassChecks.marketplace]
-one = '"--marketplace" and "--marketplace-account-id" flags are not supported with "--bypass-checks" flag'
+one = '"--billing-model", "--marketplace", "--marketplace-account-id" flags are not supported with "--bypass-checks" flag'
 
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'
-
-[kafka.create.error.userInstanceType.notFound]
-one = 'Cannot fetch user allowed instance type'
 
 [kafka.create.error.noInteractiveMode]
 one = 'Interactive mode is not supported when using --bypass-checks flag'
@@ -406,6 +403,27 @@ provided instance size is not valid. Valid sizes: {{.ValidSizes}}
 one = '''
 provided billing account id and provider are invalid {{.Billing}}
 '''
+
+[kafka.create.quota.error.onlyTrialAvailable]
+one = "only trial quotas are available, don't specify billing model details"
+
+[kafka.create.quota.error.noMarketplace]
+one = "no marketplace quotas are available"
+
+[kafka.create.quota.error.noStandard]
+one = "no standard quotas are available"
+
+[kafka.create.quota.error.noBillingModel]
+one = 'multiple quota types found, please specify "--billing-model"'
+
+[kafka.create.quota.error.multipleMarketplaceQuotas]
+one = 'multiple marketplace quota types found, please specify "--marketplace" and "--marketplace-account-id"'
+
+[kafka.create.quota.error.cloudAccountNotFound]
+one = 'no marketplace quota found with the specified marketplace provider or account id'
+
+[kafka.create.quota.error.multipleCloudAccounts]
+one = 'multiple cloud accounts found, please specify "--marketplace" and "--marketplace-account-id"'
 
 [kafka.delete.cmd.shortDescription]
 description = "Short description for command"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -328,6 +328,15 @@ one = 'Unique name of the Kafka instance'
 description = 'Input title for Cloud Provider'
 one = 'Cloud Provider:'
 
+[kafka.create.input.billingModel.message]
+one = 'Billing Model:'
+
+[kafka.create.input.marketplace.message]
+one = 'Marketplace:'
+
+[kafka.create.input.marketplaceAccountID.message]
+one = 'Marketplace Account ID:'
+
 [kafka.create.input.cloudRegion.message]
 description = 'Input title for Cloud Region'
 one = "Cloud Region:"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -289,6 +289,9 @@ one = 'Validate all user provided arguments without creating the Kafka instance'
 [kafka.create.flag.marketplaceId.description]
 one = 'Cloud Account ID for the marketplace'
 
+[kafka.create.flag.billingModel.description]
+one = 'Billing model to be used'
+
 [kafka.create.flag.marketplaceType.description]
 one = 'Name of the marketplace where the instance is purchased on'
 

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -169,7 +169,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 
 func getMarketplaceQuota(f *factory.Factory, marketplaceQuotas []QuotaSpec, marketplace MarketplaceInfo) (*QuotaSpec, error) {
 	if len(marketplaceQuotas) == 1 {
-		if marketplace.Provider != "" || marketplace.CloudAccountID != "" {
+		if marketplace.Provider != "" && marketplace.CloudAccountID != "" {
 			marketplaceQuota, err := pickMarketplaceQuota(f, marketplaceQuotas, marketplace)
 			if err != nil {
 				return nil, err
@@ -196,14 +196,8 @@ func pickMarketplaceQuota(f *factory.Factory, marketplaceQuotas []QuotaSpec, mar
 	for _, quota := range marketplaceQuotas {
 		cloudAccounts := *quota.CloudAccounts
 		for _, cloudAccount := range cloudAccounts {
-			if marketplace.Provider != "" && marketplace.CloudAccountID != "" {
-				if *cloudAccount.CloudProviderId == marketplace.Provider && *cloudAccount.CloudAccountId == marketplace.CloudAccountID {
-					matchedQuotas = append(matchedQuotas, quota)
-				}
-			} else if marketplace.Provider != "" || marketplace.CloudAccountID != "" {
-				if *cloudAccount.CloudProviderId == marketplace.Provider || *cloudAccount.CloudAccountId == marketplace.CloudAccountID {
-					matchedQuotas = append(matchedQuotas, quota)
-				}
+			if *cloudAccount.CloudProviderId == marketplace.Provider && *cloudAccount.CloudAccountId == marketplace.CloudAccountID {
+				matchedQuotas = append(matchedQuotas, quota)
 			}
 		}
 	}
@@ -228,10 +222,8 @@ func pickCloudAccount(f *factory.Factory, cloudAccounts *[]amsclient.CloudAccoun
 	var matchedAccounts []amsclient.CloudAccount
 
 	for _, cloudAccount := range *cloudAccounts {
-		if market.Provider != "" || market.CloudAccountID != "" {
-			if *cloudAccount.CloudProviderId == market.Provider || *cloudAccount.CloudAccountId == market.CloudAccountID {
-				matchedAccounts = append(matchedAccounts, cloudAccount)
-			}
+		if *cloudAccount.CloudProviderId == market.Provider || *cloudAccount.CloudAccountId == market.CloudAccountID {
+			matchedAccounts = append(matchedAccounts, cloudAccount)
 		}
 	}
 

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -71,7 +71,7 @@ func fetchOrgQuotaCost(ctx context.Context, conn connection.Connection) (*amscli
 
 }
 
-func GetUserSupportedInstanceType(f *factory.Factory, spec *remote.AmsConfig, marketplace MarketplaceInfo) (*QuotaSpec, error) {
+func GetUserSupportedInstanceType(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error) {
 
 	conn, err := f.Connection(connection.DefaultConfigSkipMasAuth)
 	if err != nil {
@@ -103,20 +103,18 @@ func GetUserSupportedInstanceType(f *factory.Factory, spec *remote.AmsConfig, ma
 		}
 	}
 
-	fmt.Println("trial quotas - ", len(trialQuotas))
-	fmt.Println("standard quotas - ", len(standardQuotas))
-	fmt.Println("marketplace quotas - ", len(marketplaceQuotas))
+	fmt.Println("inside get user supported instance type")
 
 	availableOrgQuotas := &OrgQuotas{standardQuotas, marketplaceQuotas, trialQuotas}
 
-	return SelectQuotaForUser(f, availableOrgQuotas, marketplace)
+	return availableOrgQuotas, nil
 }
 
 func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo MarketplaceInfo) (*QuotaSpec, error) {
+
+	fmt.Println("inside select quota for user")
 	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 {
-		if len(orgQuota.TrialQuotas) == 0 {
-			return nil, errors.New("no quotas available")
-		} else if marketplaceInfo.BillingModel != "" {
+		if marketplaceInfo.BillingModel != "" {
 			return nil, errors.New("only trial quotas are available")
 		} else {
 			// select a trial quota as all others are missing
@@ -125,7 +123,6 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 	}
 
 	if len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.StandardQuotas) > 0 {
-
 		if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 			return nil, errors.New("no marketplace quotas available")
 		}

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -110,7 +110,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo MarketplaceInfo) (*QuotaSpec, error) {
 
 	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 {
-		if marketplaceInfo.BillingModel != "" {
+		if marketplaceInfo.BillingModel != "" || marketplaceInfo.Provider != "" {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.onlyTrialAvailable")
 		}
 		// select a trial quota as all other types are missing

--- a/pkg/shared/accountmgmtutil/api.go
+++ b/pkg/shared/accountmgmtutil/api.go
@@ -4,6 +4,7 @@ package accountmgmtutil
 type QuotaType = string
 
 const (
-	QuotaTrialType    QuotaType = "trial"
-	QuotaStandardType QuotaType = "standard"
+	QuotaTrialType       QuotaType = "trial"
+	QuotaStandardType    QuotaType = "standard"
+	QuotaMarketplaceType QuotaType = "marketplace"
 )


### PR DESCRIPTION
This PR adds `--billing-model` flag to `rhoas kafka create` command.
The CLI should be able to create instances with standard, marketplace and trial quotas. 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. For testing against marketplace  (use _kafka_service account).

`rhoas kafka create --name test-instance` should throw error saying multiple quota types are available and user needs to specify billing model.
`rhoas kafka create --name test-instance --billing-model standard` should create a standard instance
`rhoas kafka create --name test-instance --billing-model standard` should create a marketplace instance

`rhoas kafka create` should start the creation in interactive mode and prompt for billing model.

User should be able to pick marketplace provider and market place account if multiple options are available, else the only account gets selected by default.

2. When only trial instances are available (use _kafka_devexp account)

Specifying the billing model should fail with message "only trial instances available".

`rhoas kafka create --name test-instance` should create a trial instance.

Interactive mode should not prompt billing model.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)