### PR TITLE
Enterprise create kafka interactive refactor2

### DIFF
--- a/pkg/cmd/dedicated/listclusters/list.go
+++ b/pkg/cmd/dedicated/listclusters/list.go
@@ -50,11 +50,17 @@ func NewListClusterCommand(f *factory.Factory) *cobra.Command {
 }
 
 func runListClusters(opts *options, f *factory.Factory) error {
-	kfmClusterList, err := kafkautil.ListEnterpriseClusters(f)
+	kfmClusterList, response, err := kafkautil.ListEnterpriseClusters(f)
 	opts.kfmClusterList = kfmClusterList
 	if err != nil {
-		return err
+
+		if response.StatusCode == 403 {
+			return opts.f.Localizer.MustLocalizeError("dedicated.list.error.permissionDenied")
+		}
+
+		return fmt.Errorf("%v, %v", response.Status, err)
 	}
+
 	clist, err := clustermgmt.GetClusterListByIds(opts.f, opts.accessToken, opts.clusterManagementApiUrl, CreateSearchString(opts.kfmClusterList), len(opts.kfmClusterList.Items))
 	if err != nil {
 		return err

--- a/pkg/cmd/dedicated/listclusters/list.go
+++ b/pkg/cmd/dedicated/listclusters/list.go
@@ -55,7 +55,7 @@ func runListClusters(opts *options, f *factory.Factory) error {
 	if err != nil {
 		return err
 	}
-	clist, err := clustermgmt.GetClusterListByIds(opts.f, opts.accessToken, opts.clusterManagementApiUrl, createSearchString(opts), len(opts.kfmClusterList.Items))
+	clist, err := clustermgmt.GetClusterListByIds(opts.f, opts.accessToken, opts.clusterManagementApiUrl, CreateSearchString(opts.kfmClusterList), len(opts.kfmClusterList.Items))
 	if err != nil {
 		return err
 	}
@@ -68,9 +68,9 @@ func runListClusters(opts *options, f *factory.Factory) error {
 	return nil
 }
 
-func createSearchString(opts *options) string {
+func CreateSearchString(kfmClusterList *kafkamgmtclient.EnterpriseClusterList) string {
 	searchString := ""
-	for idx, kfmcluster := range opts.kfmClusterList.Items {
+	for idx, kfmcluster := range kfmClusterList.Items {
 		if idx > 0 {
 			searchString += " or "
 		}

--- a/pkg/cmd/dedicated/listclusters/list_test.go
+++ b/pkg/cmd/dedicated/listclusters/list_test.go
@@ -16,7 +16,7 @@ func TestCreateSearchString(t *testing.T) {
 		{
 			name: "empty list",
 			opts: &options{kfmClusterList: &kafkamgmtclient.EnterpriseClusterList{
-				Items: []kafkamgmtclient.EnterpriseCluster{},
+				Items: []kafkamgmtclient.EnterpriseClusterListItem{},
 			},
 			},
 			expected: "",
@@ -24,7 +24,7 @@ func TestCreateSearchString(t *testing.T) {
 		{
 			name: "single clusters",
 			opts: &options{kfmClusterList: &kafkamgmtclient.EnterpriseClusterList{
-				Items: []kafkamgmtclient.EnterpriseCluster{
+				Items: []kafkamgmtclient.EnterpriseClusterListItem{
 					{
 						Id: "abc",
 					},
@@ -36,7 +36,7 @@ func TestCreateSearchString(t *testing.T) {
 		{
 			name: "two clusters",
 			opts: &options{kfmClusterList: &kafkamgmtclient.EnterpriseClusterList{
-				Items: []kafkamgmtclient.EnterpriseCluster{
+				Items: []kafkamgmtclient.EnterpriseClusterListItem{
 					{Id: "abc"},
 					{Id: "def"},
 				}}},
@@ -45,7 +45,7 @@ func TestCreateSearchString(t *testing.T) {
 		{
 			name: "multiple clusters",
 			opts: &options{kfmClusterList: &kafkamgmtclient.EnterpriseClusterList{
-				Items: []kafkamgmtclient.EnterpriseCluster{
+				Items: []kafkamgmtclient.EnterpriseClusterListItem{
 					{Id: "abc"},
 					{Id: "def"},
 					{Id: "ghi"},
@@ -58,7 +58,7 @@ func TestCreateSearchString(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Call the function
-			actual := createSearchString(tc.opts)
+			actual := CreateSearchString(tc.opts.kfmClusterList)
 
 			// Compare the result with the expected value
 			if actual != tc.expected {

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -612,13 +612,13 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 			}
 		}
 	}
-	
+
 	marketplaceInfo := accountmgmtutil.MarketplaceInfo{
 		BillingModel:   answers.BillingModel,
 		Provider:       answers.Marketplace,
 		CloudAccountID: answers.MarketplaceAcctID,
 	}
-	
+
 	var sizes []kafkamgmtclient.SupportedKafkaSize
 	payload := &kafkamgmtclient.KafkaRequestPayload{}
 
@@ -653,7 +653,7 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		selectedSize := sizes[index]
 
 		if selectedSize.GetCapacityConsumed() > cluster.CapacityInformation.RemainingKafkaStreamingUnits {
-			return nil, opts.f.Localizer.MustLocalizeError("kafka.create.provider.error.noStandardInstancesAvailable")
+			return nil, opts.f.Localizer.MustLocalizeError("kafka.create.cluster.error.noEnoughCapacity", localize.NewEntry("Size", selectedSize.GetId()))
 		}
 
 		answers.Size = selectedSize.GetId()

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -608,19 +608,21 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 
 		sizes = supportedKafkaTypes[0].Sizes
 
-		index, err := promptUserForSizes(opts.f, &sizes)
-		if err != nil {
-			return nil, err
+		if opts.size == "" {
+			index, err := promptUserForSizes(opts.f, &sizes)
+			if err != nil {
+				return nil, err
+			}
+
+			selectedSize := sizes[index]
+
+			if selectedSize.GetCapacityConsumed() > cluster.CapacityInformation.RemainingKafkaStreamingUnits {
+				return nil, opts.f.Localizer.MustLocalizeError("kafka.create.cluster.error.noEnoughCapacity", localize.NewEntry("Size", selectedSize.GetId()))
+			}
+
+			answers.Size = selectedSize.GetId()
+
 		}
-
-		selectedSize := sizes[index]
-
-		if selectedSize.GetCapacityConsumed() > cluster.CapacityInformation.RemainingKafkaStreamingUnits {
-			return nil, opts.f.Localizer.MustLocalizeError("kafka.create.cluster.error.noEnoughCapacity", localize.NewEntry("Size", selectedSize.GetId()))
-		}
-
-		answers.Size = selectedSize.GetId()
-
 		if len(orgQuota.EnterpriseQuotas) == 0 {
 			return nil, fmt.Errorf("No enterprise quota available")
 		}

--- a/pkg/cmd/kafka/create/data.go
+++ b/pkg/cmd/kafka/create/data.go
@@ -33,6 +33,8 @@ func mapAmsTypeToBackendType(amsType *accountmgmtutil.QuotaSpec) CloudProviderId
 		return StandardType
 	case accountmgmtutil.QuotaTrialType:
 		return DeveloperType
+	case accountmgmtutil.QuotaEnterpriseType:
+		return StandardType
 	default:
 		return DeveloperType
 	}

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -98,4 +98,8 @@ rhoas dedicated list
 [dedicated.list.cmd.errorNoRegisteredClusters]
 one = 'No registered clusters found.'
 
+[dedicated.list.error.permissionDenied]
+one = 'You do not have permissions to list Hybrid clusters'
+
+
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -464,6 +464,9 @@ one = 'no marketplace quota found with the specified marketplace provider and ac
 [kafka.create.quota.error.multipleCloudAccounts]
 one = 'multiple cloud accounts found, please specify "--marketplace" and "--marketplace-account-id"'
 
+[kafka.create.provider.error.onlyEnterpriseQuota]
+one = 'there is only quota availble for enterprise, cannot use Red Hat infrastructure'
+
 [kafka.delete.cmd.shortDescription]
 description = "Short description for command"
 one = "Delete a Kafka instance"

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -342,7 +342,7 @@ description = 'Input title for Cloud Region'
 one = "Cloud Region:"
 
 [kafka.create.input.plan.message]
-one = 'Instance type:'
+one = 'Instance size:'
 
 [kafka.create.input.marketPlace.message]
 one = 'Select a marketplace:'
@@ -1188,14 +1188,13 @@ one = 'ID of the Customer-Cloud data plane cluster to create the Kafka instance 
 one = 'Please select the cluster to provision your Kafka Instance on:'
 
 [kafka.create.input.cluster.message]
-one = 'Would you like to use Red Hat Managed infrastructure or your own OpenShift Cluster to provision your Kakfa instance on:'
+one = 'Would you like to use Red Hat Managed OpenShift clusters or your own OpenShift Cluster to provision your Kakfa instance on:'
 
 [kafka.create.input.cluster.option.enterprise]
-one = 'Bring your own OpenShift Cluster'
+one = 'Bring your own OpenShift Cluster for your Kafka Instances'
 
 [kafka.create.input.cluster.option.rhinfr]
-one = 'Red Hat Managed Infrastructure'
-
+one = 'Red Hat Managed OpenShift Cluster for your Kafka Instances'
 
 [kafka.create.input.cluster.help]
 one = 'Select the cluster to provision your Kafka instance on.'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -432,6 +432,18 @@ one = 'the cluster you have selected does not have capacity for size {{.Size}}'
 [kafka.create.provider.error.noMarketplaceQuota]
 one = 'no marketplace quota available for given provider'
 
+[kafka.create.error.notEnoughQuota]
+one = 'you do not have enough quota to create a kafka of size {{.Size}}'
+
+[kafka.create.error.noEnterpriseQuota]
+one = 'you do not have any enterprise quota availble'
+
+[kafka.create.error.noQuotaLeft]
+one = 'you have no remaining quoata to create a Kafka instance'
+
+[kafka.create.error.noCapacityInSelectedCluster]
+one = 'the cluster you selected does not have any remainging capacity'
+
 [kafka.create.provider.error.unsupportedMarketplace]
 one = 'selected marketplace is not supported for the cloud provider'
 
@@ -664,6 +676,9 @@ one = 'Text search to filter the Kafka instances by name, owner, cloud_provider,
 [kafka.list.log.debug.filteringKafkaList]
 description = 'Debug message when filtering the list of Kafka instances'
 one = 'Filtering Kafka instances with the query "{{.Search}}"'
+
+[kafka.create.getEnterpriseClusters.noQuota]
+one = ''
 
 [kafka.topic.common.flag.name.description]
 one = 'Topic name'

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -426,6 +426,9 @@ one = 'all regions in the selected cloud provider are temporarily unavailable'
 [kafka.create.provider.error.noStandardInstancesAvailable]
 one = 'standard instances are unavailable for the cloud provider, try another provider'
 
+[kafka.create.cluster.error.noEnoughCapacity]
+one = 'the cluster you have selected does not have capacity for size {{.Size}}'
+
 [kafka.create.provider.error.noMarketplaceQuota]
 one = 'no marketplace quota available for given provider'
 

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -87,6 +87,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 		return nil, err
 	}
 
+	//this should be refactored and base of the logic by the billing model information that's returned by KFM for each supported instance type
 	var standardQuotas, marketplaceQuotas, trialQuotas, evalQuotas, enterpriseQuotas []QuotaSpec
 	for _, quota := range quotaCostGet.GetItems() {
 		quotaResources := quota.GetRelatedResources()
@@ -106,9 +107,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 				case "RHOSAKEval":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
-				//	this isn't working as it should be as the product is hardcoded here
-				case "RHOSAKCC":
-					//case spec.EnterpriseProductQuotaID:
+				case spec.EnterpriseProductQuotaID:
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					enterpriseQuotas = append(enterpriseQuotas, QuotaSpec{QuotaEnterpriseType, remainingQuota, quotaResource.BillingModel, nil})
 				}

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -3,7 +3,6 @@ package accountmgmtutil
 import (
 	"context"
 	"errors"
-
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 
@@ -125,7 +124,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 // nolint:funlen
 func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo MarketplaceInfo, provider string) (*QuotaSpec, error) {
 
-	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.EvalQuotas) == 0 {
+	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.EvalQuotas) == 0 && len(orgQuota.EnterpriseQuotas) == 0 {
 		if marketplaceInfo.BillingModel != "" || marketplaceInfo.Provider != "" {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.onlyTrialAvailable")
 		}
@@ -133,7 +132,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 		return &orgQuota.TrialQuotas[0], nil
 	}
 
-	if len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.StandardQuotas) > 0 && len(orgQuota.EvalQuotas) == 0 {
+	if len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.StandardQuotas) > 0 && len(orgQuota.EvalQuotas) == 0 && len(orgQuota.EnterpriseQuotas) == 0 {
 		if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.noMarketplace")
 		}
@@ -145,7 +144,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 		return &orgQuota.StandardQuotas[0], nil
 	}
 
-	if len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.StandardQuotas) == 0 && len(orgQuota.EvalQuotas) > 0 {
+	if len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.StandardQuotas) == 0 && len(orgQuota.EvalQuotas) > 0 && len(orgQuota.EnterpriseQuotas) == 0 {
 		if marketplaceInfo.BillingModel == QuotaMarketplaceType || marketplaceInfo.Provider != "" || marketplaceInfo.CloudAccountID != "" {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.noMarketplace")
 		}
@@ -157,7 +156,7 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 		return &orgQuota.EvalQuotas[0], nil
 	}
 
-	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) > 0 && len(orgQuota.EvalQuotas) == 0 {
+	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) > 0 && len(orgQuota.EvalQuotas) == 0 && len(orgQuota.EnterpriseQuotas) == 0 {
 
 		if marketplaceInfo.BillingModel == QuotaStandardType {
 			return nil, f.Localizer.MustLocalizeError("kafka.create.quota.error.noStandard")
@@ -197,6 +196,10 @@ func SelectQuotaForUser(f *factory.Factory, orgQuota *OrgQuotas, marketplaceInfo
 		}
 
 		return marketplaceQuota, nil
+	}
+
+	if len(orgQuota.StandardQuotas) == 0 && len(orgQuota.MarketplaceQuotas) == 0 && len(orgQuota.EvalQuotas) == 0 && len(orgQuota.EnterpriseQuotas) > 0 {
+		return nil, f.Localizer.MustLocalizeError("kafka.create.provider.error.onlyEnterpriseQuota")
 	}
 
 	quotaTypeCount := 0

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -107,7 +107,9 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 				case "RHOSAKEval":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
-				case spec.EnterpriseProductQuotaID:
+					// this needs to be reflected upstream to work
+					//case spec.EnterpriseProductQuotaID:
+				case "RHOSAKCC":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					enterpriseQuotas = append(enterpriseQuotas, QuotaSpec{QuotaEnterpriseType, remainingQuota, quotaResource.BillingModel, nil})
 				}

--- a/pkg/shared/kafkautil/dedicated_utils.go
+++ b/pkg/shared/kafkautil/dedicated_utils.go
@@ -4,23 +4,24 @@ import (
 	"context"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-core/app-services-sdk-go/kafkamgmt/apiv1/client"
+	"net/http"
 )
 
-func ListEnterpriseClusters(f *factory.Factory) (*kafkamgmtclient.EnterpriseClusterList, error) {
+func ListEnterpriseClusters(f *factory.Factory) (*kafkamgmtclient.EnterpriseClusterList, *http.Response, error) {
 	conn, err := f.Connection()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
 	ctx := context.Background()
 	api := conn.API()
 	cl := api.KafkaMgmtEnterprise().GetEnterpriseOsdClusters(ctx)
 	clist, response, err := cl.Execute()
 	if err != nil {
-		return nil, err
+		return nil, response, err
 	}
-	if len(clist.Items) == 0 {
-		return &clist, nil
-	}
+
 	f.Logger.Debug(response)
-	return &clist, nil
+
+	return &clist, response, nil
 }

--- a/pkg/shared/remote/DynamicServiceConstants.go
+++ b/pkg/shared/remote/DynamicServiceConstants.go
@@ -19,5 +19,5 @@ type AmsConfig struct {
 	TrialProductQuotaID         string `json:"trialQuotaProductId"`
 	LongLivedQuotaProductID     string `json:"longLivedQuotaProductId"`
 	ResourceName                string `json:"resourceName"`
-	EnterpriseProductQuotaID    string `json:"RHOSAKCC"`
+	EnterpriseProductQuotaID    string `json:"enterpriseProductQuotaID"`
 }

--- a/pkg/shared/remote/DynamicServiceConstants.go
+++ b/pkg/shared/remote/DynamicServiceConstants.go
@@ -19,5 +19,5 @@ type AmsConfig struct {
 	TrialProductQuotaID         string `json:"trialQuotaProductId"`
 	LongLivedQuotaProductID     string `json:"longLivedQuotaProductId"`
 	ResourceName                string `json:"resourceName"`
-	EnterpriseProductQuotaID    string `json:"enterpriseProductQuotaID"`
+	EnterpriseProductQuotaID    string `json:"enterpriseProductQuotaId"`
 }

--- a/pkg/shared/remote/service-constants.json
+++ b/pkg/shared/remote/service-constants.json
@@ -9,7 +9,8 @@
       "quotaProductId": "RHOSAK",
       "trialQuotaProductId": "RHOSAKTrial",
       "longLivedQuotaProductId": "RHOSAKEval",
-      "resourceName": "rhosak"
+      "resourceName": "rhosak",
+      "enterpriseProductQuotaId": "RHOSAKCC"
     }
   },
   "serviceRegistry": {


### PR DESCRIPTION
Some refactoring of the create kafka cmd.

interactive prompt for cluster selection now shows name and ID. 

flags still need to be updated i.e. if flags are passed skip the interactive logic

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
