### PR TITLE
fix(kafka create): sync marketplace provider with cloud provider

### DIFF
--- a/pkg/cmd/kafka/create/completions.go
+++ b/pkg/cmd/kafka/create/completions.go
@@ -45,7 +45,7 @@ func GetKafkaSizeCompletionValues(f *factory.Factory, providerID string, regionI
 		return nil, directive
 	}
 
-	userInstanceType, _ := accountmgmtutil.SelectQuotaForUser(f, orgQuota, accountmgmtutil.MarketplaceInfo{})
+	userInstanceType, _ := accountmgmtutil.SelectQuotaForUser(f, orgQuota, accountmgmtutil.MarketplaceInfo{}, "")
 
 	// Not including quota in this request as it takes very long time to list quota for all regions in suggestion mode
 	validSizes, _ = FetchValidKafkaSizesLabels(f, providerID, regionId, *userInstanceType)
@@ -67,7 +67,7 @@ func GetMarketplaceCompletionValues(f *factory.Factory) (validSizes []string, di
 		return nil, directive
 	}
 
-	validMarketPlaces := FetchValidMarketplaces(orgQuota.MarketplaceQuotas)
+	validMarketPlaces := FetchValidMarketplaces(orgQuota.MarketplaceQuotas, "")
 
 	return validMarketPlaces, cobra.ShellCompDirectiveNoSpace
 }
@@ -109,7 +109,7 @@ func GetBillingModelCompletionValues(f *factory.Factory) (availableBillingModels
 		return nil, directive
 	}
 
-	availableBillingModels = FetchSupportedBillingModels(orgQuota)
+	availableBillingModels = FetchSupportedBillingModels(orgQuota, "")
 
 	return availableBillingModels, directive
 }

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -260,7 +259,7 @@ func runCreate(opts *options) error {
 
 			if opts.marketplace != "" && opts.marketplace != accountmgmtutil.RedHatMarketPlace {
 				if opts.marketplace != opts.provider {
-					return errors.New("selected marketplace is not supported for the cloud provider")
+					return opts.f.Localizer.MustLocalizeError("kafka.create.provider.error.unsupportedMarketplace")
 				}
 			}
 
@@ -487,10 +486,8 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 	availableBillingModels := FetchSupportedBillingModels(orgQuota, answers.CloudProvider)
 
 	if len(availableBillingModels) == 0 && len(orgQuota.MarketplaceQuotas) > 0 {
-		return nil, errors.New("standard instances are unavailable for the cloud provider, try another provider")
+		return nil, opts.f.Localizer.MustLocalizeError("kafka.create.provider.error.noStandardInstancesAvailable")
 	}
-
-	fmt.Println("Supported Billing Models - ", availableBillingModels)
 
 	if len(availableBillingModels) > 0 {
 		if len(availableBillingModels) == 1 {

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -417,6 +417,15 @@ provided instance size is not valid. Valid sizes: {{.ValidSizes}}
 [kafka.create.error.noRegionSupported]
 one = 'all regions in the selected cloud provider are temporarily unavailable'
 
+[kafka.create.provider.error.noStandardInstancesAvailable]
+one = 'standard instances are unavailable for the cloud provider, try another provider'
+
+[kafka.create.provider.error.noMarketplaceQuota]
+one = 'no marketplace quota available for given provider'
+
+[kafka.create.provider.error.unsupportedMarketplace]
+one = 'selected marketplace is not supported for the cloud provider'
+
 [kafka.create.error.billing.invalid]
 one = '''
 provided billing account id and provider are invalid {{.Billing}}

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -152,7 +152,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 		}
 
 		if len(orgQuota.MarketplaceQuotas) == 0 {
-			return nil, errors.New("no marketplace quota available for given provider")
+			return nil, f.Localizer.MustLocalizeError("kafka.create.provider.error.noMarketplaceQuota")
 		}
 
 		marketplaceQuota, err := getMarketplaceQuota(f, orgQuota.MarketplaceQuotas, marketplaceInfo)
@@ -190,7 +190,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 			}
 
 			if len(orgQuota.MarketplaceQuotas) == 0 {
-				return nil, errors.New("no marketplace quota available for given provider")
+				return nil, f.Localizer.MustLocalizeError("kafka.create.provider.error.noMarketplaceQuota")
 			}
 
 			marketplaceQuota, err := getMarketplaceQuota(f, orgQuota.MarketplaceQuotas, marketplaceInfo)

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -148,7 +148,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 				}
 			}
 
-			orgQuota.MarketplaceQuotas = uniqueQuota(filteredMarketPlaceQuotas)
+			orgQuota.MarketplaceQuotas = uniqueQuotaSpec(filteredMarketPlaceQuotas)
 		}
 
 		if len(orgQuota.MarketplaceQuotas) == 0 {
@@ -186,7 +186,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 					}
 				}
 
-				orgQuota.MarketplaceQuotas = uniqueQuota(filteredMarketPlaceQuotas)
+				orgQuota.MarketplaceQuotas = uniqueQuotaSpec(filteredMarketPlaceQuotas)
 			}
 
 			if len(orgQuota.MarketplaceQuotas) == 0 {
@@ -347,7 +347,8 @@ func unique(s []string) []string {
 	return result
 }
 
-func uniqueQuota(s []QuotaSpec) []QuotaSpec {
+// uniqueQuotaSpec accepts a list of QuotaSpec objects and returns the unique QuotaSpecs
+func uniqueQuotaSpec(s []QuotaSpec) []QuotaSpec {
 	inResult := make(map[QuotaSpec]bool)
 	var result []QuotaSpec
 	for _, quota := range s {


### PR DESCRIPTION
Selection of marketplace provider should be dependent on the cloud provider.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Use mock server.
2. Run Kafka create in interactive mode. User should not be able to select `gcp` as marketplace when `aws` is chosen as the cloud provider:
```
rhoas kafka create --dry-run -v
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
