### PR TITLE
fix: include bind as files flag into CR creation

### DIFF
--- a/pkg/shared/cluster/bind.go
+++ b/pkg/shared/cluster/bind.go
@@ -177,7 +177,7 @@ func createBindingCR(options *v1alpha.BindOperationOptions, serviceMetadata sche
 			Namespace: namespace,
 		},
 		Spec: bindv1alpha1.ServiceBindingSpec{
-			BindAsFiles: true,
+			BindAsFiles: options.BindAsFiles,
 			Services:    []bindv1alpha1.Service{serviceRef},
 			Application: appRef,
 		},


### PR DESCRIPTION
We should include user preference for binding as files.
Fixes https://github.com/redhat-developer/app-services-cli/issues/1665

## Verification

Typical minikube verification applies 