### PR TITLE
refactor: enterprise option is now first in prompt

### DIFF
--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -488,8 +488,8 @@ func setEnterpriseClusterList(opts *options) (*kafkamgmtclient.EnterpriseCluster
 
 func selectEnterpriseOrRHInfraPrompt(opts *options) error {
 	listOfOptions := []string{
-		opts.f.Localizer.MustLocalize("kafka.create.input.cluster.option.rhinfr"),
 		opts.f.Localizer.MustLocalize("kafka.create.input.cluster.option.enterprise"),
+		opts.f.Localizer.MustLocalize("kafka.create.input.cluster.option.rhinfr"),
 	}
 
 	promptForCluster := &survey.Select{
@@ -498,13 +498,14 @@ func selectEnterpriseOrRHInfraPrompt(opts *options) error {
 		Options: listOfOptions,
 	}
 
-	var idx int
-	err := survey.AskOne(promptForCluster, &idx)
+	var index int
+	err := survey.AskOne(promptForCluster, &index)
 	if err != nil {
 		return err
 	}
-	opts.useEnterpriseFlow = idx != 0
-	opts.useLegacyFlow = idx == 0
+
+	opts.useEnterpriseFlow = index == 0
+	opts.useLegacyFlow = index == 1
 
 	return nil
 }


### PR DESCRIPTION
When user is selecting to use the new RHOSAK flow or the legacy flow, the order in which they are displayed are inverted. Meaning the new "default" flow is the top option.

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Using an account that has access to both legacy and enterprise run `rhoas kafka create`
2. You will be promoted to select either flow
3. The new flow will now be the first option

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Prompt change
