### PR TITLE
chore(release): disable auto-updates for non-github binaries

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -16,7 +16,7 @@ import (
 type buildSource string
 
 const (
-	githubBuildSource buildSource = "github"
+	GithubBuildSource buildSource = "github"
 )
 
 // Define public variables here which you wish to be configurable at build time
@@ -75,7 +75,7 @@ func init() {
 // the version currently being used. If so, it logs this information
 // to the console.
 func CheckForUpdate(ctx context.Context, version string, logger logging.Logger, localizer localize.Localizer) {
-	if BuildSource != string(githubBuildSource) {
+	if BuildSource != string(GithubBuildSource) {
 		return
 	}
 	// prefix version with a v to correspond with Git tag

--- a/pkg/core/cmdutil/selfupdate.go
+++ b/pkg/core/cmdutil/selfupdate.go
@@ -53,6 +53,11 @@ func DoSelfUpdate(f *factory.Factory) (bool, error) {
 
 // DoSelfUpdate checks for updates once per day and prompts the user to update if there is a newer version available
 func DoSelfUpdateOnceADay(f *factory.Factory) (bool, error) {
+
+	if build.BuildSource != string(build.GithubBuildSource) {
+		return false, nil
+	}
+
 	if !f.IOStreams.CanPrompt() {
 		// Do not prompt if we are not in interactive mode
 		return false, nil


### PR DESCRIPTION
This PR will ensure that a check for auto-update is made only for binaries built via GitHub.

### Verification Steps
1. Build the binary locally with the following command:
```
go build  -ldflags "-X github.com/redhat-developer/app-services-cli/internal/build.SSORedirectPath="sso-redhat-callback" -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageNumber="1" -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageSize="10" -X github.com/redhat-developer/app-services-cli/internal/build.DynamicConfigURL="https://console.redhat.com/apps/application-services/service-constants.json" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryName="app-services-cli" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryOwner="redhat-developer" -X github.com/redhat-developer/app-services-cli/internal/build.Version="0.51.1" -X github.com/redhat-developer/app-services-cli/internal/build.BuildSource="github" " -o rhoas ./cmd/rhoas
```
2. Run any command. It should prompt for auto-update.
3. Build binary by setting `gitlab` as build source:
```
go build  -ldflags "-X github.com/redhat-developer/app-services-cli/internal/build.SSORedirectPath="sso-redhat-callback" -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageNumber="1" -X github.com/redhat-developer/app-services-cli/internal/build.DefaultPageSize="10" -X github.com/redhat-developer/app-services-cli/internal/build.DynamicConfigURL="https://console.redhat.com/apps/application-services/service-constants.json" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryName="app-services-cli" -X github.com/redhat-developer/app-services-cli/internal/build.RepositoryOwner="redhat-developer" -X github.com/redhat-developer/app-services-cli/internal/build.Version="0.51.1" -X github.com/redhat-developer/app-services-cli/internal/build.BuildSource="gitlab" " -o rhoas ./cmd/rhoas
```
4. Run any command again, there shouldn't be any prompt.

> NOTE: You will need to manually change `last_updated` field in the `config` file.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [X] Auto-updates
