### PR TITLE
Context in connector create

### DIFF
--- a/pkg/shared/contextutil/util.go
+++ b/pkg/shared/contextutil/util.go
@@ -164,7 +164,7 @@ func GetNamespaceForServiceConfig(currCtx *servicecontext.ServiceConfig, conn *c
 		return nil, f.Localizer.MustLocalizeError("context.common.error.noConnectorID")
 	}
 
-	namespace, _, err := (*conn).API().ConnectorsMgmt().ConnectorNamespacesApi.GetConnectorNamespace(f.Context, currCtx.ConnectorID).Execute()
+	namespace, _, err := (*conn).API().ConnectorsMgmt().ConnectorNamespacesApi.GetConnectorNamespace(f.Context, currCtx.NamespaceID).Execute()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Connector create now uses context to get values for kafka and namespace.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
