### PR TITLE
feat(service-account): add pagination to list command

### DIFF
--- a/docs/commands/rhoas_service-account_list.md
+++ b/docs/commands/rhoas_service-account_list.md
@@ -30,6 +30,8 @@ $ rhoas service-account list -o json
 
 ```
   -o, --output string   Format in which to display the service accounts (choose from: "json", "yml", "yaml")
+      --page int32      Current page number for the list (default 1)
+      --size int32      Maximum number of items to be returned per page (default 100)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
+++ b/pkg/core/localize/locales/en/cmd/serviceaccount.en.toml
@@ -24,6 +24,12 @@ one = 'Format in which to display the service account (choose from: "json", "yml
 [serviceAccount.list.flag.output.description]
 one = 'Format in which to display the service accounts (choose from: "json", "yml", "yaml")'
 
+[serviceAccount.list.flag.page.description]
+one = 'Current page number for the list'
+
+[serviceAccount.list.flag.size.description]
+one = 'Maximum number of items to be returned per page'
+
 [serviceAccount.common.flag.deprecated.enableAuthV2]
 one = '''migration has been completed to the new Service Account SDK
 


### PR DESCRIPTION
Add pagination to `rhoas service-account list` command.

As users are used to running `rhoas service-account list | grep <username>` to get their service accounts, the default size has been set to 100.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. `rhoas service-account list` should display upto 100 service accounts.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
