### PR TITLE
Supporting gitops

### DIFF
--- a/docs/commands/rhoas_kafka.md
+++ b/docs/commands/rhoas_kafka.md
@@ -41,11 +41,13 @@ rhoas kafka topic create --name mytopic
 
 * [rhoas](rhoas.md)	 - RHOAS CLI
 * [rhoas kafka acl](rhoas_kafka_acl.md)	 - Manage Kafka ACLs for users and service accounts
+* [rhoas kafka billing](rhoas_kafka_billing.md)	 - List Kafka Billing Types
 * [rhoas kafka consumer-group](rhoas_kafka_consumer-group.md)	 - Describe, list, and delete consumer groups for the current Kafka instance
 * [rhoas kafka create](rhoas_kafka_create.md)	 - Create a Kafka instance
 * [rhoas kafka delete](rhoas_kafka_delete.md)	 - Delete a Kafka instance
 * [rhoas kafka describe](rhoas_kafka_describe.md)	 - View configuration details of a Kafka instance
 * [rhoas kafka list](rhoas_kafka_list.md)	 - List all Kafka instances
+* [rhoas kafka providers](rhoas_kafka_providers.md)	 - List Kafka Cloud Providers
 * [rhoas kafka topic](rhoas_kafka_topic.md)	 - Create, describe, update, list, and delete topics
 * [rhoas kafka update](rhoas_kafka_update.md)	 - Update configuration details for a Kafka instance.
 * [rhoas kafka use](rhoas_kafka_use.md)	 - Set the current Kafka instance

