### PR TITLE
Fixing page and limit had same description in connector type list

### DIFF
--- a/docs/commands/rhoas_connector_type_list.md
+++ b/docs/commands/rhoas_connector_type_list.md
@@ -31,9 +31,9 @@ rhoas connector type list --search=%Amazon%
 ### Options
 
 ```
-      --limit int       Page of connector limit (default 150)
+      --limit int       The max number of connectors to return in the page (default 150)
   -o, --output string   Specify the output format. Choose from: "json", "yaml", "yml"
-      --page int        Page of connector limit (default 1)
+      --page int        Page of the list based on limit (default 1)
       --search string   Search query for name of connector type
 ```
 

--- a/pkg/cmd/connector/connector_type/list/list.go
+++ b/pkg/cmd/connector/connector_type/list/list.go
@@ -59,7 +59,7 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 
 	flags := connectorcmdutil.NewFlagSet(cmd, f)
 	flags.AddOutput(&opts.outputFormat)
-	flags.IntVar(&opts.limit, "limit", 150, f.Localizer.MustLocalize("connector.type.list.flag.page.description"))
+	flags.IntVar(&opts.limit, "limit", 150, f.Localizer.MustLocalize("connector.type.list.flag.limit.description"))
 	flags.StringVar(&opts.search, "search", DefaultSearch, f.Localizer.MustLocalize("connector.type.list.flag.search.description"))
 	flags.IntVar(&opts.page, "page", 1, f.Localizer.MustLocalize("connector.type.list.flag.page.description"))
 	return cmd

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -440,7 +440,7 @@ rhoas connector type list --search=%Amazon%
 '''
 
 [connector.type.list.flag.page.description]
-one = 'Page of connector limit'
+one = 'Page of the list based on limit'
 
 [connector.type.list.flag.search.description]
 one = 'Search query for name of connector type'


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

Before the page and limit flag in `rhoas connector type list` has the same description. This pr fixes that and gives a better description of the page flag aswell

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Use auto suggest in your shell to see the description of page and limit are no longer the same

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
