### PR TITLE
fix: add env var config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,14 @@ Once pushed, a [GitHub Action](https://github.com/redhat-developer/app-services-
 
 > NOTE: To create a pre-release, the tag should have appropriate suffix, e.g v0.20.1-alpha1
 
+### Environment variables
+
+RHOASCONFIG="./config.json" - custom configuration location (useful for testing)
+RHOAS_CONTEXT="./context.json" - custom context location
+RHOAS_TELEMETRY=false - Enables/Disables telemetry (should happen automatically in non tty sessions)
+EDITOR=Code -w - controls CLI editor
+KUBECONFIG=./config.json - custom kubernetes config used for other commands
+
 ### Changelog generation
 
 [git-chglog](https://github.com/git-chglog/git-chglog) is used to generate a changelog for the current release.

--- a/cmd/rhoas/main.go
+++ b/cmd/rhoas/main.go
@@ -50,9 +50,6 @@ func main() {
 	err = executeCommandWithTelemetry(rootCmd, cmdFactory)
 
 	if err == nil {
-		if flagutil.DebugEnabled() {
-			build.CheckForUpdate(cmdFactory.Context, build.Version, cmdFactory.Logger, localizer)
-		}
 		return
 	}
 	cmdFactory.Logger.Errorf("%v\n", rootError(err, localizer))

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/auth/login"
-	"github.com/redhat-developer/app-services-cli/pkg/core/auth/token"
-	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
@@ -179,20 +177,8 @@ func runLogin(opts *options) (err error) {
 		return err
 	}
 
-	username, ok := token.GetUsername(cfg.AccessToken)
-
 	opts.Logger.Info()
-	if !ok {
-		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccessNoUsername"))
-	} else {
-		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccess", localize.NewEntry("Username", username)))
-	}
-
-	// debug mode checks this for a version update also.
-	// so we check if is enabled first so as not to print it twice
-	if !flagutil.DebugEnabled() {
-		build.CheckForUpdate(opts.Context, build.Version, opts.Logger, opts.localizer)
-	}
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("login.log.info.loginSuccess"))
 
 	return nil
 }

--- a/pkg/core/auth/token/token.go
+++ b/pkg/core/auth/token/token.go
@@ -123,7 +123,10 @@ func GetUsername(tokenStr string) (username string, ok bool) {
 	if tokenStr == "" {
 		return "", false
 	}
-	accessTkn, _ := Parse(tokenStr)
+	accessTkn, err := Parse(tokenStr)
+	if err != nil {
+		return "", false
+	}
 	tknClaims, _ := MapClaims(accessTkn)
 	u, ok := tknClaims["preferred_username"]
 	if ok {

--- a/pkg/core/auth/token/token.go
+++ b/pkg/core/auth/token/token.go
@@ -88,7 +88,9 @@ func MapClaims(token *jwt.Token) (claims jwt.MapClaims, err error) {
 
 func GetExpiry(tokenStr string, now time.Time) (expires bool,
 	left time.Duration, err error) {
-
+	if tokenStr == "" {
+		return true, 0, nil
+	}
 	token, err := Parse(tokenStr)
 	if err != nil {
 		return false, 0, err

--- a/pkg/core/auth/token/token.go
+++ b/pkg/core/auth/token/token.go
@@ -120,6 +120,9 @@ func GetExpiry(tokenStr string, now time.Time) (expires bool,
 
 // GetUsername extracts the username claim value from the JWT
 func GetUsername(tokenStr string) (username string, ok bool) {
+	if tokenStr == "" {
+		return "", false
+	}
 	accessTkn, _ := Parse(tokenStr)
 	tknClaims, _ := MapClaims(accessTkn)
 	u, ok := tknClaims["preferred_username"]

--- a/pkg/core/cmdutil/profile/profile.go
+++ b/pkg/core/cmdutil/profile/profile.go
@@ -2,13 +2,8 @@
 package profile
 
 import (
-	"os"
-	"strconv"
-
 	"github.com/spf13/cobra"
 )
-
-const DevPreviewEnv = "RHOAS_DEV"
 
 // ApplyDevPreviewLabel adds visual element displayed in help
 func ApplyDevPreviewLabel(cmd *cobra.Command) {
@@ -23,16 +18,4 @@ func ApplyDevPreviewLabel(cmd *cobra.Command) {
 // DevPreviewAnnotation used in templates and tools like documentation generation
 func DevPreviewAnnotation() map[string]string {
 	return map[string]string{"channel": "preview"}
-}
-
-// DevModeEnabled Check if development mode is enabled
-func DevModeEnabled() bool {
-	rawEnvVal := os.Getenv(DevPreviewEnv)
-
-	boolVal, err := strconv.ParseBool(rawEnvVal)
-	if err != nil {
-		return false
-	}
-
-	return boolVal
 }

--- a/pkg/core/localize/locales/en/cmd/login.en.toml
+++ b/pkg/core/localize/locales/en/cmd/login.en.toml
@@ -83,10 +83,6 @@ one = 'Redirected to callback URL: {{.URL}}'
 
 [login.log.info.loginSuccess]
 description = 'Log in success message'
-one = 'You are now logged in as "{{.Username}}"'
-
-[login.log.info.loginSuccessNoUsername]
-description = 'Log in success message'
 one = 'You are now logged in'
 
 [login.log.info.openSSOUrl]


### PR DESCRIPTION
This fixes problems with offline tokens/refresh tokens when having empty config. I think we should use empty config flag for testing etc. 

## Verification

```
RHOASCONFIG="./config.json" rhoas login

RHOASCONFIG="./config.json" rhoas login --token

RHOASCONFIG="./config.json" rhoas login
```

Notice token login not printing user info but classic login does
Check how config changes when testing
