### PR TITLE
feat(kafka create): return appropriate error for no regions

### DIFF
--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -552,6 +552,10 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		return nil, err
 	}
 
+	if len(regionIDs) == 0 {
+		return nil, f.Localizer.MustLocalizeError("kafka.create.error.noRegionSupported")
+	}
+
 	regionPrompt := &survey.Select{
 		Message: f.Localizer.MustLocalize("kafka.create.input.cloudRegion.message"),
 		Options: regionIDs,

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -414,6 +414,9 @@ one = '''
 provided instance size is not valid. Valid sizes: {{.ValidSizes}}
 '''
 
+[kafka.create.error.noRegionSupported]
+one = 'all regions in the selected cloud provider are temporarily unavailable'
+
 [kafka.create.error.billing.invalid]
 one = '''
 provided billing account id and provider are invalid {{.Billing}}


### PR DESCRIPTION

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create Kafka instance for user with standard quota selecting gcp as the provider.
```
./rhoas kafka create --dry-run -v
```
It should fail showing `All regions in the selected cloud provider are temporarily unavailable`
2. Run the command above with a user having no quota. Creation should succeed when gcp is selected as  the cloud provider. 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
