### PR TITLE
Add clustermgmt flag to create kafka

### DIFF
--- a/docs/commands/rhoas.md
+++ b/docs/commands/rhoas.md
@@ -41,7 +41,7 @@ $ rhoas cluster connect
 * [rhoas completion](rhoas_completion.md)	 - Install command completion for your shell (bash, zsh, fish or powershell)
 * [rhoas connector](rhoas_connector.md)	 - Connectors commands
 * [rhoas context](rhoas_context.md)	 - Group, share and manage your rhoas services
-* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances.
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances
 * [rhoas generate-config](rhoas_generate-config.md)	 - Generate configurations for the service context
 * [rhoas kafka](rhoas_kafka.md)	 - Create, view, use, and manage your Kafka instances
 * [rhoas login](rhoas_login.md)	 - Log in to RHOAS

--- a/docs/commands/rhoas_dedicated.md
+++ b/docs/commands/rhoas_dedicated.md
@@ -1,17 +1,17 @@
 ## rhoas dedicated
 
-Manage your Hybrid OpenShift clusters which host your Kafka instances.
+Manage your Hybrid OpenShift clusters which host your Kafka instances
 
 ### Synopsis
 
 Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
-Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka
 
 
 ### Examples
 
 ```
-# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka.
+# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 rhoas dedicated register-cluster
 
 ```
@@ -27,6 +27,6 @@ rhoas dedicated register-cluster
 
 * [rhoas](rhoas.md)	 - RHOAS CLI
 * [rhoas dedicated deregister-cluster](rhoas_dedicated_deregister-cluster.md)	 - Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
-* [rhoas dedicated list](rhoas_dedicated_list.md)	 - List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka.
+* [rhoas dedicated list](rhoas_dedicated_list.md)	 - List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka
 * [rhoas dedicated register-cluster](rhoas_dedicated_register-cluster.md)	 - Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 

--- a/docs/commands/rhoas_dedicated.md
+++ b/docs/commands/rhoas_dedicated.md
@@ -26,7 +26,7 @@ rhoas dedicated register-cluster
 ### SEE ALSO
 
 * [rhoas](rhoas.md)	 - RHOAS CLI
-* [rhoas dedicated deregister-cluster](rhoas_dedicated_deregister-cluster.md)	 - Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
+* [rhoas dedicated deregister-cluster](rhoas_dedicated_deregister-cluster.md)	 - Deregister a Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka
 * [rhoas dedicated list](rhoas_dedicated_list.md)	 - List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka
 * [rhoas dedicated register-cluster](rhoas_dedicated_register-cluster.md)	 - Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 

--- a/docs/commands/rhoas_dedicated_deregister-cluster.md
+++ b/docs/commands/rhoas_dedicated_deregister-cluster.md
@@ -5,7 +5,7 @@ Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 ### Synopsis
 
 Removes the ability to provision your own Kafka instances on a cluster, this command will deregister your 
-Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka.
+Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka
 
 
 ```
@@ -15,20 +15,20 @@ rhoas dedicated deregister-cluster [flags]
 ### Examples
 
 ```
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters.
-rhoas cluster deregister-cluster
+# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+rhoas dedicated deregister-cluster
 
 # Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
-rhoas cluster deregister-cluster --cluster-id 1234-5678-90ab-cdef
+rhoas dedicated deregister-cluster --cluster-id 1234-5678-90ab-cdef
 
 ```
 
 ### Options
 
 ```
-      --access-token string           The access token to use to authenticate with the OpenShift Cluster Management API.
-      --cluster-id string             The ID of the OpenShift cluster to deregister.
-      --cluster-mgmt-api-url string   The API URL of the OpenShift Cluster Management API.
+      --access-token string           The access token to use to authenticate with the OpenShift Cluster Management API
+      --cluster-id string             The ID of the OpenShift cluster to deregister
+      --cluster-mgmt-api-url string   The API URL of the OpenShift Cluster Management API
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +40,5 @@ rhoas cluster deregister-cluster --cluster-id 1234-5678-90ab-cdef
 
 ### SEE ALSO
 
-* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances.
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances
 

--- a/docs/commands/rhoas_dedicated_deregister-cluster.md
+++ b/docs/commands/rhoas_dedicated_deregister-cluster.md
@@ -1,11 +1,11 @@
 ## rhoas dedicated deregister-cluster
 
-Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
+Deregister a Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka
 
 ### Synopsis
 
-Removes the ability to provision your own Kafka instances on a cluster, this command will deregister your 
-Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka
+Removes the ability to provision your own Kafka instances on your OpenShift cluster, this command will deregister your
+Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka
 
 
 ```
@@ -15,10 +15,10 @@ rhoas dedicated deregister-cluster [flags]
 ### Examples
 
 ```
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+# Deregister an OpenShift cluster from use with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
 rhoas dedicated deregister-cluster
 
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
+# Deregister an OpenShift cluster from Red Hat Streams for Apache Kafka by specifying the cluster ID
 rhoas dedicated deregister-cluster --cluster-id 1234-5678-90ab-cdef
 
 ```

--- a/docs/commands/rhoas_dedicated_list.md
+++ b/docs/commands/rhoas_dedicated_list.md
@@ -1,11 +1,11 @@
 ## rhoas dedicated list
 
-List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka.
+List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka
 
 ### Synopsis
 
 Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
-Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka
 
 
 ```
@@ -29,5 +29,5 @@ rhoas dedicated list
 
 ### SEE ALSO
 
-* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances.
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances
 

--- a/docs/commands/rhoas_dedicated_register-cluster.md
+++ b/docs/commands/rhoas_dedicated_register-cluster.md
@@ -4,8 +4,8 @@ Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 
 ### Synopsis
 
-You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat Streams for Apache Kafka
-This command will register your cluster with Red Hat Streams for Apache Kafka
+You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat OpenShift Streams for Apache Kafka
+This command will register your cluster with Red Hat OpenShift Streams for Apache Kafka
 
 
 ```
@@ -15,10 +15,10 @@ rhoas dedicated register-cluster [flags]
 ### Examples
 
 ```
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+# Register an OpenShift cluster with Red Hatl OpenShift Streams for Apache Kafka by selecting from a list of available clusters
 rhoas dedicated register-cluster
 
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID
+# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka by specifying the cluster ID
 rhoas dedicated register-cluster --cluster-id 1234-5678-90ab-cdef
 
 ```

--- a/docs/commands/rhoas_dedicated_register-cluster.md
+++ b/docs/commands/rhoas_dedicated_register-cluster.md
@@ -4,8 +4,8 @@ Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 
 ### Synopsis
 
-You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat Streams for Apache Kafka.
-This command will register your cluster with Red Hat Streams for Apache Kafka.
+You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat Streams for Apache Kafka
+This command will register your cluster with Red Hat Streams for Apache Kafka
 
 
 ```
@@ -15,10 +15,10 @@ rhoas dedicated register-cluster [flags]
 ### Examples
 
 ```
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters.
+# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
 rhoas dedicated register-cluster
 
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
+# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID
 rhoas dedicated register-cluster --cluster-id 1234-5678-90ab-cdef
 
 ```
@@ -26,11 +26,11 @@ rhoas dedicated register-cluster --cluster-id 1234-5678-90ab-cdef
 ### Options
 
 ```
-      --access-token string           The access token to use to authenticate with the OpenShift Cluster Management API.
+      --access-token string           The access token to use to authenticate with the OpenShift Cluster Management API
       --cluster-id string             The ID of the OpenShift cluster to register:
-      --cluster-mgmt-api-url string   The API URL of the OpenShift Cluster Management API.
-      --page-number int               The page number to use when listing Hybrid OpenShift clusters. (default 1)
-      --page-size int                 The page size to use when listing Hybrid OpenShift clusters. (default 100)
+      --cluster-mgmt-api-url string   The API URL of the OpenShift Cluster Management API
+      --page-number int               The page number to use when listing Hybrid OpenShift clusters (default 1)
+      --page-size int                 The page size to use when listing Hybrid OpenShift clusters (default 100)
 ```
 
 ### Options inherited from parent commands
@@ -42,5 +42,5 @@ rhoas dedicated register-cluster --cluster-id 1234-5678-90ab-cdef
 
 ### SEE ALSO
 
-* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances.
+* [rhoas dedicated](rhoas_dedicated.md)	 - Manage your Hybrid OpenShift clusters which host your Kafka instances
 

