### PR TITLE
docs: fix list of available service registry settings

### DIFF
--- a/docs/commands/rhoas_service-registry_setting.md
+++ b/docs/commands/rhoas_service-registry_setting.md
@@ -9,15 +9,15 @@ configure settings for a Service Registry instance.
 
 The available settings include the following options: 
 
+* registry.auth.authenticated-read-access.enabled - Specifies whether Service Registry grants at least 
+  read-only access to requests from any authenticated user in the same organization, regardless of their 
+  user role. Defaults to false.  
 * registry.auth.basic-auth-client-credentials.enabled - Specifies whether Service Registry users can 
   authenticate using HTTP basic authentication, in addition to OAuth. Defaults to true.
-* registry.auth.owner-only-authorization - Specifies whether only the user who creates an artifact can modify 
-  that artifact. Defaults to false. 
-* registry.auth.owner-only-authorization.limit-group-access - When registry.auth.owner-only-authorization is 
-  set to true, specifies whether only the user who creates an artifact group has write access to that artifact 
-  group, for example, to add or remove artifacts. Defaults to false.  
-* registry.ccompat.legacy-id-mode.enabled - Specifies whether the Confluent Schema Registry compatibility API 
-  uses globalId instead of contentId as an artifact identifier. Defaults to false.
+* registry.auth.owner-only-authorization - Specifies whether only the user who creates an artifact can 
+  modify that artifact. Defaults to false. 
+* registry.ccompat.legacy-id-mode.enabled - Specifies whether the Confluent Schema Registry compatibility 
+  API uses globalId instead of contentId as an artifact identifier. Defaults to false.
 
 
 ### Examples

--- a/pkg/core/localize/locales/en/cmd/setting.en.toml
+++ b/pkg/core/localize/locales/en/cmd/setting.en.toml
@@ -8,15 +8,15 @@ configure settings for a Service Registry instance.
 
 The available settings include the following options: 
 
+* registry.auth.authenticated-read-access.enabled - Specifies whether Service Registry grants at least 
+  read-only access to requests from any authenticated user in the same organization, regardless of their 
+  user role. Defaults to false.  
 * registry.auth.basic-auth-client-credentials.enabled - Specifies whether Service Registry users can 
   authenticate using HTTP basic authentication, in addition to OAuth. Defaults to true.
-* registry.auth.owner-only-authorization - Specifies whether only the user who creates an artifact can modify 
-  that artifact. Defaults to false. 
-* registry.auth.owner-only-authorization.limit-group-access - When registry.auth.owner-only-authorization is 
-  set to true, specifies whether only the user who creates an artifact group has write access to that artifact 
-  group, for example, to add or remove artifacts. Defaults to false.  
-* registry.ccompat.legacy-id-mode.enabled - Specifies whether the Confluent Schema Registry compatibility API 
-  uses globalId instead of contentId as an artifact identifier. Defaults to false.
+* registry.auth.owner-only-authorization - Specifies whether only the user who creates an artifact can 
+  modify that artifact. Defaults to false. 
+* registry.ccompat.legacy-id-mode.enabled - Specifies whether the Confluent Schema Registry compatibility 
+  API uses globalId instead of contentId as an artifact identifier. Defaults to false.
 '''
 
 [setting.cmd.example]


### PR DESCRIPTION
Document `registry.auth.authenticated-read-access.enabled` setting 
(i.e., instead of `registry.auth.owner-only-authorization.limit-group-access`, which is an Apicurio-only setting)

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
