### PR TITLE
fix(generate-config): update success message and default path for env

### DIFF
--- a/pkg/cmd/generate/configurations.go
+++ b/pkg/cmd/generate/configurations.go
@@ -57,7 +57,7 @@ func WriteConfig(opts *options, config *configValues) (string, error) {
 func getDefaultPath(configType string) (filePath string) {
 	switch configType {
 	case envFormat:
-		filePath = ".env"
+		filePath = "rhoas.env"
 	case propertiesFormat:
 		filePath = "rhoas.properties"
 	case jsonFormat:

--- a/pkg/core/localize/locales/en/cmd/generate_config.en.toml
+++ b/pkg/core/localize/locales/en/cmd/generate_config.en.toml
@@ -46,5 +46,8 @@ one='No services available to generate configurations'
 one='''
 Configurations successfully saved to "{{.FilePath}}"
 
-You can now create new service accounts or use existing ones to connect to the service(s)
+You can now use existing service accounts or create new to connect to the services.
+To create new service account, run this command:
+
+  $ rhoas service-account create
 '''


### PR DESCRIPTION
This is a follow up to #1588 .

The PR updates the success message printed after configs are generated.
`rhoas generate-config --type env` should save configurations to `rhoas.env`

### Verification Steps
1. Run the following command:

```
./rhoas generate-config --type env
```

2. The command should save configurations in `rhoas.env`.

```
Configurations successfully saved to "/home/rkpattnaik780/coding/redhat/mk/cli/rhoas.env"

You can now use existing service accounts or create new to connect to the services.
To create new service account, run this command:

  $ rhoas service-account create
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
