### PR TITLE
fix(connector update): populate kafka url

### DIFF
--- a/docs/commands/rhoas_connector_update.md
+++ b/docs/commands/rhoas_connector_update.md
@@ -24,7 +24,7 @@ rhoas connector update [flags]
 
 ```
 # Update a Connectors instance
-rhoas connector update --id=my-connector --file=myconnector.json
+rhoas connector update --name=my-connector --file=myconnector.json
 
 # Update a Connectors instance from stdin
 cat myconnector.json | rhoas connector update
@@ -34,9 +34,9 @@ cat myconnector.json | rhoas connector update
 ### Options
 
 ```
-      --kafka-id string       ID of the namespace in which you want to deploy the Connectors instance
+      --kafka-id string       ID of of the Kafka instance that you want the Connectors instance to use
       --name string           Override the name of the Connectors instance (the default name is the name specified in the connector configuration file)
-      --namespace-id string   ID of of the Kafka instance that you want the Connectors instance to use
+      --namespace-id string   ID of the namespace in which you want to deploy the Connectors instance
   -o, --output string         Specify the output format. Choose from: "json", "yaml", "yml"
 ```
 

--- a/docs/commands/rhoas_connector_update.md
+++ b/docs/commands/rhoas_connector_update.md
@@ -24,7 +24,7 @@ rhoas connector update [flags]
 
 ```
 # Update a Connectors instance
-rhoas connector update --name=my-connector --file=myconnector.json
+rhoas connector update --name=my-connector
 
 # Update a Connectors instance from stdin
 cat myconnector.json | rhoas connector update

