### PR TITLE
Add custom cluster mgmt url flag

### DIFF
--- a/docs/commands/rhoas.md
+++ b/docs/commands/rhoas.md
@@ -41,7 +41,7 @@ $ rhoas cluster connect
 * [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, fish or powershell)
 * [rhoas connector](rhoas_connector.md)	 - Connectors commands
 * [rhoas context](rhoas_context.md)	 - Group, share and manage your rhoas services
-* [rhoas dedicated](rhoas_dedicated.md)	 - shortDescription
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your OpenShift clusters which host your kafkas.
 * [rhoas generate-config](rhoas_generate-config.md)	 - Generate configurations for the service context
 * [rhoas kafka](rhoas_kafka.md)	 - Create, view, use, and manage your Kafka instances
 * [rhoas login](rhoas_login.md)	 - Log in to RHOAS

--- a/docs/commands/rhoas_dedicated.md
+++ b/docs/commands/rhoas_dedicated.md
@@ -1,15 +1,19 @@
 ## rhoas dedicated
 
-shortDescription
+Manage your OpenShift clusters which host your kafkas.
 
 ### Synopsis
 
-longDescription
+Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
+kafkas. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+
 
 ### Examples
 
 ```
-example
+# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka.
+rhoas dedicated register-cluster
+
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/rhoas_dedicated_register-cluster.md
+++ b/docs/commands/rhoas_dedicated_register-cluster.md
@@ -38,5 +38,5 @@ rhoas cluster register-cluster --cluster-id 1234-5678-90ab-cdef
 
 ### SEE ALSO
 
-* [rhoas dedicated](rhoas_dedicated.md)	 - shortDescription
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your OpenShift clusters which host your kafkas.
 

--- a/docs/commands/rhoas_dedicated_register-cluster.md
+++ b/docs/commands/rhoas_dedicated_register-cluster.md
@@ -26,7 +26,9 @@ rhoas cluster register-cluster --cluster-id 1234-5678-90ab-cdef
 ### Options
 
 ```
-      --cluster-id string   The ID of the OpenShift cluster to register:
+      --access-token string           access token
+      --cluster-id string             The ID of the OpenShift cluster to register:
+      --cluster-mgmt-api-url string   cluster management api url
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/dedicated/dedicated.go
+++ b/pkg/cmd/dedicated/dedicated.go
@@ -6,16 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TO-DO add localizer and descriptions
 func NewDedicatedCmd(f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "dedicated",
-		// Short:   f.Localizer.MustLocalize("kafka.topic.cmd.shortDescription"),
-		Short: "shortDescription",
-		// Long:    f.Localizer.MustLocalize("kafka.topic.cmd.longDescription"),
-		Long: "longDescription",
-		// Example: f.Localizer.MustLocalize("kafka.topic.cmd.example"),
-		Example: "example",
+		Use:     "dedicated",
+		Short:   f.Localizer.MustLocalize("dedicated.cmd.shortDescription"),
+		Long:    f.Localizer.MustLocalize("dedicated.cmd.longDescription"),
+		Example: f.Localizer.MustLocalize("dedicated.cmd.example"),
 	}
 
 	cmd.AddCommand(

--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -378,17 +378,12 @@ func selectAccessPrivateNetworkInteractivePrompt(opts *options) error {
 		Help:    opts.f.Localizer.MustLocalize("dedicated.registerCluster.prompt.selectPublicNetworkAccess.help"),
 		Default: false,
 	}
-	accessKafkasViaPublicNetwork := false
-	err := survey.AskOne(prompt, &accessKafkasViaPublicNetwork)
+	accessFromPublicNetwork := true
+	err := survey.AskOne(prompt, accessFromPublicNetwork)
 	if err != nil {
 		return err
 	}
-	if accessKafkasViaPublicNetwork {
-		opts.accessKafkasViaPrivateNetwork = false
-	} else {
-		opts.accessKafkasViaPrivateNetwork = true
-	}
-
+	opts.accessKafkasViaPrivateNetwork = !accessFromPublicNetwork
 	return nil
 }
 
@@ -440,7 +435,7 @@ func getStrimziAddonIdByEnv(con *config.Config) string {
 	return strimziAddonIdQE
 }
 
