### PR TITLE
fix: cache connection to skip refreshes

### DIFF
--- a/pkg/shared/factory/defaultfactory/default.go
+++ b/pkg/shared/factory/defaultfactory/default.go
@@ -38,6 +38,9 @@ func New(localizer localize.Localizer) *factory.Factory {
 	ctx := context.Background()
 
 	connectionFunc := func() (connection.Connection, error) {
+		if conn != nil {
+			return conn, nil
+		}
 		cfg, err := cfgFile.Load()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Reverting https://github.com/redhat-developer/app-services-cli/pull/1624/files
This change was to ensure that we mas-sso tokens refresh have been added. Now since mas-sso tokens are gone we should cache our regular sso tokens across session.

This is still not perfect but due to very large amount of connections created in various helpers (kafka create creates -7 connections on it's own - that is 7 sso refreshes per command). Some better refactor for connection objects is needed.
For now we can cache that object as there is no chance that tokens will outdate during single command run (5minutes)