### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -12,7 +12,8 @@ jobs:
     name: Assign to One Project
     steps:
     - name: Assign triaged issues to app-services project
-      uses: srggrs/assign-one-project-github-action@1.3.1
+      # 1.3.1
+      uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1
       if: |
         contains(github.event.issue.labels.*.name, 'triage/accepted')
       with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,13 +18,15 @@ jobs:
     
       - 
         name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+        # v1
+        uses: craicoverflow/install-git-chglog@6d338c1d96dcbf12a2115fbe8e5b9817293aae33
 
       -
         name: Generate a CHANGELOG
         run: git-chglog -o CHANGELOG.md
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+        # v4
+      - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
         with:
           branch: main
           file_pattern: CHANGELOG.md

--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -11,4 +11,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+        # v4
+      - uses: wagoid/commitlint-github-action@416045160973f9fff174ac6698412cfe7181c3f3

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        # v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
         with:
           version: v1.48.0
           # skip-go-installation: true

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -7,7 +7,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.5
+      # v2.5
+    - uses: github/issue-labeler@6ca237433dbbb8e475241b7f38f4600d9e296c57
       with:
         repo-token: "${{ secrets.PROJECT_MANAGER_TOKEN }}"
         configuration-path: .github/labeler.yml

--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -19,7 +19,8 @@ jobs:
       - run: make generate-downstream-docs
         name: Generate generate-downstream-docs
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        # v4.4.1
+        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6
         with:
           branch: modular-docs # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
             core.setOutput('version', version)
       - 
         name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+        # v1
+        uses: craicoverflow/install-git-chglog@6d338c1d96dcbf12a2115fbe8e5b9817293aae33
       - 
         name: Generate release notes
         if: steps.check-tag.outputs.prerelease == 'false'
@@ -48,7 +49,8 @@ jobs:
         run: cat RELEASE_NOTES.md
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        # v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         if: steps.check-tag.outputs.prerelease == 'false'
         with:
           version: latest
@@ -57,7 +59,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser on pre-release
-        uses: goreleaser/goreleaser-action@v3
+        # v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         if: steps.check-tag.outputs.prerelease == 'true'
         with:
           version: latest
@@ -67,7 +70,8 @@ jobs:
 
       - name: Notify Guides of new version
         if: steps.check-tag.outputs.prerelease == 'false'
-        uses: peter-evans/repository-dispatch@v2
+        # v2
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
           token: ${{ secrets.APP_SERVICES_CI }}
           repository: redhat-developer/app-services-guides


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.
