### PR TITLE
fix: print no result when list is nil and using default format

### DIFF
--- a/pkg/cmd/connector/connector.go
+++ b/pkg/cmd/connector/connector.go
@@ -38,11 +38,11 @@ func NewConnectorsCommand(f *factory.Factory) *cobra.Command {
 		start.NewStartCommand(f),
 		stop.NewStopCommand(f),
 		connector_type.NewTypeCommand(f),
+		list.NewListCommand(f),
 
 		// Hidden for the users and docs at the moment
 		create.NewCreateCommand(f),
 		delete.NewDeleteCommand(f),
-		list.NewListCommand(f),
 		describe.NewDescribeCommand(f),
 		update.NewUpdateCommand(f),
 	)

--- a/pkg/cmd/connector/list/list.go
+++ b/pkg/cmd/connector/list/list.go
@@ -44,7 +44,6 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 		Short:   f.Localizer.MustLocalize("connector.list.cmd.shortDescription"),
 		Long:    f.Localizer.MustLocalize("connector.list.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.list.cmd.example"),
-		Hidden:  true,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, flagutil.ValidOutputFormats...) {
@@ -82,15 +81,19 @@ func runList(opts *options) error {
 		return err
 	}
 
-	if response.Size == 0 && opts.outputFormat == "" {
+	if response.Items == nil && opts.outputFormat == "" {
+		f.Logger.Info(f.Localizer.MustLocalize("connector.common.log.info.noResults"))
+		return nil
+	}
+
+	if response.Size == 0  && opts.outputFormat == "" {
 		f.Logger.Info(f.Localizer.MustLocalize("connector.common.log.info.noResults"))
 		return nil
 	}
 
 	switch opts.outputFormat {
 	case dump.EmptyFormat:
-		var rows []itemRow
-		rows = mapResponseItemsToRows(response.Items)
+		rows := mapResponseItemsToRows(response.Items)
 
 		dump.Table(f.IOStreams.Out, rows)
 		f.Logger.Info("")


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Currently when running `connector list --page=2` when there are no valid connectors for that query and you are using an empty format then no result is returned (expected is to print no result message). 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Have no connectors runnning
2. On main run `rhoas connector list --page=2` and you get no output
3. On this branch run the same and you get info about empty result

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