--- a/docs/commands/rhoas_kafka_billing.md
+++ b/docs/commands/rhoas_kafka_billing.md
@@ -1,0 +1,39 @@
+## rhoas kafka billing
+
+List Kafka Billing Types
+
+### Synopsis
+
+List Kafka Billing Types
+
+
+```
+rhoas kafka billing [flags]
+```
+
+### Examples
+
+```
+# List billing types
+$ rhoas kafka billing 
+
+
+```
+
+### Options
+
+```
+  -o, --output string   Specify the output format. Choose from: "json", "yaml", "yml"
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas kafka](rhoas_kafka.md)	 - Create, view, use, and manage your Kafka instances
+

--- a/docs/commands/rhoas_kafka_providers.md
+++ b/docs/commands/rhoas_kafka_providers.md
@@ -1,0 +1,41 @@
+## rhoas kafka providers
+
+List Kafka Cloud Providers
+
+### Synopsis
+
+List all enabled Cloud Providers and Regions for Kafka deployment
+
+
+```
+rhoas kafka providers [flags]
+```
+
+### Examples
+
+```
+# List all providers using the default output format
+$ rhoas kafka providers 
+
+# List all providersin JSON format
+$ rhoas kafka providers  -o json
+
+```
+
+### Options
+
+```
+  -o, --output string   Specify the output format. Choose from: "json", "yaml", "yml"
+```
+
+### Options inherited from parent commands
+
+```
+  -h, --help      Show help for a command
+  -v, --verbose   Enable verbose mode
+```
+
+### SEE ALSO
+
+* [rhoas kafka](rhoas_kafka.md)	 - Create, view, use, and manage your Kafka instances
+

--- a/pkg/cmd/kafka/billing/billing.go
+++ b/pkg/cmd/kafka/billing/billing.go
@@ -1,0 +1,73 @@
+package billing
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create"
+	kafkaFlagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+
+	"github.com/spf13/cobra"
+)
+
+// row is the details of a Kafka instance needed to print to a table
+type billingRow struct {
+	BillingType string `json:"billing" header:"Billing"`
+}
+
+type options struct {
+	outputFormat string
+
+	f              *factory.Factory
+	ServiceContext servicecontext.IContext
+}
+
+// NewListCommand creates a new command for listing kafkas.
+func NewBillingCommand(f *factory.Factory) *cobra.Command {
+	opts := &options{
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "billing",
+		Short:   opts.f.Localizer.MustLocalize("kafka.billing.cmd.shortDescription"),
+		Long:    opts.f.Localizer.MustLocalize("kafka.billing.cmd.longDescription"),
+		Example: opts.f.Localizer.MustLocalize("kafka.billing.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, flagutil.ValidOutputFormats...) {
+				return flagutil.InvalidValueError("output", opts.outputFormat, flagutil.ValidOutputFormats...)
+			}
+
+			return runList(opts)
+		},
+	}
+
+	flags := kafkaFlagutil.NewFlagSet(cmd, opts.f.Localizer)
+
+	flags.AddOutput(&opts.outputFormat)
+
+	return cmd
+}
+
+func runList(opts *options) error {
+	billingTypes, _ := create.GetBillingModelCompletionValues(opts.f)
+
+	providersArray := make([]billingRow, 0, 10)
+	for _, billing := range billingTypes {
+		providersArray = append(providersArray, billingRow{
+			BillingType: billing,
+		})
+	}
+
+	switch opts.outputFormat {
+	case dump.EmptyFormat:
+		dump.Table(opts.f.IOStreams.Out, providersArray)
+		opts.f.Logger.Info("")
+	default:
+		return dump.Formatted(opts.f.IOStreams.Out, opts.outputFormat, providersArray)
+	}
+	return nil
+}

--- a/pkg/cmd/kafka/billing/billing.go
+++ b/pkg/cmd/kafka/billing/billing.go
@@ -27,7 +27,7 @@ type options struct {
 // NewListCommand creates a new command for listing kafkas.
 func NewBillingCommand(f *factory.Factory) *cobra.Command {
 	opts := &options{
-		ServiceContext: f.ServiceContext,
+		f: f,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/kafka/billing/billing.go
+++ b/pkg/cmd/kafka/billing/billing.go
@@ -56,10 +56,16 @@ func runList(opts *options) error {
 	billingTypes, _ := create.GetBillingModelCompletionValues(opts.f)
 
 	providersArray := make([]billingRow, 0, 10)
-	for _, billing := range billingTypes {
+	if len(billingTypes) == 0 {
 		providersArray = append(providersArray, billingRow{
-			BillingType: billing,
+			BillingType: create.DeveloperType,
 		})
+	} else {
+		for _, billing := range billingTypes {
+			providersArray = append(providersArray, billingRow{
+				BillingType: billing,
+			})
+		}
 	}
 
 	switch opts.outputFormat {

--- a/pkg/cmd/kafka/billing/billing.go
+++ b/pkg/cmd/kafka/billing/billing.go
@@ -1,20 +1,27 @@
 package billing
 
 import (
+	"fmt"
+
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create"
 	kafkaFlagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/accountmgmtutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/remote"
 
 	"github.com/spf13/cobra"
 )
 
 // row is the details of a Kafka instance needed to print to a table
 type billingRow struct {
-	BillingType string `json:"billing" header:"Billing"`
+	CloudProvider string `json:"cloud_provider" header:"Cloud Provider"`
+	Region        string `json:"region" header:"Region"`
+	BillingType   string `json:"billing" header:"Billing"`
+	Plan          string `json:"plan" header:"Plan"`
 }
 
 type options struct {
@@ -53,27 +60,70 @@ func NewBillingCommand(f *factory.Factory) *cobra.Command {
 }
 
 func runList(opts *options) error {
-	billingTypes, _ := create.GetBillingModelCompletionValues(opts.f)
 
-	providersArray := make([]billingRow, 0, 10)
+	err, constants := remote.GetRemoteServiceConstants(opts.f.Context, opts.f.Logger)
+	if err != nil {
+		return err
+	}
+
+	orgQuotas, err := accountmgmtutil.GetOrgQuotas(opts.f, &constants.Kafka.Ams)
+	if err != nil {
+		return err
+	}
+
+	billingTypes := create.FetchSupportedBillingModels(orgQuotas)
+
+	billingArray := make([]billingRow, 0, 10)
 	if len(billingTypes) == 0 {
-		providersArray = append(providersArray, billingRow{
+		billingArray = append(billingArray, billingRow{
 			BillingType: create.DeveloperType,
 		})
 	} else {
-		for _, billing := range billingTypes {
-			providersArray = append(providersArray, billingRow{
-				BillingType: billing,
-			})
+
+		quotas := append(orgQuotas.MarketplaceQuotas, orgQuotas.StandardQuotas...)
+
+		for _, quota := range quotas {
+
+			providers, err := create.GetEnabledCloudProviderNames(opts.f)
+			if err != nil {
+				return err
+			}
+			for _, providerId := range providers {
+				regions, err := create.GetEnabledCloudRegionIDs(opts.f, providerId, nil)
+				if err != nil {
+					return err
+				}
+				for _, region := range regions {
+					kafkaSizes, _ := create.FetchValidKafkaSizes(opts.f, "aws", "us-east-1", quota)
+					sizeLabels := create.GetValidKafkaSizesLabels(kafkaSizes)
+					for _, sizeLabel := range sizeLabels {
+						billingArray = append(billingArray, billingRow{
+							CloudProvider: providerId,
+							Region:        region,
+							BillingType:   quota.BillingModel,
+							Plan:          fmt.Sprintf("%s.%s", quota.BillingModel, sizeLabel),
+						})
+					}
+				}
+			}
+
 		}
+		// for _, billing := range billingTypes {
+
+		// 	kafkaSizes := create.FetchValidKafkaSizes(opts.f, "aws", "us-east-1", orgQuotas)
+
+		// 	billingArray = append(billingArray, billingRow{
+		// 		BillingType: billing,
+		// 	})
+		// }
 	}
 
 	switch opts.outputFormat {
 	case dump.EmptyFormat:
-		dump.Table(opts.f.IOStreams.Out, providersArray)
+		dump.Table(opts.f.IOStreams.Out, billingArray)
 		opts.f.Logger.Info("")
 	default:
-		return dump.Formatted(opts.f.IOStreams.Out, opts.outputFormat, providersArray)
+		return dump.Formatted(opts.f.IOStreams.Out, opts.outputFormat, billingArray)
 	}
 	return nil
 }

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -477,15 +477,10 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		return nil, err
 	}
 
-	orgQuotaJSON, _ := json.Marshal(orgQuota)
-	fmt.Println(string(orgQuotaJSON))
-
 	availableBillingModels := FetchSupportedBillingModels(orgQuota)
-	fmt.Println(availableBillingModels)
 
 	if len(availableBillingModels) > 0 {
 		if len(availableBillingModels) == 1 {
-			fmt.Println("inside billing model")
 			answers.BillingModel = availableBillingModels[0]
 		} else {
 			billingModelPrompt := &survey.Select{

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -477,10 +477,15 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		return nil, err
 	}
 
+	orgQuotaJSON, _ := json.Marshal(orgQuota)
+	fmt.Println(string(orgQuotaJSON))
+
 	availableBillingModels := FetchSupportedBillingModels(orgQuota)
+	fmt.Println(availableBillingModels)
 
 	if len(availableBillingModels) > 0 {
 		if len(availableBillingModels) == 1 {
+			fmt.Println("inside billing model")
 			answers.BillingModel = availableBillingModels[0]
 		} else {
 			billingModelPrompt := &survey.Select{

--- a/pkg/cmd/kafka/create/data.go
+++ b/pkg/cmd/kafka/create/data.go
@@ -1,6 +1,9 @@
 package create
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/redhat-developer/app-services-cli/pkg/shared/accountmgmtutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/client"
@@ -124,6 +127,10 @@ func FetchValidKafkaSizes(f *factory.Factory,
 	if err != nil {
 		return nil, err
 	}
+
+	instanceTypesJson, _ := json.Marshal(instanceTypes)
+
+	fmt.Println("instance Types", string(instanceTypesJson))
 
 	desiredInstanceType := mapAmsTypeToBackendType(&amsType)
 

--- a/pkg/cmd/kafka/kafka.go
+++ b/pkg/cmd/kafka/kafka.go
@@ -5,11 +5,13 @@ package kafka
 import (
 	"github.com/redhat-developer/app-services-cli/internal/doc"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/acl"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/billing"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/consumergroup"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/delete"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/describe"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/list"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/providers"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/topic"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/update"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/use"
@@ -38,6 +40,8 @@ func NewKafkaCommand(f *factory.Factory) *cobra.Command {
 		consumergroup.NewConsumerGroupCommand(f),
 		update.NewUpdateCommand(f),
 		acl.NewAclCommand(f),
+		billing.NewBillingCommand(f),
+		providers.NewProviderCommand(f),
 	)
 
 	return cmd

--- a/pkg/cmd/kafka/providers/providers.go
+++ b/pkg/cmd/kafka/providers/providers.go
@@ -28,7 +28,7 @@ type options struct {
 // NewListCommand creates a new command for listing kafkas.
 func NewProviderCommand(f *factory.Factory) *cobra.Command {
 	opts := &options{
-		ServiceContext: f.ServiceContext,
+		f: f,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/kafka/providers/providers.go
+++ b/pkg/cmd/kafka/providers/providers.go
@@ -1,0 +1,83 @@
+package providers
+
+import (
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/create"
+	kafkaFlagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
+
+	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/servicecontext"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
+
+	"github.com/spf13/cobra"
+)
+
+// row is the details of a Kafka instance needed to print to a table
+type providerRow struct {
+	CloudProvider string `json:"cloud_provider" header:"Cloud Provider"`
+	Region        string `json:"region" header:"Region"`
+}
+
+type options struct {
+	outputFormat string
+
+	f              *factory.Factory
+	ServiceContext servicecontext.IContext
+}
+
+// NewListCommand creates a new command for listing kafkas.
+func NewProviderCommand(f *factory.Factory) *cobra.Command {
+	opts := &options{
+		ServiceContext: f.ServiceContext,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "providers",
+		Short:   opts.f.Localizer.MustLocalize("kafka.provider.cmd.shortDescription"),
+		Long:    opts.f.Localizer.MustLocalize("kafka.provider.cmd.longDescription"),
+		Example: opts.f.Localizer.MustLocalize("kafka.provider.cmd.example"),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.outputFormat != "" && !flagutil.IsValidInput(opts.outputFormat, flagutil.ValidOutputFormats...) {
+				return flagutil.InvalidValueError("output", opts.outputFormat, flagutil.ValidOutputFormats...)
+			}
+
+			return runList(opts)
+		},
+	}
+
+	flags := kafkaFlagutil.NewFlagSet(cmd, opts.f.Localizer)
+
+	flags.AddOutput(&opts.outputFormat)
+
+	return cmd
+}
+
+func runList(opts *options) error {
+	providers, err := create.GetEnabledCloudProviderNames(opts.f)
+	if err != nil {
+		return err
+	}
+	providersArray := make([]providerRow, 0, 10)
+	for _, providerId := range providers {
+		regions, err := create.GetEnabledCloudRegionIDs(opts.f, providerId, nil)
+		if err != nil {
+			return err
+		}
+		for _, region := range regions {
+			providersArray = append(providersArray, providerRow{
+				CloudProvider: providerId,
+				Region:        region,
+			})
+		}
+	}
+
+	switch opts.outputFormat {
+	case dump.EmptyFormat:
+		dump.Table(opts.f.IOStreams.Out, providersArray)
+		opts.f.Logger.Info("")
+	default:
+		return dump.Formatted(opts.f.IOStreams.Out, opts.outputFormat, providersArray)
+	}
+	return nil
+}

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -570,6 +570,9 @@ $ rhoas kafka billing
 
 '''
 
+[kafka.billing.log.info.noStandardInstancesAvailable]
+one = "Only developer instances are available"
+
 
 [kafka.list.cmd.shortDescription]
 description = "Short description for command"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -538,6 +538,39 @@ one = 'If specified, only the bootstrap server host of the Kafka instance will b
 [kafka.describe.bootstrapserver.not.available]
 one = 'Kafka instance "{{.Name}}" does not have a bootstrap server URL.'
 
+[kafka.provider.cmd.shortDescription]
+one = "List Kafka Cloud Providers"
+
+[kafka.provider.cmd.longDescription]
+one = '''
+List all enabled Cloud Providers and Regions for Kafka deployment
+'''
+
+[kafka.provider.cmd.example]
+one = '''
+# List all providers using the default output format
+$ rhoas kafka providers 
+
+# List all providersin JSON format
+$ rhoas kafka providers  -o json
+'''
+
+[kafka.billing.cmd.shortDescription]
+one = "List Kafka Billing Types"
+
+[kafka.billing.cmd.longDescription]
+one = '''
+List Kafka Billing Types
+'''
+
+[kafka.billing.cmd.example]
+one = '''
+# List billing types
+$ rhoas kafka billing 
+
+'''
+
+
 [kafka.list.cmd.shortDescription]
 description = "Short description for command"
 one = "List all Kafka instances"


### PR DESCRIPTION
## Motivation

Enable users to fetch state for their organization and personal account required for kafka creation.
This approach enables granular set of commands that can be useful for users to get information about where kafka is deployed and how they are billed by creating kafka.  

## Supported commands

### Fetching cloud providers and regions

```
[wtrocki@graphapi app-services-cli (supporting-gitops)]$ rhoas kafka providers 
  CLOUD PROVIDER   REGION     
 ---------------- ----------- 
  aws              eu-west-1  
  aws              us-east-1  
```

### Fetching billing types

This command fetching billing information - We need to extend this by including plans etc.
Depends on @rkpattnaik780 investigation on how we can represent all of that in gitops setup.

```
[wtrocki@graphapi app-services-cli (supporting-gitops ✗)]$ rhoas kafka billing
  BILLING    
 ----------- 
  developer  

```