-func getKafkaFleetManagerAddonIdByEnv(con *config.Config) string {
+func getKafkaFleetShardAddonIdByEnv(con *config.Config) string {
 	if con.APIUrl == build.ProductionAPIURL {
 		return fleetshardAddonId
 	}
@@ -481,7 +476,7 @@ func registerClusterWithKasFleetManager(opts *options) error {
 	if err != nil {
 		return err
 	}
-	err = createAddonWithParams(opts, getKafkaFleetManagerAddonIdByEnv(con), response.FleetshardParameters)
+	err = createAddonWithParams(opts, getKafkaFleetShardAddonIdByEnv(con), response.FleetshardParameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -33,19 +33,18 @@ type options struct {
 
 // list of consts should come from KFM
 const (
-	machinePoolId                  = "kafka-standard"
-	machinePoolTaintKey            = "bf2.org/kafkaInstanceProfileType"
-	machinePoolTaintEffect         = "NoExecute"
-	machinePoolTaintValue          = "standard"
-	machinePoolInstanceType        = "r5.xlarge"
-	machinePoolLabelKey            = "bf2.org/kafkaInstanceProfileType"
-	machinePoolLabelValue          = "standard"
-	clusterReadyState              = "ready"
-	defaultClusterManagementAPIURL = "https://api.openshift.com"
-	fleetshardAddonId              = "kas-fleetshard-operator"
-	strimziAddonId                 = "managed-kafka"
-	fleetshardAddonIdQE            = "kas-fleetshard-operator-qe"
-	strimziAddonIdQE               = "managed-kafka-qe"
+	machinePoolId           = "kafka-standard"
+	machinePoolTaintKey     = "bf2.org/kafkaInstanceProfileType"
+	machinePoolTaintEffect  = "NoExecute"
+	machinePoolTaintValue   = "standard"
+	machinePoolInstanceType = "r5.xlarge"
+	machinePoolLabelKey     = "bf2.org/kafkaInstanceProfileType"
+	machinePoolLabelValue   = "standard"
+	clusterReadyState       = "ready"
+	fleetshardAddonId       = "kas-fleetshard-operator"
+	strimziAddonId          = "managed-kafka"
+	fleetshardAddonIdQE     = "kas-fleetshard-operator-qe"
+	strimziAddonIdQE        = "managed-kafka-qe"
 )
 
 func NewRegisterClusterCommand(f *factory.Factory) *cobra.Command {
@@ -74,9 +73,6 @@ func NewRegisterClusterCommand(f *factory.Factory) *cobra.Command {
 
 func runRegisterClusterCmd(opts *options) (err error) {
 	// Set the base URL for the cluster management API
-	if opts.clusterManagementApiUrl == "" {
-		opts.clusterManagementApiUrl = defaultClusterManagementAPIURL
-	}
 	err = setListClusters(opts)
 	if err != nil {
 		return err

--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -3,6 +3,8 @@ package register
 import (
 	"context"
 	"fmt"
+	"github.com/redhat-developer/app-services-cli/internal/build"
+	"github.com/redhat-developer/app-services-cli/pkg/core/config"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -15,12 +17,11 @@ import (
 )
 
 type options struct {
-	selectedClusterId string
-	// clusterManagementApiUrl       string
-	// accessToken                   string
-	clusterList     []clustersmgmtv1.Cluster
-	selectedCluster clustersmgmtv1.Cluster
-	// clusterMachinePoolList        clustersmgmtv1.MachinePoolList
+	selectedClusterId             string
+	clusterManagementApiUrl       string
+	accessToken                   string
+	clusterList                   []clustersmgmtv1.Cluster
+	selectedCluster               clustersmgmtv1.Cluster
 	existingMachinePoolList       []clustersmgmtv1.MachinePool
 	selectedClusterMachinePool    clustersmgmtv1.MachinePool
 	requestedMachinePoolNodeCount int
@@ -32,18 +33,19 @@ type options struct {
 
 // list of consts should come from KFM
 const (
-	machinePoolId          = "kafka-standard"
-	machinePoolTaintKey    = "bf2.org/kafkaInstanceProfileType"
-	machinePoolTaintEffect = "NoExecute"
-	machinePoolTaintValue  = "standard"
-	// machinePoolInstanceType = "m5.2xlarge"
-	machinePoolInstanceType = "r5.xlarge"
-	machinePoolLabelKey     = "bf2.org/kafkaInstanceProfileType"
-	machinePoolLabelValue   = "standard"
-	clusterReadyState       = "ready"
-	fleetshardAddonId       = "kas-fleetshard-operator"
-	strimziAddonId          = "managed-kafka"
-	// clusterManagementAPIURL = "https://api.openshift.com"
+	machinePoolId                  = "kafka-standard"
+	machinePoolTaintKey            = "bf2.org/kafkaInstanceProfileType"
+	machinePoolTaintEffect         = "NoExecute"
+	machinePoolTaintValue          = "standard"
+	machinePoolInstanceType        = "r5.xlarge"
+	machinePoolLabelKey            = "bf2.org/kafkaInstanceProfileType"
+	machinePoolLabelValue          = "standard"
+	clusterReadyState              = "ready"
+	defaultClusterManagementAPIURL = "https://api.openshift.com"
+	fleetshardAddonId              = "kas-fleetshard-operator"
+	strimziAddonId                 = "managed-kafka"
+	fleetshardAddonIdQE            = "kas-fleetshard-operator-qe"
+	strimziAddonIdQE               = "managed-kafka-qe"
 )
 
 func NewRegisterClusterCommand(f *factory.Factory) *cobra.Command {
@@ -62,19 +64,19 @@ func NewRegisterClusterCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	// TO-DO add flags
-	// add a flag for clustermgmt url, i.e --cluster-management-api-url, make the flag hidden, default to api.openshift.com
-	// supply customer mgmt access token via a flag, i.e --access-token, make the flag hidden, default to ""
 	flags := kafkaFlagutil.NewFlagSet(cmd, f.Localizer)
-	// flags.StringVar(&opts.clusterManagementApiUrl, "cluster-management-api-url", clusterManagementAPIURL, "cluster management api url")
-	// flags.StringVar(&opts.accessToken, "access-token", "", "access token")
-	// this flag will allow the user to pass the cluster id as a flag
+	flags.StringVar(&opts.clusterManagementApiUrl, "cluster-mgmt-api-url", "", f.Localizer.MustLocalize("dedicated.registerCluster.flag.clusterMgmtApiUrl.description"))
+	flags.StringVar(&opts.accessToken, "access-token", "", f.Localizer.MustLocalize("dedicated.registercluster.flag.accessToken.description"))
 	flags.StringVar(&opts.selectedClusterId, "cluster-id", "", f.Localizer.MustLocalize("dedicated.registerCluster.flag.clusterId.description"))
 
 	return cmd
 }
 
 func runRegisterClusterCmd(opts *options) (err error) {
+	// Set the base URL for the cluster management API
+	if opts.clusterManagementApiUrl == "" {
+		opts.clusterManagementApiUrl = defaultClusterManagementAPIURL
+	}
 	err = setListClusters(opts)
 	if err != nil {
 		return err
@@ -114,12 +116,11 @@ func runRegisterClusterCmd(opts *options) (err error) {
 }
 
 func getClusterList(opts *options) (*clustersmgmtv1.ClusterList, error) {
-	// ocm client connection
 	conn, err := opts.f.Connection()
 	if err != nil {
 		return nil, err
 	}
-	client, cc, err := conn.API().OCMClustermgmt()
+	client, cc, err := conn.API().OCMClustermgmt(opts.clusterManagementApiUrl, opts.accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -147,9 +148,7 @@ func setListClusters(opts *options) error {
 
 func validateClusters(clusters *clustersmgmtv1.ClusterList, cls []clustersmgmtv1.Cluster) []clustersmgmtv1.Cluster {
 	for _, cluster := range clusters.Slice() {
-		// TO-DO the cluster must be multiAZ
 		if cluster.State() == clusterReadyState && cluster.MultiAZ() == true {
-			// if cluster.State() == clusterReadyState {
 			cls = append(cls, *cluster)
 		}
 	}
@@ -223,7 +222,7 @@ func getMachinePoolList(opts *options) (*clustersmgmtv1.MachinePoolsListResponse
 	if err != nil {
 		return nil, err
 	}
-	client, cc, err := conn.API().OCMClustermgmt()
+	client, cc, err := conn.API().OCMClustermgmt(opts.clusterManagementApiUrl, opts.accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -295,12 +294,11 @@ func createMachinePoolRequestForDedicated(machinePoolNodeCount int) (*clustersmg
 
 // TO-DO this function should be moved to an ocm client / provider area
 func createMachinePool(opts *options, mprequest *clustersmgmtv1.MachinePool) error {
-	// create a new machine pool via ocm
 	conn, err := opts.f.Connection()
 	if err != nil {
 		return err
 	}
-	client, cc, err := conn.API().OCMClustermgmt()
+	client, cc, err := conn.API().OCMClustermgmt(opts.clusterManagementApiUrl, opts.accessToken)
 	if err != nil {
 		return err
 	}
@@ -416,7 +414,7 @@ func createAddonWithParams(opts *options, addonId string, params *[]kafkamgmtcli
 	if err != nil {
 		return err
 	}
-	client, cc, err := conn.API().OCMClustermgmt()
+	client, cc, err := conn.API().OCMClustermgmt(opts.clusterManagementApiUrl, opts.accessToken)
 	if err != nil {
 		return err
 	}
@@ -437,6 +435,20 @@ func createAddonWithParams(opts *options, addonId string, params *[]kafkamgmtcli
 	}
 
 	return nil
+}
+
+func getStrimziAddonIdByEnv(con *config.Config) string {
+	if con.APIUrl == build.ProductionAPIURL {
+		return strimziAddonId
+	}
+	return strimziAddonIdQE
+}
+
+func getKafkaFleetManagerAddonIdByEnv(con *config.Config) string {
+	if con.APIUrl == build.ProductionAPIURL {
+		return fleetshardAddonId
+	}
+	return fleetshardAddonIdQE
 }
 
 // TO-DO go through errs and make them more user friendly with actual error messages.
@@ -465,11 +477,15 @@ func registerClusterWithKasFleetManager(opts *options) error {
 	if err != nil {
 		return err
 	}
-	err = createAddonWithParams(opts, strimziAddonId, nil)
+	con, err := opts.f.Config.Load()
 	if err != nil {
 		return err
 	}
-	err = createAddonWithParams(opts, fleetshardAddonId, response.FleetshardParameters)
+	err = createAddonWithParams(opts, getStrimziAddonIdByEnv(con), nil)
+	if err != nil {
+		return err
+	}
+	err = createAddonWithParams(opts, getKafkaFleetManagerAddonIdByEnv(con), response.FleetshardParameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -26,7 +26,7 @@ one = 'The ID of the OpenShift cluster to register:'
 one = 'Select the ready cluster to register'
 
 [dedicated.registerCluster.prompt.selectPublicNetworkAccess.message]
-one = 'Would you like your Kakfas to be accessible via a public network?'
+one = 'Would you like your Kafkas to be accessible via a public network?'
 
 [dedicated.registerCluster.prompt.selectPublicNetworkAccess.help]
 one = 'If you select yes, your Kafka will be accessible via a public network'

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -67,3 +67,9 @@ terraforming your cluster for use with your Kafkas.
 
 [dedicated.registerCluster.kfmResponse.status.conflict]
 one = 'The cluster has already been registered with Red Hat OpenShift Streams for Apache Kafka.'
+
+[dedicated.registerCluster.flag.clusterMgmtApiUrl.description]
+one = 'The API URL of the OpenShift Cluster Management API.'
+
+[dedicated.registercluster.flag.accessToken.description]
+one = 'The access token to use to authenticate with the OpenShift Cluster Management API.'

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -43,3 +43,27 @@ There will be N/3 streaming units in your Kafka cluster, where N is the machine 
 
 [dedicated.registerCluster.info.foundValidMachinePool]
 one = 'Using the valid machine pool:'
+
+[dedicated.cmd.shortDescription]
+one = 'Manage your OpenShift clusters which host your kafkas.'
+
+[dedicated.cmd.longDescription]
+one = '''
+Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
+kafkas. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+'''
+
+[dedicated.cmd.example]
+one = '''
+# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka.
+rhoas dedicated register-cluster
+'''
+
+[dedicated.registerCluster.kfmResponse.status.clusterAccepted]
+one = '''
+The cluster has been accepted. Red Hat OpenShift Streams for Apache Kafka control plane is now
+terraforming your cluster for use with your Kafkas.
+'''
+
+[dedicated.registerCluster.kfmResponse.status.conflict]
+one = 'The cluster has already been registered with Red Hat OpenShift Streams for Apache Kafka.'

--- a/pkg/shared/connection/api/api.go
+++ b/pkg/shared/connection/api/api.go
@@ -1,10 +1,10 @@
 package api
 
 import (
+	ocmclustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"net/http"
 	"net/url"
 
-	ocmclustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/redhat-developer/app-services-cli/pkg/api/generic"
 	"github.com/redhat-developer/app-services-cli/pkg/api/rbac"
 	"github.com/redhat-developer/app-services-cli/pkg/core/logging"
@@ -29,7 +29,7 @@ type API interface {
 	RBAC() rbac.RbacAPI
 	GenericAPI() generic.GenericAPI
 	GetConfig() Config
-	OCMClustermgmt() (*ocmclustersmgmtv1.Client, func(), error)
+	OCMClustermgmt(apiGateway, accessToken string) (*ocmclustersmgmtv1.Client, func(), error)
 }
 
 type Config struct {

--- a/pkg/shared/connection/api/defaultapi/default_client.go
+++ b/pkg/shared/connection/api/defaultapi/default_client.go
@@ -291,11 +291,13 @@ func (a *defaultAPI) CreateOAuthTransport(accessToken string) *http.Client {
 }
 
 func (a *defaultAPI) createOCMConnection(clusterMgmtApiUrl, accessToken string) (*ocmSdkClient.Connection, func(), error) {
+	if clusterMgmtApiUrl == "" {
+		clusterMgmtApiUrl = build.ProductionAPIURL
+	}
 	if accessToken == "" {
 		accessToken = a.AccessToken
 	}
 	connection, err := ocmSdkClient.NewConnectionBuilder().
-		// the access token and url here should be specified and configurable
 		URL(clusterMgmtApiUrl).
 		Tokens(accessToken).
 		Build()

--- a/pkg/shared/connection/api/defaultapi/default_client.go
+++ b/pkg/shared/connection/api/defaultapi/default_client.go
@@ -290,10 +290,14 @@ func (a *defaultAPI) CreateOAuthTransport(accessToken string) *http.Client {
 	}
 }
 
-func (a *defaultAPI) CreateOCMConnection() (*ocmSdkClient.Connection, func(), error) {
+func (a *defaultAPI) createOCMConnection(clusterMgmtApiUrl, accessToken string) (*ocmSdkClient.Connection, func(), error) {
+	if accessToken == "" {
+		accessToken = a.AccessToken
+	}
 	connection, err := ocmSdkClient.NewConnectionBuilder().
 		// the access token and url here should be specified and configurable
-		Tokens(a.AccessToken).
+		URL(clusterMgmtApiUrl).
+		Tokens(accessToken).
 		Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
@@ -305,8 +309,8 @@ func (a *defaultAPI) CreateOCMConnection() (*ocmSdkClient.Connection, func(), er
 }
 
 // create an OCM clustermgmt client
-func (a *defaultAPI) OCMClustermgmt() (*ocmclustersmgmtv1.Client, func(), error) {
-	connection, closeConnection, err := a.CreateOCMConnection()
+func (a *defaultAPI) OCMClustermgmt(clusterMgmtApiUrl, accessToken string) (*ocmclustersmgmtv1.Client, func(), error) {
+	connection, closeConnection, err := a.createOCMConnection(clusterMgmtApiUrl, accessToken)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

This allows the user to specify a custom api-gateway for their clustermgmt (ocm) which allows the CLI to install stage Addons if the targeted KFM deployment is stage.

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
