### PR TITLE
WIP: feat(service-registry): setting command

### DIFF
--- a/docs/commands/rhoas_service-registry.md
+++ b/docs/commands/rhoas_service-registry.md
@@ -43,5 +43,6 @@ rhoas service-registry list
 * [rhoas service-registry list](rhoas_service-registry_list.md)	 - List Service Registry instances
 * [rhoas service-registry role](rhoas_service-registry_role.md)	 - Service Registry role management
 * [rhoas service-registry rule](rhoas_service-registry_rule.md)	 - Manage artifact rules in a Service Registry instance
+* [rhoas service-registry setting](rhoas_service-registry_setting.md)	 - Configure settings of a Service Registry instance
 * [rhoas service-registry use](rhoas_service-registry_use.md)	 - Use a Service Registry instance
 

--- a/docs/commands/rhoas_service-registry_setting.md
+++ b/docs/commands/rhoas_service-registry_setting.md
@@ -1,0 +1,34 @@
+## rhoas service-registry setting
+
+Configure settings of a Service Registry instance
+
+### Synopsis
+
+Configure settings of a Service Registry instance
+
+
+### Examples
+
+```
+## List all settings of the current Service Registry instance
+$ rhoas service-registry setting list
+
+## Set the value of setting
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry](rhoas_service-registry.md)	 - Service Registry commands
+* [rhoas service-registry setting get](rhoas_service-registry_setting_get.md)	 - Get value of the setting
+* [rhoas service-registry setting list](rhoas_service-registry_setting_list.md)	 - List settings
+* [rhoas service-registry setting set](rhoas_service-registry_setting_set.md)	 - Set value of the setting
+

--- a/docs/commands/rhoas_service-registry_setting.md
+++ b/docs/commands/rhoas_service-registry_setting.md
@@ -14,7 +14,7 @@ Configure settings of a Service Registry instance
 $ rhoas service-registry setting list
 
 ## Set the value of setting
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --value true
 
 ```
 

--- a/docs/commands/rhoas_service-registry_setting_get.md
+++ b/docs/commands/rhoas_service-registry_setting_get.md
@@ -1,0 +1,42 @@
+## rhoas service-registry setting get
+
+Get value of the setting
+
+### Synopsis
+
+Get formatted setting value and other information
+
+```
+rhoas service-registry setting get [flags]
+```
+
+### Examples
+
+```
+## Get setting by name
+$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled
+
+## Get setting in yaml format by name
+$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled --output yaml
+
+```
+
+### Options
+
+```
+      --instance-id string    ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+  -o, --output string         Specify the output format. Choose from: "json", "yaml", "yml"
+  -n, --setting-name string   Name of the setting
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry setting](rhoas_service-registry_setting.md)	 - Configure settings of a Service Registry instance
+

--- a/docs/commands/rhoas_service-registry_setting_get.md
+++ b/docs/commands/rhoas_service-registry_setting_get.md
@@ -14,19 +14,19 @@ rhoas service-registry setting get [flags]
 
 ```
 ## Get setting by name
-$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled
+$ rhoas service-registry setting get --name registry.ccompat.legacy-id-mode.enabled
 
 ## Get setting in yaml format by name
-$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled --output yaml
+$ rhoas service-registry setting get --name registry.ccompat.legacy-id-mode.enabled --output yaml
 
 ```
 
 ### Options
 
 ```
-      --instance-id string    ID of the Service Registry instance to be used (by default, uses the currently selected instance)
-  -o, --output string         Specify the output format. Choose from: "json", "yaml", "yml"
-  -n, --setting-name string   Name of the setting
+      --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+  -n, --name string          Name of the setting
+  -o, --output string        Specify the output format. Choose from: "json", "yaml", "yml"
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/rhoas_service-registry_setting_list.md
+++ b/docs/commands/rhoas_service-registry_setting_list.md
@@ -1,0 +1,40 @@
+## rhoas service-registry setting list
+
+List settings
+
+### Synopsis
+
+List all settings with their values and types
+
+```
+rhoas service-registry setting list [flags]
+```
+
+### Examples
+
+```
+## List all settings of the current Service Registry
+$ rhoas service-registry setting list
+
+## List all settings of a specific Service Registry instance
+$ rhoas service-registry setting list --instance-id=8ecff228-1ffe-4cf5-b38b-55223885ee00
+
+```
+
+### Options
+
+```
+      --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry setting](rhoas_service-registry_setting.md)	 - Configure settings of a Service Registry instance
+

--- a/docs/commands/rhoas_service-registry_setting_set.md
+++ b/docs/commands/rhoas_service-registry_setting_set.md
@@ -1,0 +1,43 @@
+## rhoas service-registry setting set
+
+Set value of the setting
+
+### Synopsis
+
+Set value of the setting to a specific value or reset to default
+
+```
+rhoas service-registry setting set [flags]
+```
+
+### Examples
+
+```
+## Set value of setting by name
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+
+## Reset value of setting by name
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --default
+
+```
+
+### Options
+
+```
+      --default               Reset value of the setting to default
+      --instance-id string    ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+  -n, --setting-name string   Name of the setting
+      --value string          New value of the setting
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas service-registry setting](rhoas_service-registry_setting.md)	 - Configure settings of a Service Registry instance
+

