### PR TITLE
fix(dedicated): attempts to correctly parse the cluster ingress dns name

### DIFF
--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -3,9 +3,10 @@ package register
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/redhat-developer/app-services-cli/internal/build"
 	"github.com/redhat-developer/app-services-cli/pkg/core/config"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -181,13 +182,19 @@ func runClusterSelectionInteractivePrompt(opts *options) error {
 	return nil
 }
 
-// parses the
+// parseDNSURL attempts to parse the cluster ingress dns name from the console url.
 func parseDNSURL(opts *options) (string, error) {
 	clusterIngressDNSName := opts.selectedCluster.Console().URL()
 	if len(clusterIngressDNSName) == 0 {
 		return "", fmt.Errorf("DNS url is empty")
 	}
-	return strings.SplitAfter(clusterIngressDNSName, ".apps.")[1], nil
+
+	splits := strings.SplitAfterN(clusterIngressDNSName, "console-openshift-console.", 2)
+	if len(splits) == 2 {
+		return splits[1], nil
+	}
+
+	return "", fmt.Errorf("could not construct cluster_ingress_dns_name")
 }
 
 func getOrCreateMachinePoolList(opts *options) error {


### PR DESCRIPTION
This is so that "apps." prefix is always included and required by KFM when it is running under certain configuration

Related to https://github.com/bf2fc6cc711aee1a0c2a/kas-installer/issues/266#issuecomment-1424156487

### Verification Steps

1. `make binary`
2. `./rhoas dedicated register-cluster  -v` and observe that the KFM cluster registration payload now contains a valid `cluster_ingress_dns_name` field i.e with `apps.` prefix in it.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- ~~[ ] New feature (non-breaking change which adds functionality)~~
- ~~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- ~~[ ] Documentation change~~
- ~~[ ] Other (please specify)~~
