### PR TITLE
feat(kafka create): enable creating long-lived trial instances

### DIFF
--- a/docs/commands/rhoas_kafka_create.md
+++ b/docs/commands/rhoas_kafka_create.md
@@ -32,6 +32,7 @@ $ rhoas kafka create -o yaml
 ```
       --billing-model string            Billing model to be used
       --dry-run                         Validate all user provided arguments without creating the Kafka instance
+      --instance-type string            Type of the Kafka instance
       --marketplace string              Name of the marketplace where the instance is purchased on
       --marketplace-account-id string   Cloud Account ID for the marketplace
       --name string                     Unique name of the Kafka instance

--- a/docs/commands/rhoas_kafka_create.md
+++ b/docs/commands/rhoas_kafka_create.md
@@ -32,7 +32,6 @@ $ rhoas kafka create -o yaml
 ```
       --billing-model string            Billing model to be used
       --dry-run                         Validate all user provided arguments without creating the Kafka instance
-      --instance-type string            Type of the Kafka instance
       --marketplace string              Name of the marketplace where the instance is purchased on
       --marketplace-account-id string   Cloud Account ID for the marketplace
       --name string                     Unique name of the Kafka instance

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
@@ -139,18 +138,4 @@ func ValidateBillingModel(billingModel string) error {
 	}
 
 	return flagutil.InvalidValueError("billing-model", billingModel, validBillingModels...)
-}
-
-// ValidateBillingModel validates if user provided a valid instance type
-func ValidateInstanceType(instanceType string, billingModel string) error {
-
-	if billingModel == accountmgmtutil.QuotaEvalType {
-		if instanceType == accountmgmtutil.QuotaStandardType {
-			return nil
-		}
-
-		return errors.New("\"--instance-type\" flag needs to be provided")
-	}
-
-	return nil
 }

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/redhat-developer/app-services-cli/pkg/core/cmdutil/flagutil"
@@ -138,4 +139,18 @@ func ValidateBillingModel(billingModel string) error {
 	}
 
 	return flagutil.InvalidValueError("billing-model", billingModel, validBillingModels...)
+}
+
+// ValidateBillingModel validates if user provided a valid instance type
+func ValidateInstanceType(instanceType string, billingModel string) error {
+
+	if billingModel == accountmgmtutil.QuotaEvalType {
+		if instanceType == accountmgmtutil.QuotaStandardType {
+			return nil
+		}
+
+		return errors.New("\"--instance-type\" flag needs to be provided")
+	}
+
+	return nil
 }

--- a/pkg/cmd/kafka/create/api_validators.go
+++ b/pkg/cmd/kafka/create/api_validators.go
@@ -26,7 +26,7 @@ type ValidatorInput struct {
 	conn      connection.Connection
 }
 