--- a/docs/commands/rhoas_service-registry_setting_set.md
+++ b/docs/commands/rhoas_service-registry_setting_set.md
@@ -14,20 +14,20 @@ rhoas service-registry setting set [flags]
 
 ```
 ## Set value of setting by name
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --value true
 
 ## Reset value of setting by name
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --default
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --default
 
 ```
 
 ### Options
 
 ```
-      --default               Reset value of the setting to default
-      --instance-id string    ID of the Service Registry instance to be used (by default, uses the currently selected instance)
-  -n, --setting-name string   Name of the setting
-      --value string          New value of the setting
+      --default              Restore value of the setting to default
+      --instance-id string   ID of the Service Registry instance to be used (by default, uses the currently selected instance)
+  -n, --name string          Name of the setting
+      --value string         New value of the setting
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/registry/registry.go
+++ b/pkg/cmd/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/describe"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/list"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/setting"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/use"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ func NewServiceRegistryCommand(f *factory.Factory) *cobra.Command {
 		artifact.NewArtifactsCommand(f),
 		role.NewRoleCommand(f),
 		rule.NewRuleCommand(f),
+		setting.NewSettingCommand(f),
 	)
 
 	return cmd

--- a/pkg/cmd/registry/setting/get/get.go
+++ b/pkg/cmd/registry/setting/get/get.go
@@ -1,0 +1,120 @@
+package get
+
+import (
+	"context"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+)
+
+type options struct {
+	IO             *iostreams.IOStreams
+	Connection     factory.ConnectionFunc
+	Logger         logging.Logger
+	localizer      localize.Localizer
+	Context        context.Context
+	ServiceContext servicecontext.IContext
+
+	registryID  string
+	settingName string
+	output      string
+}
+
+// NewGetCommand creates a new command to get a service registry setting
+func NewGetCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		IO:             f.IOStreams,
+		Connection:     f.Connection,
+		Logger:         f.Logger,
+		localizer:      f.Localizer,
+		Context:        f.Context,
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "get",
+		Short:   f.Localizer.MustLocalize("setting.get.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("setting.get.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("setting.get.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			if opts.settingName == "" {
+				if !opts.IO.CanPrompt() {
+					return flagutil.RequiredWhenNonInteractiveError("setting-name")
+				}
+				err = runInteractivePrompt(opts)
+				if err != nil {
+					return err
+				}
+			}
+
+			registryInstance, err := contextutil.GetCurrentRegistryInstance(f)
+			if err != nil {
+				return err
+			}
+
+			opts.registryID = registryInstance.GetId()
+
+			return runGet(opts)
+		},
+	}
+
+	flags := rulecmdutil.NewFlagSet(cmd, f)
+
+	flags.AddRegistryInstance(&opts.registryID)
+
+	flags.StringVarP(&opts.settingName, "setting-name", "n", "", f.Localizer.MustLocalize("setting.get.cmd.flag.settingName.description"))
+
+	flags.AddOutput(&opts.output)
+
+	return cmd
+}
+
+func runGet(opts *options) error {
+	conn, err := opts.Connection()
+	if err != nil {
+		return err
+	}
+
+	api := conn.API()
+
+	a, _, err := api.ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	request := a.AdminApi.GetConfigProperty(opts.Context, opts.settingName)
+
+	configProperty, _, err := request.Execute()
+	if err != nil {
+		return registrycmdutil.TransformInstanceError(err)
+	}
+
+	return dump.Formatted(opts.IO.Out, opts.output, configProperty)
+}
+
+func runInteractivePrompt(opts *options) (err error) {
+
+	settingNamePrompt := &survey.Input{
+		Message: opts.localizer.MustLocalize("setting.get.input.settingName.message"),
+	}
+
+	err = survey.AskOne(settingNamePrompt, &opts.settingName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/registry/setting/list/list.go
+++ b/pkg/cmd/registry/setting/list/list.go
@@ -1,0 +1,124 @@
+package list
+
+import (
+	"context"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+)
+
+// settingRow is the details of a Service Registry settings needed to print to a table
+type settingRow struct {
+	Name string `json:"name" header:"Name"`
+
+	Label string `json:"label,omitempty" header:"Label"`
+
+	Type string `json:"type" header:"Type"`
+
+	Value string `json:"value" header:"Value"`
+}
+
+type options struct {
+	IO             *iostreams.IOStreams
+	Connection     factory.ConnectionFunc
+	Logger         logging.Logger
+	localizer      localize.Localizer
+	Context        context.Context
+	ServiceContext servicecontext.IContext
+
+	registryID string
+}
+
+// NewListCommand creates a new command to view a list of settings
+func NewListCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		IO:             f.IOStreams,
+		Connection:     f.Connection,
+		Logger:         f.Logger,
+		localizer:      f.Localizer,
+		Context:        f.Context,
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   f.Localizer.MustLocalize("setting.list.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("setting.list.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("setting.list.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			registryInstance, err := contextutil.GetCurrentRegistryInstance(f)
+			if err != nil {
+				return err
+			}
+
+			opts.registryID = registryInstance.GetId()
+
+			return runList(opts)
+		},
+	}
+
+	flags := rulecmdutil.NewFlagSet(cmd, f)
+
+	flags.AddRegistryInstance(&opts.registryID)
+
+	return cmd
+
+}
+
+func runList(opts *options) error {
+	conn, err := opts.Connection()
+	if err != nil {
+		return err
+	}
+
+	api := conn.API()
+
+	a, _, err := api.ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+	request := a.AdminApi.ListConfigProperties(opts.Context)
+
+	response, _, err := request.Execute()
+	if err != nil {
+		return registrycmdutil.TransformInstanceError(err)
+	}
+
+	rows := mapResponseItemsToRows(response)
+
+	opts.Logger.Info("")
+	dump.Table(opts.IO.Out, rows)
+	opts.Logger.Info("")
+
+	return nil
+}
+
+func mapResponseItemsToRows(settings []registryinstanceclient.ConfigurationProperty) []settingRow {
+	rows := make([]settingRow, len(settings))
+
+	for i := range settings {
+		k := (settings)[i]
+		row := settingRow{
+			Name:  k.GetName(),
+			Value: k.GetValue(),
+			Type:  k.GetType(),
+			Label: k.GetLabel(),
+		}
+
+		rows[i] = row
+	}
+
+	return rows
+}

--- a/pkg/cmd/registry/setting/set/set.go
+++ b/pkg/cmd/registry/setting/set/set.go
@@ -1,0 +1,160 @@
+package set
+
+import (
+	"context"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/registrycmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/rule/rulecmdutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/iostreams"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
+	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	registryinstanceclient "github.com/redhat-developer/app-services-sdk-go/registryinstance/apiv1internal/client"
+	"github.com/spf13/cobra"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+)
+
+type options struct {
+	IO             *iostreams.IOStreams
+	Connection     factory.ConnectionFunc
+	Logger         logging.Logger
+	localizer      localize.Localizer
+	Context        context.Context
+	ServiceContext servicecontext.IContext
+
+	registryID     string
+	settingName    string
+	value          string
+	resetToDefault bool
+}
+
+// NewSetCommand creates a new command to set a service registry setting
+func NewSetCommand(f *factory.Factory) *cobra.Command {
+
+	opts := &options{
+		IO:             f.IOStreams,
+		Connection:     f.Connection,
+		Logger:         f.Logger,
+		localizer:      f.Localizer,
+		Context:        f.Context,
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "set",
+		Short:   f.Localizer.MustLocalize("setting.set.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("setting.set.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("setting.set.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+
+			var missingFlags []string
+
+			if opts.settingName == "" {
+				missingFlags = append(missingFlags, "setting-name")
+			}
+			if opts.value == "" && !opts.resetToDefault {
+				missingFlags = append(missingFlags, "value")
+			}
+
+			if !opts.IO.CanPrompt() && len(missingFlags) > 0 {
+				return flagutil.RequiredWhenNonInteractiveError(missingFlags...)
+			}
+
+			if len(missingFlags) > 0 {
+				err = runInteractivePrompt(opts, missingFlags)
+				if err != nil {
+					return err
+				}
+			}
+
+			registryInstance, err := contextutil.GetCurrentRegistryInstance(f)
+			if err != nil {
+				return err
+			}
+
+			opts.registryID = registryInstance.GetId()
+
+			return runSet(opts)
+		},
+	}
+
+	flags := rulecmdutil.NewFlagSet(cmd, f)
+
+	flags.AddRegistryInstance(&opts.registryID)
+
+	flags.StringVarP(&opts.settingName, "setting-name", "n", "", f.Localizer.MustLocalize("setting.set.cmd.flag.settingName.description"))
+	flags.StringVar(&opts.value, "value", "", f.Localizer.MustLocalize("setting.set.cmd.flag.value.description"))
+	flags.BoolVar(&opts.resetToDefault, "default", false, f.Localizer.MustLocalize("setting.set.cmd.flag.default.description"))
+
+	return cmd
+}
+
+func runSet(opts *options) error {
+	conn, err := opts.Connection()
+	if err != nil {
+		return err
+	}
+
+	api := conn.API()
+
+	a, _, err := api.ServiceRegistryInstance(opts.registryID)
+	if err != nil {
+		return err
+	}
+
+	if !opts.resetToDefault {
+		request := a.AdminApi.UpdateConfigProperty(opts.Context, opts.settingName)
+
+		request = request.UpdateConfigurationProperty(registryinstanceclient.UpdateConfigurationProperty{Value: opts.value})
+
+		_, err = request.Execute()
+		if err != nil {
+			return registrycmdutil.TransformInstanceError(err)
+		}
+
+		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("setting.set.log.info.settingSet"))
+	} else {
+		request := a.AdminApi.ResetConfigProperty(opts.Context, opts.settingName)
+
+		_, err = request.Execute()
+		if err != nil {
+			return registrycmdutil.TransformInstanceError(err)
+		}
+
+		opts.Logger.Info(icon.SuccessPrefix(), opts.localizer.MustLocalize("setting.set.log.info.settingReset"))
+	}
+	return nil
+}
+
+func runInteractivePrompt(opts *options, missingFlags []string) (err error) {
+
+	if slices.Contains(missingFlags, "setting-name") {
+		settingNamePrompt := &survey.Input{
+			Message: opts.localizer.MustLocalize("setting.set.input.settingName.message"),
+		}
+
+		err = survey.AskOne(settingNamePrompt, &opts.settingName)
+		if err != nil {
+			return err
+		}
+	}
+
+	if slices.Contains(missingFlags, "value") {
+		valuePrompt := &survey.Input{
+			Message: opts.localizer.MustLocalize("setting.set.input.value.message"),
+		}
+
+		err = survey.AskOne(valuePrompt, &opts.value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/registry/setting/setting.go
+++ b/pkg/cmd/registry/setting/setting.go
@@ -1,0 +1,28 @@
+package setting
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/setting/get"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/setting/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/registry/setting/set"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewSettingCommand(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "setting",
+		Short:   f.Localizer.MustLocalize("setting.cmd.description.short"),
+		Long:    f.Localizer.MustLocalize("setting.cmd.description.long"),
+		Example: f.Localizer.MustLocalize("setting.cmd.example"),
+		Args:    cobra.MinimumNArgs(1),
+	}
+
+	// add sub-commands
+	cmd.AddCommand(
+		list.NewListCommand(f),
+		get.NewGetCommand(f),
+		set.NewSetCommand(f),
+	)
+
+	return cmd
+}

--- a/pkg/core/localize/locales/en/cmd/setting.en.toml
+++ b/pkg/core/localize/locales/en/cmd/setting.en.toml
@@ -12,7 +12,7 @@ one = '''
 $ rhoas service-registry setting list
 
 ## Set the value of setting
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --value true
 '''
 
 [setting.list.cmd.description.short]
@@ -39,10 +39,10 @@ one = 'Get formatted setting value and other information'
 [setting.get.cmd.example]
 one = '''
 ## Get setting by name
-$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled
+$ rhoas service-registry setting get --name registry.ccompat.legacy-id-mode.enabled
 
 ## Get setting in yaml format by name
-$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled --output yaml
+$ rhoas service-registry setting get --name registry.ccompat.legacy-id-mode.enabled --output yaml
 '''
 
 [setting.get.cmd.flag.settingName.description]
@@ -60,10 +60,10 @@ one = 'Set value of the setting to a specific value or reset to default'
 [setting.set.cmd.example]
 one = '''
 ## Set value of setting by name
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --value true
 
 ## Reset value of setting by name
-$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --default
+$ rhoas service-registry setting set --name registry.ccompat.legacy-id-mode.enabled --default
 '''
 
 [setting.set.cmd.flag.settingName.description]
@@ -79,10 +79,14 @@ one = 'New value:'
 one = 'New value of the setting'
 
 [setting.set.cmd.flag.default.description]
-one = 'Reset value of the setting to default'
+one = 'Restore value of the setting to default'
 
 [setting.set.log.info.settingSet]
-one = 'Setting was successfully set'
+one = 'Successfully updated settings for update'
 
 [setting.set.log.info.settingReset]
 one = 'Setting was successfully reset to default'
+
+[setting.set.warning.valueignored]
+one = 'Value is ignore while setting is being restored to default'
+

--- a/pkg/core/localize/locales/en/cmd/setting.en.toml
+++ b/pkg/core/localize/locales/en/cmd/setting.en.toml
@@ -1,0 +1,88 @@
+[setting.cmd.description.short]
+one = 'Configure settings of a Service Registry instance'
+
+[setting.cmd.description.long]
+one = '''
+Configure settings of a Service Registry instance
+'''
+
+[setting.cmd.example]
+one = '''
+## List all settings of the current Service Registry instance
+$ rhoas service-registry setting list
+
+## Set the value of setting
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+'''
+
+[setting.list.cmd.description.short]
+one = 'List settings'
+
+[setting.list.cmd.description.long]
+one = 'List all settings with their values and types'
+
+[setting.list.cmd.example]
+one = '''
+## List all settings of the current Service Registry
+$ rhoas service-registry setting list
+
+## List all settings of a specific Service Registry instance
+$ rhoas service-registry setting list --instance-id=8ecff228-1ffe-4cf5-b38b-55223885ee00
+'''
+
+[setting.get.cmd.description.short]
+one = 'Get value of the setting'
+
+[setting.get.cmd.description.long]
+one = 'Get formatted setting value and other information'
+
+[setting.get.cmd.example]
+one = '''
+## Get setting by name
+$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled
+
+## Get setting in yaml format by name
+$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled --output yaml
+'''
+
+[setting.get.cmd.flag.settingName.description]
+one = 'Name of the setting'
+
+[setting.get.input.settingName.message]
+one = 'Name of the setting:'
+
+[setting.set.cmd.description.short]
+one = 'Set value of the setting'
+
+[setting.set.cmd.description.long]
+one = 'Set value of the setting to a specific value or reset to default'
+
+[setting.set.cmd.example]
+one = '''
+## Set value of setting by name
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
+
+## Reset value of setting by name
+$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --default
+'''
+
+[setting.set.cmd.flag.settingName.description]
+one = 'Name of the setting'
+
+[setting.set.input.settingName.message]
+one = 'Name of the setting:'
+
+[setting.set.input.value.message]
+one = 'New value:'
+
+[setting.set.cmd.flag.value.description]
+one = 'New value of the setting'
+
+[setting.set.cmd.flag.default.description]
+one = 'Reset value of the setting to default'
+
+[setting.set.log.info.settingSet]
+one = 'Setting was successfully set'
+
+[setting.set.log.info.settingReset]
+one = 'Setting was successfully reset to default'


### PR DESCRIPTION
This PR adds new setting command group with three subcommands:

list : List current configuration settings
set : Set the value of a configuration setting
get: Get the value of a configuration setting

Closes #1650

## Usage:
### List all settings of the current Service Registry instance
```
$ rhoas service-registry setting list
```
### Set the value of setting
```
$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --value true
```

Also, in registry there is an option to reset setting to default value, to do this using cli tool you can use a set command:
```
$ rhoas service-registry setting set --setting-name registry.ccompat.legacy-id-mode.enabled --default
```

### Get the calue of setting
From the original proposal I have added also get command to get ConfigurationProperty of specific name.
```
$ rhoas service-registry setting get --setting-name registry.ccompat.legacy-id-mode.enabled
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
