### PR TITLE
feat(connector): load current context for commands

### DIFF
--- a/pkg/cmd/connector/describe/describe.go
+++ b/pkg/cmd/connector/describe/describe.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 
 	"github.com/spf13/cobra"
@@ -38,11 +39,27 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 				return flagutil.InvalidValueError("output", opts.outputFormat, validOutputFormats...)
 			}
 
+			if opts.id != "" {
+				return runDescribe(opts)
+			}
+
+			conn, err := opts.f.Connection()
+			if err != nil {
+				return err
+			}
+
+			connectorInstance, err := contextutil.GetCurrentConnectorInstance(&conn, f)
+			if err != nil {
+				return err
+			}
+
+			opts.id = connectorInstance.GetId()
+
 			return runDescribe(opts)
 		},
 	}
 	flags := connectorcmdutil.NewFlagSet(cmd, f)
-	_ = flags.AddConnectorID(&opts.id).Required()
+	_ = flags.AddConnectorID(&opts.id)
 	flags.AddOutput(&opts.outputFormat)
 
 	return cmd

--- a/pkg/cmd/connector/list/list.go
+++ b/pkg/cmd/connector/list/list.go
@@ -107,7 +107,7 @@ func runList(opts *options) error {
 			return err
 		}
 
-		if currCtx.KafkaID != "" {
+		if currCtx.ConnectorID != "" {
 			rows = mapResponseItemsToRows(response.GetItems(), currCtx.ConnectorID)
 		} else {
 			rows = mapResponseItemsToRows(response.GetItems(), "-")

--- a/pkg/cmd/connector/list/list.go
+++ b/pkg/cmd/connector/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"fmt"
 	"strconv"
 
 	connectormgmtclient "github.com/redhat-developer/app-services-sdk-go/connectormgmt/apiv1/client"
@@ -8,6 +9,8 @@ import (
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
+	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/icon"
+	"github.com/redhat-developer/app-services-cli/pkg/shared/contextutil"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 
 	"github.com/spf13/cobra"
@@ -93,7 +96,22 @@ func runList(opts *options) error {
 
 	switch opts.outputFormat {
 	case dump.EmptyFormat:
-		rows := mapResponseItemsToRows(response.Items)
+		var rows []itemRow
+
+		svcContext, err := opts.f.ServiceContext.Load()
+		if err != nil {
+			return err
+		}
+		currCtx, err := contextutil.GetCurrentContext(svcContext, opts.f.Localizer)
+		if err != nil {
+			return err
+		}
+
+		if currCtx.KafkaID != "" {
+			rows = mapResponseItemsToRows(response.GetItems(), currCtx.ConnectorID)
+		} else {
+			rows = mapResponseItemsToRows(response.GetItems(), "-")
+		}
 
 		dump.Table(f.IOStreams.Out, rows)
 		f.Logger.Info("")
@@ -103,13 +121,15 @@ func runList(opts *options) error {
 	return nil
 }
 
-func mapResponseItemsToRows(items []connectormgmtclient.Connector) []itemRow {
+func mapResponseItemsToRows(items []connectormgmtclient.Connector, selectedId string) []itemRow {
 	rows := make([]itemRow, len(items))
 
 	for i := range items {
 		k := items[i]
 		name := k.GetName()
-
+		if k.GetId() == selectedId {
+			name = fmt.Sprintf("%s %s", name, icon.Emoji("✔", "(current)"))
+		}
 		row := itemRow{
 			ID:     k.GetId(),
 			Name:   name,


### PR DESCRIPTION
The commands `rhoas connector describe`, `rhoas connector list` and `rhoas connector namespace list` now reflect the instance set in the current context.

### Verification Steps
1. Select a connector instance:
```
rhoas connector use
```
2. List the Connector instances in the org, it should show the connectors instance set in the current context
```
rhoas connector list
```
3. View the connector instance currently set in the context.
```
rhoas connector describe
```
4. Select a connector namespace:
```
rhoas connector namespace use
```
5. List all connector namespaces, it should show the namespace set in the current context
```
rhoas connector namespace list
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
