### PR TITLE
fix(documentation) How to start locally the website

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -11,7 +11,7 @@ yarn
 ### Local Development
 
 ```shell
-npx docusaurus start
+yarn start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.

--- a/website/README.md
+++ b/website/README.md
@@ -11,10 +11,12 @@ yarn
 ### Local Development
 
 ```shell
-yarn copyDocs
+npx docusaurus start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+
+**NOTE:** Requires Node.js >=16.14.
 
 ### Build
 


### PR DESCRIPTION
This PR includes a small fix of the documentation to start locally the website documentation. It is related with the #1777 issue.

(Could) Closes #1777 

### Verification Steps

1. Follow instructions from README.md file

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [ ] Other (please specify)
