### PR TITLE
docs(context unset): erroneous flag description

### DIFF
--- a/docs/commands/rhoas_context_unset.md
+++ b/docs/commands/rhoas_context_unset.md
@@ -28,7 +28,7 @@ $ rhoas context unset --name dev --services service-registry
 
 ```
       --name string        Name of the context
-      --services strings   context.unset.flag.services.description
+      --services strings   The name of the services to unset
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/context/unset/unset.go
+++ b/pkg/cmd/context/unset/unset.go
@@ -51,7 +51,7 @@ func NewUnsetCommand(f *factory.Factory) *cobra.Command {
 	flags := contextcmdutil.NewFlagSet(cmd, f)
 
 	flags.AddContextName(&opts.name)
-	flags.StringSliceVar(&opts.services, "services", []string{}, "context.unset.flag.services.description")
+	flags.StringSliceVar(&opts.services, "services", []string{}, f.Localizer.MustLocalize("context.unset.flag.services.description"))
 
 	return cmd
 

--- a/pkg/cmd/generate/build-configs.go
+++ b/pkg/cmd/generate/build-configs.go
@@ -86,7 +86,7 @@ func BuildConfiguration(svcConfig *servicecontext.ServiceConfig, opts *options) 
 	}
 
 	if !serviceAvailable {
-		return opts.localizer.MustLocalizeError("generate.log.info.noSevices")
+		return opts.localizer.MustLocalizeError("generate.log.info.noServices")
 	}
 	configInstanceName := fmt.Sprintf("%s-%v", opts.name, time.Now().Unix())
 	serviceAccount, err := createServiceAccount(opts, configInstanceName)

--- a/pkg/core/localize/locales/en/cmd/generate_config.en.toml
+++ b/pkg/core/localize/locales/en/cmd/generate_config.en.toml
@@ -39,7 +39,7 @@ one = 'Sets a custom file location to save the configurations'
 description = 'Error message for when a configuration file alredy exists at a location'
 one = 'file {{.FilePath}} already exists. Use --overwrite to overwrite the file, or the --output-file flag to choose a different location'
 
-[generate.log.info.noSevices]
+[generate.log.info.noServices]
 one='No services available to generate configurations'
 
 [generate.log.info.credentialsSaved]


### PR DESCRIPTION
Flag description for `context unset` command used the key rather than getting the corresponding value through localizations.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
The following command should display proper flag descriptions:
```
rhoas context unset -h
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
