### PR TITLE
error: return detailed error message for ns not found

### DIFF
--- a/pkg/core/localize/locales/en/cmd/context.en.toml
+++ b/pkg/core/localize/locales/en/cmd/context.en.toml
@@ -274,6 +274,13 @@ Your instance might have been removed.
 You can update your context by creating a new instance or by using the "rhoas context set-kafka" command
 '''
 
+[context.common.error.namespace.notFound]
+one='''
+Connector namespace in your context does not exist.
+Your connector namespace might have been removed.
+You can set a namespace in the current context by creating a new connector namespace or by using the "rhoas context set-namespace" command
+'''
+
 [context.common.error.context.notFound]
 one='''
 context with name "{{.Name}}" does not exist


### PR DESCRIPTION
This commit improves the error handling in case the namespace is not found. It returns more detailed message rather than just returning the error.

Fixes: #1738

Signed-off-by: yati1998 <ypadia@redhat.com>

