### PR TITLE
feat: new connector commands are now not hidden

### DIFF
--- a/docs/commands/rhoas_connector.md
+++ b/docs/commands/rhoas_connector.md
@@ -50,12 +50,16 @@ rhoas connector stop
 ### SEE ALSO
 
 * [rhoas](rhoas.md)	 - RHOAS CLI
+* [rhoas connector build](rhoas_connector_build.md)	 - Build a Connectors instance
 * [rhoas connector cluster](rhoas_connector_cluster.md)	 - Create, delete, and list Connectors clusters
+* [rhoas connector create](rhoas_connector_create.md)	 - Create a Connectors instance
 * [rhoas connector delete](rhoas_connector_delete.md)	 - Delete a Connectors instance
+* [rhoas connector describe](rhoas_connector_describe.md)	 - Get the details for the Connectors instance
 * [rhoas connector list](rhoas_connector_list.md)	 - List of Connectors instances
 * [rhoas connector namespace](rhoas_connector_namespace.md)	 - Connectors namespace commands
 * [rhoas connector start](rhoas_connector_start.md)	 - Start a Connectors instance
 * [rhoas connector stop](rhoas_connector_stop.md)	 - Stop a Connectors instance
 * [rhoas connector type](rhoas_connector_type.md)	 - List and get details of different connector types
+* [rhoas connector update](rhoas_connector_update.md)	 - Update a Connectors instance
 * [rhoas connector use](rhoas_connector_use.md)	 - Set the current Connectors instance
 

--- a/docs/commands/rhoas_connector_build.md
+++ b/docs/commands/rhoas_connector_build.md
@@ -1,0 +1,48 @@
+## rhoas connector build
+
+Build a Connectors instance
+
+### Synopsis
+
+Command builds specficication for Connector 
+instance that can be later created using create command.
+
+
+```
+rhoas connector build [flags]
+```
+
+### Examples
+
+```
+# Build a Connectors instance
+rhoas connector build --type=--type=aws_lambda_sink_0.1
+
+# Build a Connectors instance with a name of my_connector
+rhoas connector build --name=my_connector --type=--type=aws_lambda_sink_0.1
+
+cat myconnector.json | rhoas connector create
+
+```
+
+### Options
+
+```
+      --name string          name of the connector
+  -o, --output string        Specify the output format. Choose from: "json", "yaml", "yml"
+      --output-file string   filename of the connector specification file
+      --overwrite            should overwrite file if exist
+      --type string          Connector type (id of the connector)
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas connector](rhoas_connector.md)	 - Connectors instance commands
+

--- a/docs/commands/rhoas_connector_create.md
+++ b/docs/commands/rhoas_connector_create.md
@@ -1,0 +1,42 @@
+## rhoas connector create
+
+Create a Connectors instance
+
+### Synopsis
+
+Create a Connectors instance
+
+```
+rhoas connector create [flags]
+```
+
+### Examples
+
+```
+# Create a Connectors instance
+rhoas connector create --file=myconnector.json
+
+```
+
+### Options
+
+```
+      --create-service-account   If set, the connector will be created with the newly specified service account
+  -f, --file string              Location of the Connectors JSON file that describes the connector
+      --kafka string             Id of the kafka instance (by default kafka instance from context would be used)
+      --name string              Override name of the connector (by default name in the connector spec would be used)
+      --namespace string         Id of the namespace for the connector (by default namespace from context would be used)
+  -o, --output string            Specify the output format. Choose from: "json", "yaml", "yml"
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas connector](rhoas_connector.md)	 - Connectors instance commands
+

