### PR TITLE
feat: added name of cluster to kafka list

### DIFF
--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -659,6 +659,9 @@ one = 'Text search to filter the Kafka instances by name, owner, cloud_provider,
 description = 'Debug message when filtering the list of Kafka instances'
 one = 'Filtering Kafka instances with the query "{{.Search}}"'
 
+[kafka.list.output.customerCloud.redhat]
+one = 'Red Hat Infrastructure'
+
 [kafka.topic.common.flag.name.description]
 one = 'Topic name'
 


### PR DESCRIPTION
### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Create a cluster that is on a dedicated cluster
2. Run `rhoas kafka list`
3. See the cluster colom now contains the name and id of the cluster

 
<img width="1556" alt="image" src="https://user-images.githubusercontent.com/45426048/222730736-2722b8a4-7916-44d7-a461-06c4f21315b4.png">


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
