### PR TITLE
fix(generate-config): print path to configuration file

### DIFF
--- a/pkg/cmd/generate/build-configs.go
+++ b/pkg/cmd/generate/build-configs.go
@@ -114,11 +114,12 @@ func BuildConfiguration(svcConfig *servicecontext.ServiceConfig, opts *options) 
 	configurations.TokenURL = providerUrls.GetTokenUrl()
 	configurations.Name = configInstanceName
 
-	if err = WriteConfig(opts, configurations); err != nil {
+	var fileName string
+	if fileName, err = WriteConfig(opts, configurations); err != nil {
 		return err
 	}
 
-	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("generate.log.info.credentialsSaved"))
+	opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("generate.log.info.credentialsSaved", localize.NewEntry("FilePath", fileName)))
 
 	return nil
 }

--- a/pkg/cmd/generate/configurations.go
+++ b/pkg/cmd/generate/configurations.go
@@ -29,13 +29,13 @@ var (
 
 // WriteConfig saves the configurations to a file
 // in the specified output format
-func WriteConfig(opts *options, config *configValues) error {
+func WriteConfig(opts *options, config *configValues) (string, error) {
 
 	var fileBody bytes.Buffer
 	fileTemplate := getFileFormat(opts.configType)
 	err := fileTemplate.Execute(&fileBody, config)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	fileData := []byte(fileBody.String())
@@ -47,10 +47,10 @@ func WriteConfig(opts *options, config *configValues) error {
 	// indicating that the user should explicitly request overwriting of the file
 	_, err = os.Stat(opts.fileName)
 	if err == nil && !opts.overwrite {
-		return opts.localizer.MustLocalizeError("generate.error.configFileAlreadyExists", localize.NewEntry("FilePath", opts.fileName))
+		return "", opts.localizer.MustLocalizeError("generate.error.configFileAlreadyExists", localize.NewEntry("FilePath", opts.fileName))
 	}
 
-	return ioutil.WriteFile(opts.fileName, fileData, 0o600)
+	return opts.fileName, ioutil.WriteFile(opts.fileName, fileData, 0o600)
 }
 
 // getDefaultPath returns the default absolute path for the configuration file

--- a/pkg/core/localize/locales/en/cmd/generate_config.en.toml
+++ b/pkg/core/localize/locales/en/cmd/generate_config.en.toml
@@ -43,4 +43,4 @@ one = 'file {{.FilePath}} already exists. Use --overwrite to overwrite the file,
 one='No services available to generate configurations'
 
 [generate.log.info.credentialsSaved]
-one='Configurations successfully saved'
+one='Configurations successfully saved to "{{.FilePath}}"'


### PR DESCRIPTION
`rhoas generate-config` should now print the file to which the configurations have been saved to. This had been one of the PM feedback for the `generate-config` command.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Run the following command to save configurations in `config.json`
```
./rhoas generate-config --type json --output-file "config.json"
```
2. It should log the following message:
```
✔️  Configurations successfully saved to "config.json"
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
