### PR TITLE
Doc: update command help for kafka instance settings

### DIFF
--- a/docs/commands/rhoas_kafka.md
+++ b/docs/commands/rhoas_kafka.md
@@ -47,6 +47,6 @@ rhoas kafka topic create --name mytopic
 * [rhoas kafka describe](rhoas_kafka_describe.md)	 - View configuration details of a Kafka instance
 * [rhoas kafka list](rhoas_kafka_list.md)	 - List all Kafka instances
 * [rhoas kafka topic](rhoas_kafka_topic.md)	 - Create, describe, update, list, and delete topics
-* [rhoas kafka update](rhoas_kafka_update.md)	 - Update configuration details of a Kafka instance.
+* [rhoas kafka update](rhoas_kafka_update.md)	 - Update configuration details for a Kafka instance.
 * [rhoas kafka use](rhoas_kafka_use.md)	 - Set the current Kafka instance
 

--- a/docs/commands/rhoas_kafka_update.md
+++ b/docs/commands/rhoas_kafka_update.md
@@ -1,13 +1,10 @@
 ## rhoas kafka update
 
-Update configuration details of a Kafka instance.
+Update configuration details for a Kafka instance.
 
 ### Synopsis
 
-Update certain configuration details of a Kafka instance.
-
-Currently it is possible to update the "owner" field. The new owner 
-will be authorized to manage this instance.
+Update configuration details for a Kafka instance. By modifying these settings, you can configure your Kafka instances to suit your particular environment.
 
 
 ```
@@ -17,16 +14,16 @@ rhoas kafka update [flags]
 ### Examples
 
 ```
-# update the Kafka instance owner
+# Update the Kafka instance owner
 $ rhoas kafka update --name=my-kafka --owner=other-user
 
-# update the owner of the current Kafka instance
+# Update the owner of the current Kafka instance
 $ rhoas kafka update --owner=other-user
 
-# update the reauthentication configuration of the current Kafka instance
+# Update the reauthentication configuration of the current Kafka instance
 $ rhoas kafka update --reauthentication=true
 
-# update the current Kafka instance in interactive mode
+# Update the current Kafka instance in interactive mode
 $ rhoas kafka update
 
 ```
@@ -37,7 +34,7 @@ $ rhoas kafka update
       --id string                  Unique ID of the Kafka instance you want to update
       --name string                Name of the Kafka instance you want to update
       --owner string               ID of the user you want to set as the owner of this Kafka instance
-      --reauthentication Tribool   Enable connection reauthentication for the Kafka instance
+      --reauthentication Tribool   Enable or disable connection reauthentication for the Kafka instance
   -y, --yes                        Skip confirmation of this action 
 ```
 

--- a/pkg/core/localize/locales/en/cmd/kafka_update.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka_update.en.toml
@@ -1,29 +1,26 @@
 [kafka.update.cmd.shortDescription]
 description = "Short description for command"
-one = "Update configuration details of a Kafka instance."
+one = "Update configuration details for a Kafka instance."
 
 [kafka.update.cmd.longDescription]
 description = "Long description for command"
 one = '''
-Update certain configuration details of a Kafka instance.
-
-Currently it is possible to update the "owner" field. The new owner 
-will be authorized to manage this instance.
+Update configuration details for a Kafka instance. By modifying these settings, you can configure your Kafka instances to suit your particular environment.
 '''
 
 [kafka.update.cmd.examples]
 description = 'Examples of how to use the command'
 one = '''
-# update the Kafka instance owner
+# Update the Kafka instance owner
 $ rhoas kafka update --name=my-kafka --owner=other-user
 
-# update the owner of the current Kafka instance
+# Update the owner of the current Kafka instance
 $ rhoas kafka update --owner=other-user
 
-# update the reauthentication configuration of the current Kafka instance
+# Update the reauthentication configuration of the current Kafka instance
 $ rhoas kafka update --reauthentication=true
 
-# update the current Kafka instance in interactive mode
+# Update the current Kafka instance in interactive mode
 $ rhoas kafka update
 '''
 
@@ -40,7 +37,7 @@ description = 'Description for the --owner flag'
 one = 'ID of the user you want to set as the owner of this Kafka instance'
 
 [kafka.update.flag.reauthentication]
-one = 'Enable connection reauthentication for the Kafka instance'
+one = 'Enable or disable connection reauthentication for the Kafka instance'
 
 [kafka.update.flag.yes]
 one = 'Forcibly update the Kafka instance without confirmation'
@@ -50,12 +47,7 @@ one = 'Summary of Proposed Changes'
 
 [kafka.update.reauthentication.disclaimer]
 one = '''
-This change can affect your Kafka security if a bad actor obtains credentials or service account to Kafka instance that has disabled reauthentication,
-deactivating the user account or service account will not disconnect already established connections.
-
-Options to disconnect client when reauthentication is disabled:
-* Use ACLs to prevent unauthorized connections from performing any operation
-* Create support case for RHOSAK product
+This change can affect the security of your Kafka instance. If an attacker obtains credentials to your Kafka instance, they will be able to stay connected indefinitely. Deactivating the user account or service account will not close the connections that the attacker has opened. In this scenario, you would need to add Access Control List rules (ACLs) to prevent the unauthorized connections from performing any operations. You could also contact Red Hat Support for assistance.
 '''
 
 [kafka.update.confirmDialog.message]


### PR DESCRIPTION
As I'm writing the doc for the new re-authenticate connection setting in the web console UI, I updated the CLI help text to match.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
