### PR TITLE
feat: added info on pageination in type list

### DIFF
--- a/pkg/cmd/connector/connector_type/list/list.go
+++ b/pkg/cmd/connector/connector_type/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/redhat-developer/app-services-cli/internal/build"
@@ -111,6 +112,10 @@ func runUpdateCommand(opts *options) error {
 			return err
 		}
 	}
+
+	start := (opts.page - 1) * opts.limit
+	end := start + len(rows)
+	opts.f.Logger.Info(fmt.Sprintf("[%v %v : %v - %v]", opts.f.Localizer.MustLocalize("connector.common.page.prompt"), opts.page, start, end))
 
 	return nil
 }

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -611,3 +611,6 @@ one = 'Unexpected error occured when updating connector'
 [connector.update.info.editor.open]
 one = 'Opening a text editor to edit connector details, close the editor to continue'
 
+[connector.common.page.prompt]
+one = 'Page'
+


### PR DESCRIPTION
Adds some info on the output of connector type list on where the current list is in relation to the pages.

Before
```
.
.
.
{
    "name": "Apache Cassandra sink",
    "id": "cassandra_sink_0.1",
    "description": "Send data to an Apache Cassandra cluster."
}
{
    "name": "Apache Cassandra source",
    "id": "cassandra_source_0.1",
    "description": "Retrieve data by sending a query to an Apache Cassandra cluster table."
}
{
    "name": "Azure Blob Storage change feed source",
    "id": "azure_storage_blob_changefeed_source_0.1",
    "description": "Receive data from Azure Blob storage change feed."
}
{
    "name": "Azure Blob Storage sink",
    "id": "azure_storage_blob_sink_0.1",
    "description": "Send data to Azure Blob storage."
}
{
    "name": "Azure Blob Storage source",
    "id": "azure_storage_blob_source_0.1",
    "description": "Receive data from Azure Blob storage."
}
```

After
```
.
.
.
{
    "name": "Apache Cassandra source",
    "id": "cassandra_source_0.1",
    "description": "Retrieve data by sending a query to an Apache Cassandra cluster table."
}
{
    "name": "Azure Blob Storage change feed source",
    "id": "azure_storage_blob_changefeed_source_0.1",
    "description": "Receive data from Azure Blob storage change feed."
}
{
    "name": "Azure Blob Storage sink",
    "id": "azure_storage_blob_sink_0.1",
    "description": "Send data to Azure Blob storage."
}
{
    "name": "Azure Blob Storage source",
    "id": "azure_storage_blob_source_0.1",
    "description": "Receive data from Azure Blob storage."
}
[page 2 : 10 - 20]
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
