### PR TITLE
feat: do not check for context existence if a custom context file is set

### DIFF
--- a/pkg/core/servicecontext/file.go
+++ b/pkg/core/servicecontext/file.go
@@ -97,12 +97,6 @@ func (c *File) Remove() error {
 func (c *File) Location() (path string, err error) {
 
 	if rhoasContext := os.Getenv(ContextEnvName); rhoasContext != "" {
-
-		_, err := os.Stat(rhoasContext)
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("Custom file path '%s' provided doesn't exist", rhoasContext)
-		}
-
 		path = rhoasContext
 	} else {
 		rhoasCtxDir, err := DefaultDir()


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

As today, it a custom context file is set, then the code check for the existence of the context file and fails if it does not exist, however, this is not true for custom configuration location. This PR aims to make config and context behaving consistently. 

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Set `RHOASCONFIG` to an not existing file
2. Run `rhoas`
3. No error should be reported and the `RHOASCONFIG` file should have been created

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
