### PR TITLE
fix: can now only consume and wait from single topic

### DIFF
--- a/pkg/cmd/kafka/topic/consume/consume.go
+++ b/pkg/cmd/kafka/topic/consume/consume.go
@@ -142,6 +142,11 @@ func runCmd(opts *options) error {
 }
 
 func consumeAndWait(opts *options, api *kafkainstanceclient.APIClient, kafkaInstance *kafkamgmtclient.KafkaRequest) error {
+
+	if opts.partition == DefaultPartition {
+		return opts.f.Localizer.MustLocalizeError("kafka.topic.consume.error.noPartitionWhenWaiting")
+	}
+
 	if opts.limit != DefaultLimit {
 		opts.f.Logger.Info(opts.f.Localizer.MustLocalize("kafka.topic.consume.log.info.limitIgnored", localize.NewEntry("Limit", DefaultLimit)))
 		opts.limit = DefaultLimit
@@ -188,12 +193,12 @@ func consumeAndWait(opts *options, api *kafkainstanceclient.APIClient, kafkaInst
 }
 
 func consume(opts *options, api *kafkainstanceclient.APIClient, kafkaInstance *kafkamgmtclient.KafkaRequest) (*kafkainstanceclient.RecordList, error) {
-
 	request := api.RecordsApi.ConsumeRecords(opts.f.Context, opts.topicName).Limit(opts.limit)
+
 	if opts.partition != DefaultPartition {
-		opts.f.Logger.Info(opts.f.Localizer.MustLocalize("kafka.topic.consume.partition.value", localize.NewEntry("Partition", opts.partition)))
 		request = request.Partition(opts.partition)
 	}
+
 	if opts.offset != DefaultOffset {
 		intOffset, err := strconv.ParseInt(opts.offset, 10, 64)
 		if err != nil {

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -690,6 +690,9 @@ one = 'Output format for consumed messages (choose from: "json", "yaml", "key-va
 [kafka.topic.consume.log.info.limitIgnored]
 one = 'Ignore specified limit value and use default value of {{.Limit}}'
 
+[kafka.topic.consume.error.noPartitionWhenWaiting]
+one = 'Must set a partition when using --wait in consume'
+
 [kafka.topic.consume.log.info.offsetIgnored]
 one = 'Ignore specified offset value and use default value of {{.Offset}}'
 


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a kafka with 2 topics
2. run `rhoas kafka topic consume --name=topic --partition=0 --wait`
3. Then in another terminal produce to the same topic `rhoas kafka topic produce --name=topic --partition=0`
4. You should the messages come in
5. Try and produce a message on a different topic and no messages should appear
6. Repeat for each topic
7. Run  `rhoas kafka topic consume --name=topic --wait` should not work

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