--- a/docs/commands/rhoas_connector_update.md
+++ b/docs/commands/rhoas_connector_update.md
@@ -23,17 +23,18 @@ rhoas connector update [flags]
 ### Examples
 
 ```
-# Update a Connectors instance
+# Update name of the current Connectors instance
 rhoas connector update --name=my-connector
 
-# Update a Connectors instance from stdin
-cat myconnector.json | rhoas connector update
+# Update Kafka Instance of a Connectors instance by ID
+rhoas connector update --kafka-id ce6pg07k09f3rs6us7sg --id ce6tgb1mk0orirpo5i70
 
 ```
 
 ### Options
 
 ```
+      --id string             ID of the Connectors instance to be updated (the default is the instance in current context)
       --kafka-id string       ID of of the Kafka instance that you want the Connectors instance to use
       --name string           Override the name of the Connectors instance (the default name is the name specified in the connector configuration file)
       --namespace-id string   ID of the namespace in which you want to deploy the Connectors instance

--- a/pkg/cmd/connector/create/create.go
+++ b/pkg/cmd/connector/create/create.go
@@ -164,9 +164,21 @@ func createServiceAccount(opts *factory.Factory, shortDescription string) (*svca
 }
 
 func setDefaultValuesFromFlags(connector *connectormgmtclient.ConnectorRequest, opts *options) error {
+
+	conn, err := opts.f.Connection()
+	if err != nil {
+		return err
+	}
+
 	if opts.kafkaId != "" {
+		kafkaInstance, _, kafkaErr := kafkautil.GetKafkaByID(opts.f.Context, conn.API().KafkaMgmt(), opts.kafkaId)
+		if kafkaErr != nil {
+			return kafkaErr
+		}
+
 		connector.Kafka = connectormgmtclient.KafkaConnectionSettings{
-			Id: opts.kafkaId,
+			Id:  opts.kafkaId,
+			Url: kafkaInstance.GetBootstrapServerHost(),
 		}
 	}
 

--- a/pkg/cmd/connector/update/update.go
+++ b/pkg/cmd/connector/update/update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connectorutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/kafkautil"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
@@ -83,7 +84,12 @@ func runUpdate(opts *options) error {
 		connectorChanged = true
 	}
 	if opts.kafkaID != "" {
-		connector.Kafka.SetId(opts.kafkaID)
+		kafkaInstance, _, kafkaErr := kafkautil.GetKafkaByID(opts.f.Context, api.KafkaMgmt(), opts.kafkaID)
+		if kafkaErr != nil {
+			return kafkaErr
+		}
+		connector.Kafka.SetId(kafkaInstance.GetId())
+		connector.Kafka.SetUrl(kafkaInstance.GetBootstrapServerHost())
 		connectorChanged = true
 	}
 

--- a/pkg/cmd/connector/update/update.go
+++ b/pkg/cmd/connector/update/update.go
@@ -22,6 +22,7 @@ type options struct {
 	namespaceID string
 	kafkaID     string
 	name        string
+	id          string
 
 	outputFormat string
 	f            *factory.Factory
@@ -45,10 +46,27 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 				return flagutil.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
+			if opts.id != "" {
+				return runUpdate(opts)
+			}
+
+			conn, err := opts.f.Connection()
+			if err != nil {
+				return err
+			}
+
+			connector, err := contextutil.GetCurrentConnectorInstance(&conn, opts.f)
+			if err != nil {
+				return err
+			}
+
+			opts.id = connector.GetId()
+
 			return runUpdate(opts)
 		},
 	}
 	flags := flagutil.NewFlagSet(cmd, f.Localizer)
+	flags.StringVar(&opts.id, "id", "", f.Localizer.MustLocalize("connector.flag.id.description"))
 	flags.StringVar(&opts.name, "name", "", f.Localizer.MustLocalize("connector.flag.name.description"))
 	flags.StringVar(&opts.namespaceID, "namespace-id", "", f.Localizer.MustLocalize("connector.flag.namespaceID.description"))
 	flags.StringVar(&opts.kafkaID, "kafka-id", "", f.Localizer.MustLocalize("connector.flag.kafkaID.description"))
@@ -65,13 +83,10 @@ func runUpdate(opts *options) error {
 		return err
 	}
 
-	api := conn.API()
-
-	connector, err := contextutil.GetCurrentConnectorInstance(&conn, opts.f)
-	if err != nil || connector == nil {
-		if connector, err = connectorutil.InteractiveSelect(conn, opts.f); err != nil {
-			return err
-		}
+	connectorsApi := conn.API().ConnectorsMgmt()
+	connector, err := connectorutil.GetConnectorByID(&connectorsApi, opts.id, opts.f)
+	if err != nil {
+		return err
 	}
 
 	connectorChanged := false
@@ -84,7 +99,7 @@ func runUpdate(opts *options) error {
 		connectorChanged = true
 	}
 	if opts.kafkaID != "" {
-		kafkaInstance, _, kafkaErr := kafkautil.GetKafkaByID(opts.f.Context, api.KafkaMgmt(), opts.kafkaID)
+		kafkaInstance, _, kafkaErr := kafkautil.GetKafkaByID(opts.f.Context, conn.API().KafkaMgmt(), opts.kafkaID)
 		if kafkaErr != nil {
 			return kafkaErr
 		}
@@ -112,7 +127,7 @@ func runUpdate(opts *options) error {
 		return err
 	}
 
-	a := api.ConnectorsMgmt().ConnectorsApi.PatchConnector(opts.f.Context, connector.GetId())
+	a := conn.API().ConnectorsMgmt().ConnectorsApi.PatchConnector(opts.f.Context, connector.GetId())
 	a = a.Body(patchData)
 	updated, httpRes, err := a.Execute()
 	if httpRes != nil {

--- a/pkg/cmd/connector/update/update.go
+++ b/pkg/cmd/connector/update/update.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"encoding/json"
+
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connectorutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
@@ -48,8 +49,8 @@ func NewUpdateCommand(f *factory.Factory) *cobra.Command {
 	}
 	flags := flagutil.NewFlagSet(cmd, f.Localizer)
 	flags.StringVar(&opts.name, "name", "", f.Localizer.MustLocalize("connector.flag.name.description"))
-	flags.StringVar(&opts.namespaceID, "namespace-id", "", f.Localizer.MustLocalize("connector.flag.kafkaID.description"))
-	flags.StringVar(&opts.kafkaID, "kafka-id", "", f.Localizer.MustLocalize("connector.flag.namespaceID.description"))
+	flags.StringVar(&opts.namespaceID, "namespace-id", "", f.Localizer.MustLocalize("connector.flag.namespaceID.description"))
+	flags.StringVar(&opts.kafkaID, "kafka-id", "", f.Localizer.MustLocalize("connector.flag.kafkaID.description"))
 	flags.AddOutput(&opts.outputFormat)
 
 	return cmd

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -359,7 +359,7 @@ After you edit the configuration file, use the "connector update" command to upd
 [connector.update.cmd.example]
 one = '''
 # Update a Connectors instance
-rhoas connector update --name=my-connector --file=myconnector.json
+rhoas connector update --name=my-connector
 
 # Update a Connectors instance from stdin
 cat myconnector.json | rhoas connector update

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -358,11 +358,11 @@ After you edit the configuration file, use the "connector update" command to upd
 
 [connector.update.cmd.example]
 one = '''
-# Update a Connectors instance
+# Update name of the current Connectors instance
 rhoas connector update --name=my-connector
 
-# Update a Connectors instance from stdin
-cat myconnector.json | rhoas connector update
+# Update Kafka Instance of a Connectors instance by ID
+rhoas connector update --kafka-id ce6pg07k09f3rs6us7sg --id ce6tgb1mk0orirpo5i70
 '''
 
 [connector.update.info.success]
@@ -382,6 +382,9 @@ one = 'ID of of the Kafka instance that you want the Connectors instance to use'
 
 [connector.flag.namespace.description]
 one = 'ID of the namespace for the Connectors instance (the default is the namespace for the current context)'
+
+[connector.flag.id.description]
+one = 'ID of the Connectors instance to be updated (the default is the instance in current context)'
 
 [connector.flag.name.description]
 one = 'Override the name of the Connectors instance (the default name is the name specified in the connector configuration file)'

--- a/pkg/core/localize/locales/en/cmd/connectors.toml
+++ b/pkg/core/localize/locales/en/cmd/connectors.toml
@@ -359,7 +359,7 @@ After you edit the configuration file, use the "connector update" command to upd
 [connector.update.cmd.example]
 one = '''
 # Update a Connectors instance
-rhoas connector update --id=my-connector --file=myconnector.json
+rhoas connector update --name=my-connector --file=myconnector.json
 
 # Update a Connectors instance from stdin
 cat myconnector.json | rhoas connector update


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
1. Run the following command to update a connector instance by id:
```
rhoas connector update --kafka-id ce6pg07k09f3rs6us7sg --id ce6tgb1mk0orirpo5i70
```
2. Ensure that the connectors instance has been updated, and the new Kafka URL has been specified.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change
- [ ] Other (please specify)
