### PR TITLE
fix: make request command public

### DIFF
--- a/docs/commands/rhoas.md
+++ b/docs/commands/rhoas.md
@@ -45,6 +45,7 @@ $ rhoas cluster connect
 * [rhoas kafka](rhoas_kafka.md)	 - Create, view, use, and manage your Kafka instances
 * [rhoas login](rhoas_login.md)	 - Log in to RHOAS
 * [rhoas logout](rhoas_logout.md)	 - Log out from RHOAS
+* [rhoas request](rhoas_request.md)	 - Allows you to perform API requests against the API server
 * [rhoas service-account](rhoas_service-account.md)	 - Create, list, describe, delete, and update service accounts
 * [rhoas service-registry](rhoas_service-registry.md)	 - Service Registry commands
 * [rhoas status](rhoas_status.md)	 - View the status of application services in a service context

--- a/docs/commands/rhoas_request.md
+++ b/docs/commands/rhoas_request.md
@@ -1,0 +1,37 @@
+## rhoas request
+
+Allows you to perform API requests against the API server
+
+```
+rhoas request [flags]
+```
+
+### Examples
+
+```
+
+		  # Perform a GET request to the specified path
+		  rhoas request --path /api/kafkas_mgmt/v1/kafkas
+		  
+		  # Perform a POST request to the specified path
+		  cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post 
+```
+
+### Options
+
+```
+      --method string   HTTP method to use. (get, post) (default "GET")
+      --path string     Path to send request. For example /api/kafkas_mgmt/v1/kafkas?async=true
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas](rhoas.md)	 - RHOAS CLI
+

--- a/docs/commands/rhoas_request.md
+++ b/docs/commands/rhoas_request.md
@@ -2,6 +2,10 @@
 
 Allows you to perform API requests against the API server
 
+### Synopsis
+
+Command allows users you to perform API requests against the API server.
+
 ```
 rhoas request [flags]
 ```
@@ -14,7 +18,7 @@ rhoas request [flags]
 		  rhoas request --path /api/kafkas_mgmt/v1/kafkas
 		  
 		  # Perform a POST request to the specified path
-		  cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post 
+		  # cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post 
 ```
 
 ### Options

--- a/pkg/cmd/request/request.go
+++ b/pkg/cmd/request/request.go
@@ -42,7 +42,6 @@ func NewCallCmd(f *factory.Factory) *cobra.Command {
 		  
 		  # Perform a POST request to the specified path
 		  cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post `,
-		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCmd(opts)

--- a/pkg/cmd/request/request.go
+++ b/pkg/cmd/request/request.go
@@ -36,13 +36,14 @@ func NewCallCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request",
 		Short: "Allows you to perform API requests against the API server",
+		Long:  "Command allows users you to perform API requests against the API server.",
 		Example: `
 		  # Perform a GET request to the specified path
 		  rhoas request --path /api/kafkas_mgmt/v1/kafkas
 		  
 		  # Perform a POST request to the specified path
-		  cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post `,
-		Args:   cobra.NoArgs,
+		  # cat request.json | rhoas request --path "/api/kafkas_mgmt/v1/kafkas?async=true" --method post `,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCmd(opts)
 		},


### PR DESCRIPTION
When chatting with @dimakis we seen that request command is not public. adding this as PR instead of issue as change is trivial