-var validBillingModels []string = []string{accountmgmtutil.QuotaMarketplaceType, accountmgmtutil.QuotaStandardType}
+var validBillingModels []string = []string{accountmgmtutil.QuotaMarketplaceType, accountmgmtutil.QuotaStandardType, accountmgmtutil.QuotaEvalType}
 
 func (input *ValidatorInput) ValidateProviderAndRegion() error {
 	f := input.f

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -46,8 +46,6 @@ const (
 	FlagMarketPlace = "marketplace"
 	// FlagMarketPlace is a flag representing billing model of the instance
 	FlagBillingModel = "billing-model"
-	// FlagInstanceType is a flag representing the type of instance
-	FlagInstanceType = "instance-type"
 )
 
 type options struct {
@@ -144,7 +142,6 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	flags.StringVar(&opts.size, FlagSize, "", f.Localizer.MustLocalize("kafka.create.flag.size.description"))
 	flags.StringVar(&opts.marketplaceAcctId, FlagMarketPlaceAcctID, "", f.Localizer.MustLocalize("kafka.create.flag.marketplaceId.description"))
 	flags.StringVar(&opts.marketplace, FlagMarketPlace, "", f.Localizer.MustLocalize("kafka.create.flag.marketplaceType.description"))
-	flags.StringVar(&opts.instanceType, FlagInstanceType, "", f.Localizer.MustLocalize("kafka.create.flag.instanceType.description"))
 	flags.AddOutput(&opts.outputFormat)
 	flags.BoolVar(&opts.autoUse, "use", true, f.Localizer.MustLocalize("kafka.create.flag.autoUse.description"))
 	flags.BoolVarP(&opts.wait, "wait", "w", false, f.Localizer.MustLocalize("kafka.create.flag.wait.description"))
@@ -250,11 +247,6 @@ func runCreate(opts *options) error {
 		if !opts.bypassChecks {
 
 			err = ValidateBillingModel(opts.billingModel)
-			if err != nil {
-				return err
-			}
-
-			err = ValidateInstanceType(opts.instanceType, opts.billingModel)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -46,6 +46,8 @@ const (
 	FlagMarketPlace = "marketplace"
 	// FlagMarketPlace is a flag representing billing model of the instance
 	FlagBillingModel = "billing-model"
+	// FlagInstanceType is a flag representing the type of instance
+	FlagInstanceType = "instance-type"
 )
 
 type options struct {
@@ -57,6 +59,7 @@ type options struct {
 	marketplaceAcctId string
 	marketplace       string
 	billingModel      string
+	instanceType      string
 
 	outputFormat string
 	autoUse      bool
@@ -141,6 +144,7 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	flags.StringVar(&opts.size, FlagSize, "", f.Localizer.MustLocalize("kafka.create.flag.size.description"))
 	flags.StringVar(&opts.marketplaceAcctId, FlagMarketPlaceAcctID, "", f.Localizer.MustLocalize("kafka.create.flag.marketplaceId.description"))
 	flags.StringVar(&opts.marketplace, FlagMarketPlace, "", f.Localizer.MustLocalize("kafka.create.flag.marketplaceType.description"))
+	flags.StringVar(&opts.instanceType, FlagInstanceType, "", f.Localizer.MustLocalize("kafka.create.flag.instanceType.description"))
 	flags.AddOutput(&opts.outputFormat)
 	flags.BoolVar(&opts.autoUse, "use", true, f.Localizer.MustLocalize("kafka.create.flag.autoUse.description"))
 	flags.BoolVarP(&opts.wait, "wait", "w", false, f.Localizer.MustLocalize("kafka.create.flag.wait.description"))
@@ -246,6 +250,11 @@ func runCreate(opts *options) error {
 		if !opts.bypassChecks {
 
 			err = ValidateBillingModel(opts.billingModel)
+			if err != nil {
+				return err
+			}
+
+			err = ValidateInstanceType(opts.instanceType, opts.billingModel)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -57,7 +57,6 @@ type options struct {
 	marketplaceAcctId string
 	marketplace       string
 	billingModel      string
-	instanceType      string
 
 	outputFormat string
 	autoUse      bool

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -110,6 +110,10 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 				return f.Localizer.MustLocalizeError("kafka.create.error.standard.invalidFlags")
 			}
 
+			if opts.billingModel == accountmgmtutil.QuotaEvalType && (opts.marketplaceAcctId != "" || opts.marketplace != "") {
+				return f.Localizer.MustLocalizeError("kafka.create.error.eval.invalidFlags")
+			}
+
 			if !f.IOStreams.CanPrompt() && opts.name == "" {
 				return f.Localizer.MustLocalizeError("kafka.create.argument.name.error.requiredWhenNonInteractive")
 			} else if opts.name == "" {

--- a/pkg/cmd/kafka/create/data.go
+++ b/pkg/cmd/kafka/create/data.go
@@ -27,6 +27,8 @@ func mapAmsTypeToBackendType(amsType *accountmgmtutil.QuotaSpec) CloudProviderId
 	switch amsType.Name {
 	case accountmgmtutil.QuotaStandardType:
 		return StandardType
+	case accountmgmtutil.QuotaEvalType:
+		return StandardType
 	case accountmgmtutil.QuotaMarketplaceType:
 		return StandardType
 	case accountmgmtutil.QuotaTrialType:
@@ -61,6 +63,10 @@ func FetchSupportedBillingModels(userQuotas *accountmgmtutil.OrgQuotas, provider
 
 	if len(userQuotas.StandardQuotas) > 0 {
 		billingModels = append(billingModels, accountmgmtutil.QuotaStandardType)
+	}
+
+	if len(userQuotas.EvalQuotas) > 0 {
+		billingModels = append(billingModels, accountmgmtutil.QuotaEvalType)
 	}
 
 	if len(userQuotas.MarketplaceQuotas) > 0 {

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -295,6 +295,9 @@ one = 'Billing model to be used'
 [kafka.create.flag.marketplaceType.description]
 one = 'Name of the marketplace where the instance is purchased on'
 
+[kafka.create.flag.instanceType.description]
+one = 'Type of the Kafka instance'
+
 [kafka.create.log.info.creatingKafka]
 description = 'Message when Kafka instance is being created'
 one = 'Creating Kafka instance "{{.Name}}"...'
@@ -439,6 +442,9 @@ one = "only trial quotas are available, don't specify billing model details"
 
 [kafka.create.quota.error.noMarketplace]
 one = "no marketplace quotas are available"
+
+[kafka.create.quota.error.noEval]
+one = "no evaluation quotas are available"
 
 [kafka.create.quota.error.noStandard]
 one = "no standard quotas are available"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -370,7 +370,10 @@ one = '"--billing-model", "--marketplace", "--marketplace-account-id" flags are 
 one = '"--marketplace" and "--marketplace-account-id" flags should be supplied together'
 
 [kafka.create.error.standard.invalidFlags]
-one = 'billing model cannot be standard if "--marketplace-account-id" or "--marketplace" are set'
+one = 'billing model can not be standard if "--marketplace-account-id" or "--marketplace" are set'
+
+[kafka.create.error.eval.invalidFlags]
+one = 'billing model can not be eval if "--marketplace-account-id" or "--marketplace" are set'
 
 [kafka.create.error.conflictError]
 one = 'Kafka instance "{{.Name}}" already exists'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -295,9 +295,6 @@ one = 'Billing model to be used'
 [kafka.create.flag.marketplaceType.description]
 one = 'Name of the marketplace where the instance is purchased on'
 
-[kafka.create.flag.instanceType.description]
-one = 'Type of the Kafka instance'
-
 [kafka.create.log.info.creatingKafka]
 description = 'Message when Kafka instance is being created'
 one = 'Creating Kafka instance "{{.Name}}"...'

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -93,16 +93,17 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 		for i := range quotaResources {
 			quotaResource := quotaResources[i]
 			if quotaResource.GetResourceName() == spec.ResourceName {
-				if quotaResource.GetProduct() == spec.TrialProductQuotaID {
+				switch quotaResource.GetProduct() {
+				case spec.TrialProductQuotaID:
 					trialQuotas = append(trialQuotas, QuotaSpec{QuotaTrialType, 0, quotaResource.BillingModel, nil})
-				} else if quotaResource.GetProduct() == spec.InstanceQuotaID {
+				case spec.InstanceQuotaID:
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					if quotaResource.BillingModel == QuotaStandardType {
 						standardQuotas = append(standardQuotas, QuotaSpec{QuotaStandardType, remainingQuota, quotaResource.BillingModel, nil})
 					} else if quotaResource.BillingModel == QuotaMarketplaceType {
 						marketplaceQuotas = append(marketplaceQuotas, QuotaSpec{QuotaMarketplaceType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 					}
-				} else if quotaResource.GetProduct() == "RHOSAKEval" {
+				case "RHOSAKEval":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 				}
@@ -206,11 +207,14 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 
 	if quotaTypeCount > 1 {
 
-		if marketplaceInfo.BillingModel == QuotaStandardType {
+		switch marketplaceInfo.BillingModel {
+		case QuotaStandardType:
 			return &orgQuota.StandardQuotas[0], nil
-		} else if marketplaceInfo.BillingModel == QuotaEvalType {
+		case QuotaEvalType:
 			return &orgQuota.EvalQuotas[0], nil
-		} else if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
+		}
+
+		if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 
 			var filteredMarketPlaceQuotas []QuotaSpec
 

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -122,6 +122,14 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 // nolint:funlen
 func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo MarketplaceInfo, provider string) (*QuotaSpec, error) {
 
+	if marketplaceInfo.BillingModel == QuotaEvalType {
+		if len(orgQuota.EvalQuotas) > 0 {
+			return &orgQuota.EvalQuotas[0], nil
+		}
+
+		return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.noEval")
+	}
+
 	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 {
 		if marketplaceInfo.BillingModel != "" || marketplaceInfo.Provider != "" {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.onlyTrialAvailable")
@@ -180,8 +188,6 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 
 		if marketplaceInfo.BillingModel == QuotaStandardType {
 			return &orgQuota.StandardQuotas[0], nil
-		} else if marketplaceInfo.BillingModel == QuotaEvalType {
-			return &orgQuota.EvalQuotas[0], nil
 		} else if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 
 			var filteredMarketPlaceQuotas []QuotaSpec

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -97,18 +97,14 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 					trialQuotas = append(trialQuotas, QuotaSpec{QuotaTrialType, 0, quotaResource.BillingModel, nil})
 				} else if quotaResource.GetProduct() == spec.InstanceQuotaID {
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
-					if remainingQuota > 0 {
-						if quotaResource.BillingModel == QuotaStandardType {
-							standardQuotas = append(standardQuotas, QuotaSpec{QuotaStandardType, remainingQuota, quotaResource.BillingModel, nil})
-						} else if quotaResource.BillingModel == QuotaMarketplaceType {
-							marketplaceQuotas = append(marketplaceQuotas, QuotaSpec{QuotaMarketplaceType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
-						}
+					if quotaResource.BillingModel == QuotaStandardType {
+						standardQuotas = append(standardQuotas, QuotaSpec{QuotaStandardType, remainingQuota, quotaResource.BillingModel, nil})
+					} else if quotaResource.BillingModel == QuotaMarketplaceType {
+						marketplaceQuotas = append(marketplaceQuotas, QuotaSpec{QuotaMarketplaceType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 					}
 				} else if quotaResource.GetProduct() == "RHOSAKEval" {
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
-					if remainingQuota > 0 {
-						evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
-					}
+					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 				}
 			}
 		}

--- a/pkg/shared/accountmgmtutil/api.go
+++ b/pkg/shared/accountmgmtutil/api.go
@@ -7,4 +7,5 @@ const (
 	QuotaTrialType       QuotaType = "trial"
 	QuotaStandardType    QuotaType = "standard"
 	QuotaMarketplaceType QuotaType = "marketplace"
+	QuotaEvalType        QuotaType = "eval"
 )

--- a/pkg/shared/remote/DynamicServiceConstants.go
+++ b/pkg/shared/remote/DynamicServiceConstants.go
@@ -17,5 +17,6 @@ type AmsConfig struct {
 	TermsAndConditionsSiteCode  string `json:"termsAndConditionsSiteCode"`
 	InstanceQuotaID             string `json:"quotaProductId"`
 	TrialProductQuotaID         string `json:"trialQuotaProductId"`
+	LongLivedQuotaProductID     string `json:"longLivedQuotaProductId"`
 	ResourceName                string `json:"resourceName"`
 }

--- a/pkg/shared/remote/service-constants.json
+++ b/pkg/shared/remote/service-constants.json
@@ -8,6 +8,7 @@
       "trialQuotaId": "cluster|rhinfra|rhosaktrial|standard",
       "quotaProductId": "RHOSAK",
       "trialQuotaProductId": "RHOSAKTrial",
+      "longLivedQuotaProductId": "RHOSAKEval",
       "resourceName": "rhosak"
     }
   },


### PR DESCRIPTION
Add additional billing model `eval` to create long lived trial instances.

### Verification Steps
1. Create a local binary of the CLI:
```
make binary
```
2. Login to an org having quotas for long lived trial instances
```
rhoas login --api-gateway staging
```
3. Run kafka create command setting `eval` as billing model
```
./rhoas kafka create --name test-instance --billing-model eval --dry-run -v
```
4. The logs should show that the selected quota object with name "eval".
5. Request body should have billing model "eval".

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