--- a/docs/commands/rhoas_connector_describe.md
+++ b/docs/commands/rhoas_connector_describe.md
@@ -1,0 +1,38 @@
+## rhoas connector describe
+
+Get the details for the Connectors instance
+
+### Synopsis
+
+Get the details for the Connectors instance by specifying its ID. Use the "connector list" command to see a list of all Connectors instances and their ID values.
+
+```
+rhoas connector describe [flags]
+```
+
+### Examples
+
+```
+# Get the Connectors instance details
+rhoas connector describe --id=c980124otd37bufiemj0
+
+```
+
+### Options
+
+```
+      --id string       The ID for the Connectors instance
+  -o, --output string   Specify the output format. Choose from: "json", "yaml", "yml"
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas connector](rhoas_connector.md)	 - Connectors instance commands
+

--- a/docs/commands/rhoas_connector_update.md
+++ b/docs/commands/rhoas_connector_update.md
@@ -1,0 +1,53 @@
+## rhoas connector update
+
+Update a Connectors instance
+
+### Synopsis
+
+Update a Connectors instance
+
+Allows you to change the details of a already existing connectors instance.
+By changing its configuration in a text editor. To change which editor use
+edit the EDITOR environment variable. Below are some comman editors you may
+use.
+
+export EDITOR=nvim
+export EDITOR=vim
+export EDITOR="code -w"
+
+
+```
+rhoas connector update [flags]
+```
+
+### Examples
+
+```
+# Update a Connectors instance
+rhoas connector update --id=my-connector --file=myconnector.json
+
+# Update a Connectors instance from stdin
+cat myconnector.json | rhoas connector update
+
+```
+
+### Options
+
+```
+      --kafka-id string       ID of of the namespace you want the connector to be updated to
+      --name string           Override name of the connector (by default name in the connector spec would be used)
+      --namespace-id string   ID of of the kafka you want the connector to be updated to
+  -o, --output string         Specify the output format. Choose from: "json", "yaml", "yml"
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas connector](rhoas_connector.md)	 - Connectors instance commands
+

--- a/pkg/cmd/connector/build/build.go
+++ b/pkg/cmd/connector/build/build.go
@@ -42,7 +42,7 @@ func NewBuildCommand(f *factory.Factory) *cobra.Command {
 		Short:   f.Localizer.MustLocalize("connector.build.cmd.shortDescription"),
 		Long:    f.Localizer.MustLocalize("connector.build.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.build.cmd.example"),
-		Hidden:  true,
+		Hidden:  false,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validOutputFormats := flagutil.ValidOutputFormats

--- a/pkg/cmd/connector/connector.go
+++ b/pkg/cmd/connector/connector.go
@@ -40,8 +40,6 @@ func NewConnectorsCommand(f *factory.Factory) *cobra.Command {
 		stop.NewStopCommand(f),
 		connector_type.NewTypeCommand(f),
 		list.NewListCommand(f),
-
-		// Hidden for the users and docs at the moment
 		create.NewCreateCommand(f),
 		build.NewBuildCommand(f),
 		delete.NewDeleteCommand(f),

--- a/pkg/cmd/connector/create/create.go
+++ b/pkg/cmd/connector/create/create.go
@@ -52,7 +52,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 		Short:   f.Localizer.MustLocalize("connector.create.cmd.shortDescription"),
 		Long:    f.Localizer.MustLocalize("connector.create.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.create.cmd.example"),
-		Hidden:  true,
+		Hidden:  false,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validOutputFormats := flagutil.ValidOutputFormats

--- a/pkg/cmd/connector/delete/delete.go
+++ b/pkg/cmd/connector/delete/delete.go
@@ -36,6 +36,7 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 		Short:   f.Localizer.MustLocalize("connector.delete.cmd.shortDescription"),
 		Long:    f.Localizer.MustLocalize("connector.delete.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.delete.cmd.example"),
+		Hidden:  false,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validOutputFormats := flagutil.ValidOutputFormats

--- a/pkg/cmd/connector/describe/describe.go
+++ b/pkg/cmd/connector/describe/describe.go
@@ -30,7 +30,7 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 		Long:    f.Localizer.MustLocalize("connector.describe.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.describe.cmd.example"),
 		Args:    cobra.NoArgs,
-		Hidden:  true,
+		Hidden:  false,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			validOutputFormats := flagutil.ValidOutputFormats

--- a/pkg/cmd/connector/update/update.go
+++ b/pkg/cmd/connector/update/update.go
@@ -36,7 +36,7 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 		Long:    f.Localizer.MustLocalize("connector.update.cmd.longDescription"),
 		Example: f.Localizer.MustLocalize("connector.update.cmd.example"),
 		Args:    cobra.NoArgs,
-		Hidden:  true,
+		Hidden:  false,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			validOutputFormats := flagutil.ValidOutputFormats
 			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, validOutputFormats...) {


### PR DESCRIPTION
This PR makes the new connectors command that were added in the last release not hidden.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Enter `rhoas connector` and use TAB for auto suggestions, you will be prompt with a list. Verify options such as `create`, `build` are there.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