--- a/docs/commands/rhoas_kafka_list.md
+++ b/docs/commands/rhoas_kafka_list.md
@@ -29,7 +29,7 @@ $ rhoas kafka list -o json
 ### Options
 
 ```
-      --limit int       The maximum number of Kafka instances to be returned (default 100)
+      --limit int       The maximum number of Kafka instances to be returned (default 10)
   -o, --output string   Specify the output format. Choose from: "json", "yaml", "yml"
       --page int        Display the Kafka instances from the specified page number (default 1)
       --search string   Text search to filter the Kafka instances by name, owner, cloud_provider, region and status

--- a/pkg/cmd/dedicated/dedicated.go
+++ b/pkg/cmd/dedicated/dedicated.go
@@ -22,5 +22,7 @@ func NewDedicatedCmd(f *factory.Factory) *cobra.Command {
 		deregister.NewDeRegisterClusterCommand(f),
 	)
 
+	cmd.Hidden = true
+
 	return cmd
 }

--- a/pkg/cmd/dedicated/dedicated.go
+++ b/pkg/cmd/dedicated/dedicated.go
@@ -2,7 +2,7 @@ package dedicated
 
 import (
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/dedicated/deregister"
-	"github.com/redhat-developer/app-services-cli/pkg/cmd/dedicated/listclusters"
+	"github.com/redhat-developer/app-services-cli/pkg/cmd/dedicated/list"
 	"github.com/redhat-developer/app-services-cli/pkg/cmd/dedicated/register"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
 	"github.com/spf13/cobra"
@@ -18,7 +18,7 @@ func NewDedicatedCmd(f *factory.Factory) *cobra.Command {
 
 	cmd.AddCommand(
 		register.NewRegisterClusterCommand(f),
-		listclusters.NewListClusterCommand(f),
+		list.NewListClusterCommand(f),
 		deregister.NewDeRegisterClusterCommand(f),
 	)
 

--- a/pkg/cmd/dedicated/deregister/deregister.go
+++ b/pkg/cmd/dedicated/deregister/deregister.go
@@ -14,6 +14,7 @@ import (
 	kafkamgmtclient "github.com/redhat-developer/app-services-sdk-core/app-services-sdk-go/kafkamgmt/apiv1/client"
 	"github.com/spf13/cobra"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -268,7 +269,11 @@ func runClusterSelectionInteractivePrompt(opts *options, clusterList *[]*cluster
 		return err
 	}
 
-	// get the desired cluster
+	// get the desired cluster, ROSA cluster names and IDs cannot have spaces in them, so we can safely split on spaces
+	// strip brackets from the cluster ID
+	selectedClusterName = strings.Split(selectedClusterName, " ")[0]
+	selectedClusterName = strings.TrimSuffix(selectedClusterName, ")")
+	selectedClusterName = strings.TrimPrefix(selectedClusterName, "(")
 	for _, cluster := range *clusterList {
 		if cluster.Name() == selectedClusterName {
 			opts.selectedCluster = cluster

--- a/pkg/cmd/dedicated/deregister/deregister.go
+++ b/pkg/cmd/dedicated/deregister/deregister.go
@@ -116,13 +116,14 @@ func runDeRegisterClusterCmd(opts *options) error {
 func getListOfClusters(opts *options) ([]*clustersmgmtv1.Cluster, error) {
 	kfmClusterList, response, err := kafkautil.ListEnterpriseClusters(opts.f)
 	if err != nil {
-		if response.StatusCode == 403 {
-			return nil, opts.f.Localizer.MustLocalizeError("dedicated.deregisterCluster.error.403")
+		if response != nil {
+			if response.StatusCode == 403 {
+				return nil, opts.f.Localizer.MustLocalizeError("dedicated.deregisterCluster.error.403")
+			}
+
+			return nil, fmt.Errorf("%v, %w", response.Status, err)
 		}
-
-		return nil, fmt.Errorf("%v, %w", response.Status, err)
 	}
-
 	ocmClusterList, err := clustermgmt.GetClusterListByIds(opts.f, opts.accessToken, opts.clusterManagementApiUrl, kafkautil.CreateClusterSearchStringFromKafkaList(kfmClusterList), len(kfmClusterList.Items))
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/dedicated/list/list.go
+++ b/pkg/cmd/dedicated/list/list.go
@@ -1,4 +1,4 @@
-package listclusters
+package list
 
 import (
 	"fmt"
@@ -71,7 +71,7 @@ func runListClusters(opts *options, f *factory.Factory) error {
 
 	opts.kfmClusterList = kfmClusterList
 
-	clist, err := clustermgmt.GetClusterListByIds(opts.f, opts.accessToken, opts.clusterManagementApiUrl, kafkautil.CreateClusterSearchStringFromKafkaList(opts.kfmClusterList), len(opts.kfmClusterList.Items))
+	clist, err := clustermgmt.GetClusterListByIds(opts.f, opts.clusterManagementApiUrl, opts.accessToken, kafkautil.CreateClusterSearchStringFromKafkaList(opts.kfmClusterList), len(opts.kfmClusterList.Items))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dedicated/list/list_test.go
+++ b/pkg/cmd/dedicated/list/list_test.go
@@ -1,4 +1,4 @@
-package listclusters
+package list
 
 import (
 	"testing"

--- a/pkg/cmd/dedicated/listclusters/list.go
+++ b/pkg/cmd/dedicated/listclusters/list.go
@@ -3,6 +3,7 @@ package listclusters
 import (
 	"fmt"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	kafkaFlagutil "github.com/redhat-developer/app-services-cli/pkg/cmd/kafka/flagutil"
 	"github.com/redhat-developer/app-services-cli/pkg/core/ioutil/dump"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/connection/api/clustermgmt"
 	"github.com/redhat-developer/app-services-cli/pkg/shared/factory"
@@ -45,7 +46,12 @@ func NewListClusterCommand(f *factory.Factory) *cobra.Command {
 		},
 	}
 
+	flags := kafkaFlagutil.NewFlagSet(cmd, f.Localizer)
+
+	flags.StringVar(&opts.clusterManagementApiUrl, "cluster-mgmt-api-url", "", f.Localizer.MustLocalize("dedicated.registerCluster.flag.clusterMgmtApiUrl.description"))
+	flags.StringVar(&opts.accessToken, "access-token", "", f.Localizer.MustLocalize("dedicated.registercluster.flag.accessToken.description"))
 	return cmd
+
 }
 
 func runListClusters(opts *options, f *factory.Factory) error {
@@ -60,7 +66,7 @@ func runListClusters(opts *options, f *factory.Factory) error {
 			return fmt.Errorf("%v, %v", response.Status, err)
 		}
 
-		return fmt.Errorf("%v, %w", response.Status, err)
+		return err
 	}
 
 	opts.kfmClusterList = kfmClusterList

--- a/pkg/cmd/dedicated/listclusters/list.go
+++ b/pkg/cmd/dedicated/listclusters/list.go
@@ -60,7 +60,7 @@ func runListClusters(opts *options, f *factory.Factory) error {
 			return fmt.Errorf("%v, %v", response.Status, err)
 		}
 
-		return err
+		return fmt.Errorf("%v, %w", response.Status, err)
 	}
 
 	opts.kfmClusterList = kfmClusterList

--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -152,21 +152,14 @@ func runClusterSelectionInteractivePrompt(opts *options) error {
 		Options: clusterStringList,
 	}
 
-	var selectedClusterName string
-	err := survey.AskOne(prompt, &selectedClusterName)
+	var idx int
+	err := survey.AskOne(prompt, &idx)
 	if err != nil {
 		return err
 	}
+	opts.selectedCluster = opts.clusterList[idx]
+	opts.selectedClusterId = opts.clusterList[idx].ID()
 
-	// get the desired cluster name from the selected cluster string, rosa clusters cannot have spaces in their name
-	// therefore, we can split the string by the first space and get the cluster name
-	selectedClusterName = strings.Split(selectedClusterName, " (")[0]
-	for i := range opts.clusterList {
-		cluster := opts.clusterList[i]
-		if cluster.Name() == selectedClusterName {
-			opts.selectedCluster = cluster
-		}
-	}
 	return nil
 }
 

--- a/pkg/cmd/dedicated/register/registercluster.go
+++ b/pkg/cmd/dedicated/register/registercluster.go
@@ -158,7 +158,9 @@ func runClusterSelectionInteractivePrompt(opts *options) error {
 		return err
 	}
 
-	// get the desired cluster
+	// get the desired cluster name from the selected cluster string, rosa clusters cannot have spaces in their name
+	// therefore, we can split the string by the first space and get the cluster name
+	selectedClusterName = strings.Split(selectedClusterName, " (")[0]
 	for i := range opts.clusterList {
 		cluster := opts.clusterList[i]
 		if cluster.Name() == selectedClusterName {

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -4,32 +4,32 @@ one = 'Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache
 [dedicated.deregisterCluster.cmd.longDescription]
 one = '''
 Removes the ability to provision your own Kafka instances on a cluster, this command will deregister your 
-Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka.
+Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka
 '''
 
 [dedicated.deregisterCluster.cmd.example]
 one = '''
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters.
-rhoas cluster deregister-cluster
+# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+rhoas dedicated deregister-cluster
 
 # Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
-rhoas cluster deregister-cluster --cluster-id 1234-5678-90ab-cdef
+rhoas dedicated deregister-cluster --cluster-id 1234-5678-90ab-cdef
 '''
 
 [dedicated.deregisterCluster.flag.clusterMgmtApiUrl.description]
-one = 'The API URL of the OpenShift Cluster Management API.'
+one = 'The API URL of the OpenShift Cluster Management API'
 
 [dedicated.deregistercluster.flag.accessToken.description]
-one = 'The access token to use to authenticate with the OpenShift Cluster Management API.'
+one = 'The access token to use to authenticate with the OpenShift Cluster Management API'
 
 [dedicated.deregisterCluster.flag.clusterId.description]
-one = 'The ID of the OpenShift cluster to deregister.'
+one = 'The ID of the OpenShift cluster to deregister'
 
 [dedicated.deregisterCluster.run.noClusterFound]
-one = 'No valid OpenShift clusters found.'
+one = 'No valid OpenShift clusters found'
 
 [dedicated.deregisterCluster.noClusterFoundFromIdFlag]
-one = 'The cluster ID you have given "{{.ID}}" is not associated with a cluster'
+one = 'The cluster ID you have given "{{.ID}}" is not associated with an OpenShift cluster'
 
 [dedicated.deregisterCluster.deletingKafka.message]
 one = 'Waiting for all Kafkas to be deleted'
@@ -45,19 +45,19 @@ one = 'Register an OpenShift cluster with Red Hat OpenShift Streams for Apache K
 
 [dedicated.registerCluster.cmd.longDescription]
 one = '''
-You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat Streams for Apache Kafka.
-This command will register your cluster with Red Hat Streams for Apache Kafka.
+You can use your own OpenShift cluster to provision your Kafka instances which will be managed by Red Hat Streams for Apache Kafka
+This command will register your cluster with Red Hat Streams for Apache Kafka
 '''
 
 [dedicated.registerCluster.run.noClusterFound]
-one = 'No valid OpenShift clusters found.'
+one = 'No valid OpenShift clusters found'
 
 [dedicated.registerCluster.cmd.example]
 one = '''
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters.
+# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
 rhoas dedicated register-cluster
 
-# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
+# Register an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID
 rhoas dedicated register-cluster --cluster-id 1234-5678-90ab-cdef
 '''
 
@@ -87,17 +87,17 @@ There will be N/3 streaming units in your Kafka cluster, where N is the machine 
 one = 'Using the valid machine pool:'
 
 [dedicated.cmd.shortDescription]
-one = 'Manage your Hybrid OpenShift clusters which host your Kafka instances.'
+one = 'Manage your Hybrid OpenShift clusters which host your Kafka instances'
 
 [dedicated.cmd.longDescription]
 one = '''
 Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
-Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka
 '''
 
 [dedicated.cmd.example]
 one = '''
-# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka.
+# Register an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka
 rhoas dedicated register-cluster
 '''
 
@@ -114,27 +114,27 @@ one = 'To deregister a Hybrid OpenShift cluster all Kafka instances must be dele
 one = 'There was an unexpected error when deleting the Kafka instance'
 
 [dedicated.registerCluster.kfmResponse.status.conflict]
-one = 'This OpenShift cluster has already been registered with Red Hat OpenShift Streams for Apache Kafka.'
+one = 'This OpenShift cluster has already been registered with Red Hat OpenShift Streams for Apache Kafka'
 
 [dedicated.registerCluster.flag.clusterMgmtApiUrl.description]
-one = 'The API URL of the OpenShift Cluster Management API.'
+one = 'The API URL of the OpenShift Cluster Management API'
 
 [dedicated.registercluster.flag.accessToken.description]
-one = 'The access token to use to authenticate with the OpenShift Cluster Management API.'
+one = 'The access token to use to authenticate with the OpenShift Cluster Management API'
 
 [dedicated.registerCluster.flag.pageNumber.description]
-one = 'The page number to use when listing Hybrid OpenShift clusters.'
+one = 'The page number to use when listing Hybrid OpenShift clusters'
 
 [dedicated.registerCluster.flag.pageSize.description]
-one = 'The page size to use when listing Hybrid OpenShift clusters.'
+one = 'The page size to use when listing Hybrid OpenShift clusters'
 
 [dedicated.list.cmd.shortDescription]
-one = 'List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka.'
+one = 'List all OpenShift clusters registered with Red Hat OpenShift Streams for Apache Kafka'
 
 [dedicated.list.cmd.longDescription]
 one = '''
 Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
-Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
+Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka
 '''
 
 [dedicated.list.cmd.example]
@@ -144,10 +144,12 @@ rhoas dedicated list
 '''
 
 [dedicated.list.error.noRegisteredClustersFound]
-one = 'No registered OpenShift clusters found.'
+one = 'No registered OpenShift clusters found'
 
 [dedicated.list.error.permissionDenied]
 one = 'You do not have permissions to list Hybrid clusters'
 
+[dedicated.deregisterCluster.error.403]
+one = 'You do not have permissions to deregister this cluster'
 
 

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -4,12 +4,12 @@ one = 'Deregister a Hybrid OpenShift cluster from use with Red Hat OpenShift Str
 [dedicated.deregisterCluster.cmd.longDescription]
 one = '''
 Removes the ability to provision your own Kafka instances on your OpenShift cluster, this command will deregister your
-Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka
+Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka.
 '''
 
 [dedicated.deregisterCluster.cmd.example]
 one = '''
-# Deregister an OpenShift cluster from use with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+# Deregister an OpenShift cluster from use with Red Hat Streams for Apache Kafka by selecting from a list of available clusters.
 rhoas dedicated deregister-cluster
 
 # Deregister an OpenShift cluster from Red Hat Streams for Apache Kafka by specifying the cluster ID
@@ -32,7 +32,7 @@ one = 'No valid OpenShift clusters found'
 one = 'The cluster ID you have given "{{.ID}}" is not associated with an OpenShift cluster'
 
 [dedicated.deregisterCluster.deletingKafka.message]
-one = 'Waiting for all Kafkas to be deleted'
+one = 'Waiting for all Kafka instances to be deleted'
 
 [dedicated.deregisterCluster.deletingKafka.success]
 one = 'All Kafka instances have been deleted from cluster'
@@ -92,7 +92,7 @@ one = 'Manage your Hybrid OpenShift clusters which host your Kafka instances'
 [dedicated.cmd.longDescription]
 one = '''
 Red Hat OpenShift Streams for Apache Kafka allows you to use your own OpenShift clusters to provision your
-Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka
+Kafka instances. These Kafka instances will be managed by Red Hat OpenShift Streams for Apache Kafka.
 '''
 
 [dedicated.cmd.example]

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -1,18 +1,18 @@
 [dedicated.deregisterCluster.cmd.shortDescription]
-one = 'Deregister an OpenShift cluster with Red Hat OpenShift Streams for Apache Kafka'
+one = 'Deregister a Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka'
 
 [dedicated.deregisterCluster.cmd.longDescription]
 one = '''
-Removes the ability to provision your own Kafka instances on a cluster, this command will deregister your 
-Hybrid cluster with Red Hat OpenShift Streams for Apache Kafka
+Removes the ability to provision your own Kafka instances on your OpenShift cluster, this command will deregister your
+Hybrid OpenShift cluster from use with Red Hat OpenShift Streams for Apache Kafka
 '''
 
 [dedicated.deregisterCluster.cmd.example]
 one = '''
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
+# Deregister an OpenShift cluster from use with Red Hat Streams for Apache Kafka by selecting from a list of available clusters
 rhoas dedicated deregister-cluster
 
-# Deregister an OpenShift cluster with Red Hat Streams for Apache Kafka by specifying the cluster ID.
+# Deregister an OpenShift cluster from Red Hat Streams for Apache Kafka by specifying the cluster ID
 rhoas dedicated deregister-cluster --cluster-id 1234-5678-90ab-cdef
 '''
 
@@ -153,5 +153,11 @@ one = 'You do not have permissions to list Hybrid clusters'
 one = 'You do not have permissions to deregister this cluster'
 
 [dedicated.registerCluster.info.clusterRegisteredWithKasFleetManager]
-one = 'The cluster has been registered with Red Hat OpenShift Streams for Apache Kafka and is being prepared for use'
+one = '''
+The cluster has been registered with Red Hat OpenShift Streams for Apache Kafka and is being prepared for use
+
+You can check for when your cluster status is "ready" by running the following command:
+
+    rhoas dedicated list
+'''
 

--- a/pkg/core/localize/locales/en/cmd/dedicated.en.toml
+++ b/pkg/core/localize/locales/en/cmd/dedicated.en.toml
@@ -152,4 +152,6 @@ one = 'You do not have permissions to list Hybrid clusters'
 [dedicated.deregisterCluster.error.403]
 one = 'You do not have permissions to deregister this cluster'
 
+[dedicated.registerCluster.info.clusterRegisteredWithKasFleetManager]
+one = 'The cluster has been registered with Red Hat OpenShift Streams for Apache Kafka and is being prepared for use'
 

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -442,7 +442,7 @@ one = 'you do not have any enterprise quota availble'
 one = 'you have no remaining quoata to create a Kafka instance'
 
 [kafka.create.error.noCapacityInSelectedCluster]
-one = 'the cluster you selected does not have any remainging capacity'
+one = 'the cluster you selected does not have any remaining capacity'
 
 [kafka.create.provider.error.unsupportedMarketplace]
 one = 'selected marketplace is not supported for the cloud provider'

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -108,7 +108,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 					// this needs to be reflected upstream to work
-					// case spec.EnterpriseProductQuotaID:
+					// case spec.EnterpriseProductQuotaId:
 				case "RHOSAKCC":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					enterpriseQuotas = append(enterpriseQuotas, QuotaSpec{QuotaEnterpriseType, remainingQuota, quotaResource.BillingModel, nil})

--- a/pkg/shared/accountmgmtutil/ams.go
+++ b/pkg/shared/accountmgmtutil/ams.go
@@ -87,7 +87,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 		return nil, err
 	}
 
-	//this should be refactored and base of the logic by the billing model information that's returned by KFM for each supported instance type
+	// this should be refactored and base of the logic by the billing model information that's returned by KFM for each supported instance type
 	var standardQuotas, marketplaceQuotas, trialQuotas, evalQuotas, enterpriseQuotas []QuotaSpec
 	for _, quota := range quotaCostGet.GetItems() {
 		quotaResources := quota.GetRelatedResources()
@@ -108,7 +108,7 @@ func GetOrgQuotas(f *factory.Factory, spec *remote.AmsConfig) (*OrgQuotas, error
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					evalQuotas = append(evalQuotas, QuotaSpec{QuotaEvalType, remainingQuota, quotaResource.BillingModel, quota.CloudAccounts})
 					// this needs to be reflected upstream to work
-					//case spec.EnterpriseProductQuotaID:
+					// case spec.EnterpriseProductQuotaID:
 				case "RHOSAKCC":
 					remainingQuota := int(quota.GetAllowed() - quota.GetConsumed())
 					enterpriseQuotas = append(enterpriseQuotas, QuotaSpec{QuotaEnterpriseType, remainingQuota, quotaResource.BillingModel, nil})


### PR DESCRIPTION
- Updates the CLI to display cluster ID and Name for `register-cluster`, `deregister-cluster` 
- adds the `cluster-mgmt-api-url` and `access-token` flags to `kafka create`
- fixes typos and implements better wording
- addresses some comments brought up in the sprint review demo

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Register an OpenShift cluster
2. Create Kafka clusters interactively
3. Deregister Hybrid OpenShift clusters

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
