### PR TITLE
fix: remove mas-auth  url

### DIFF
--- a/docs/commands/rhoas_login.md
+++ b/docs/commands/rhoas_login.md
@@ -34,14 +34,13 @@ $ rhoas login --token f5cgc...
 ### Options
 
 ```
-      --api-gateway string    URL of the API gateway (default "https://api.openshift.com")
-      --auth-url string       The URL of the SSO Authentication server (default "https://sso.redhat.com/auth/realms/redhat-external")
-      --client-id string      OpenID client identifier (default "rhoas-cli-prod")
-      --insecure              Allow insecure communication with the server by disabling TLS certificate and host name verification
-      --mas-auth-url string   Unused: This flag is no longer valid and will be removed in a future release
-      --print-sso-url         Print the console login URL, which you can use to log in to RHOAS from a different web browser (this is useful if you need to log in with different credentials than the credentials you used in your default web browser)
-      --scope stringArray     Override the default OpenID scope (to specify multiple scopes, use a separate --scope for each scope) (default [openid])
-  -t, --token string          Log in using an offline token, which can be obtained at https://console.redhat.com/openshift/token
+      --api-gateway string   URL of the API gateway (default "https://api.openshift.com")
+      --auth-url string      The URL of the SSO Authentication server (default "https://sso.redhat.com/auth/realms/redhat-external")
+      --client-id string     OpenID client identifier (default "rhoas-cli-prod")
+      --insecure             Allow insecure communication with the server by disabling TLS certificate and host name verification
+      --print-sso-url        Print the console login URL, which you can use to log in to RHOAS from a different web browser (this is useful if you need to log in with different credentials than the credentials you used in your default web browser)
+      --scope stringArray    Override the default OpenID scope (to specify multiple scopes, use a separate --scope for each scope) (default [openid])
+  -t, --token string         Log in using an offline token, which can be obtained at https://console.redhat.com/openshift/token
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// When the value of the `--api-gateway` option is one of the keys of this map it will be replaced by the
+// When tzhe value of the `--api-gateway` option is one of the keys of this map it will be replaced by the
 // corresponding value.
 var apiGatewayAliases = map[string]string{
 	"production": build.ProductionAPIURL,
@@ -52,7 +52,6 @@ type options struct {
 
 	url                   string
 	authURL               string
-	deprecatedUrl         string
 	clientID              string
 	scopes                []string
 	insecureSkipTLSVerify bool

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -94,7 +94,6 @@ func NewLoginCmd(f *factory.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.insecureSkipTLSVerify, "insecure", false, opts.localizer.MustLocalize("login.flag.insecure"))
 	cmd.Flags().StringVar(&opts.clientID, "client-id", build.DefaultClientID, opts.localizer.MustLocalize("login.flag.clientId"))
 	cmd.Flags().StringVar(&opts.authURL, "auth-url", build.ProductionAuthURL, opts.localizer.MustLocalize("login.flag.authUrl"))
-	cmd.Flags().StringVar(&opts.deprecatedUrl, "mas-auth-url", "", opts.localizer.MustLocalize("login.flag.masAuthUrl"))
 	cmd.Flags().BoolVar(&opts.printURL, "print-sso-url", false, opts.localizer.MustLocalize("login.flag.printSsoUrl"))
 	cmd.Flags().StringArrayVar(&opts.scopes, "scope", kcconnection.DefaultScopes, opts.localizer.MustLocalize("login.flag.scope"))
 	cmd.Flags().StringVarP(&opts.offlineToken, "token", "t", "", opts.localizer.MustLocalize("login.flag.token", localize.NewEntry("OfflineTokenURL", build.OfflineTokenURL)))

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// When tzhe value of the `--api-gateway` option is one of the keys of this map it will be replaced by the
+// When the value of the `--api-gateway` option is one of the keys of this map it will be replaced by the
 // corresponding value.
 var apiGatewayAliases = map[string]string{
 	"production": build.ProductionAPIURL,

--- a/pkg/core/localize/locales/en/cmd/login.en.toml
+++ b/pkg/core/localize/locales/en/cmd/login.en.toml
@@ -43,9 +43,6 @@ one = 'OpenID client identifier'
 description = 'Description for the --auth-url flag'
 one = "The URL of the SSO Authentication server"
 
-[login.flag.masAuthUrl]
-one = "Unused: This flag is no longer valid and will be removed in a future release"
-
 [login.flag.token]
 one = "Log in using an offline token, which can be obtained at {{.OfflineTokenURL}}"
 
@@ -64,10 +61,6 @@ one = 'Welcome to RHOAS'
 [login.redirectPage.body]
 description = 'Title for the RHOAS login redirect webpage'
 one = 'You are now logged in as <span style="font-weight:700">{{.Username}}</span>.'
-
-[login.masRedirectPage.body]
-description = 'Title for the identity.api.openshift.com login redirect webpage'
-one = 'You are now logged in to <span style="font-weight:700">{{.Host}}</span> as <span style="font-weight:700">{{.Username}}</span>.'
 
 [login.error.schemeMissingFromUrl]
 description = 'Error message for when scheme is missing from the Auth URL'

--- a/pkg/shared/connection/kcconnection/errors.go
+++ b/pkg/shared/connection/kcconnection/errors.go
@@ -10,19 +10,7 @@ type AuthError struct {
 	Err error
 }
 
-type MasAuthError struct {
-	Err error
-}
-
 func (e *AuthError) Error() string {
-	return fmt.Sprintf("%v", e.Err)
-}
-
-func (e *MasAuthError) Unwrap() error {
-	return e.Err
-}
-
-func (e *MasAuthError) Error() string {
 	return fmt.Sprintf("%v", e.Err)
 }
 


### PR DESCRIPTION
URL is no longer valid and have been included in +2 releases as deprecated. We can remove it