### PR TITLE
fix(connector): add missing name in the log

### DIFF
--- a/pkg/cmd/connector/cluster/create/create.go
+++ b/pkg/cmd/connector/cluster/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/localize"
 
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
@@ -79,7 +80,7 @@ func runCreate(opts *options) error {
 		return err
 	}
 
-	f.Logger.Info(f.Localizer.MustLocalize("connector.cluster.create.info.success"))
+	f.Logger.Info(f.Localizer.MustLocalize("connector.cluster.create.info.success", localize.NewEntry("NAME", response.Name)))
 
 	return nil
 }


### PR DESCRIPTION
### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

fixes an issue with `connector cluster create` command:

```
rhoas connector cluster create --name=test
Successfully created the Connectors cluster named "<no value>"
```