### PR TITLE
fix(documentation): Use right flags for export command

### DIFF
--- a/docs/commands/rhoas_service-registry_artifact_export.md
+++ b/docs/commands/rhoas_service-registry_artifact_export.md
@@ -15,7 +15,7 @@ rhoas service-registry artifact export [flags]
 
 ```
 ## Export all artifacts and metadata to export file for another Service Registry instance
-rhoas service-registry artifact export --file=export.zip
+rhoas service-registry artifact export --output-file=export.zip
 
 ```
 

--- a/pkg/core/localize/locales/en/cmd/artifact.en.toml
+++ b/pkg/core/localize/locales/en/cmd/artifact.en.toml
@@ -452,7 +452,7 @@ Export all artifacts and metadata from a Service Registry instance to a specifie
 [artifact.cmd.export.example]
 one = '''
 ## Export all artifacts and metadata to export file for another Service Registry instance
-rhoas service-registry artifact export --file=export.zip
+rhoas service-registry artifact export --output-file=export.zip
 '''
 
 [artifact.export.success]


### PR DESCRIPTION
The current export command text is not aligned with the real flags used by the command.

The command requires to use `output-file` however the help sais to use `file` flag.

### Verification Steps

1. Display the export help: `rhoas service-registry artifact export --help' 
2. Execute the export: `rhoas service-registry artifact export --output-file=export.zip`
3. 
### Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [] Other (please specify)
