### PR TITLE
fix(kafka create): chose standard if no marketplace info is provided

### DIFF
--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -146,7 +146,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 
 	if len(orgQuota.StandardQuotas) > 0 && len(orgQuota.MarketplaceQuotas) > 0 {
 
-		if marketplaceInfo.BillingModel == QuotaStandardType {
+		if marketplaceInfo.BillingModel == QuotaStandardType || (marketplaceInfo.BillingModel == "" && marketplaceInfo.Provider == "") {
 			return &orgQuota.StandardQuotas[0], nil
 		} else if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 			marketplaceQuota, err := getMarketplaceQuota(f, orgQuota.MarketplaceQuotas, marketplaceInfo)


### PR DESCRIPTION
Earlier the Kafka create failed with error if multiple quota types were present and billing model was not specified by the user. This PR changes logic to pick `standard` quota if no marketplace detail is provided.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the mock server.
2. Run `rhoas kafka create` command in verbose mode.
```
rhoas kafka create --name test-instance -v --dry-run
```
3. It should log the following as the selected quota:
```
Selected Quota object:
{
  "Name": "standard",
  "Quota": 299,
  "BillingModel": "standard",
  "CloudAccounts": null
}
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
