### PR TITLE
feat: now mapping cluster status to custom status

### DIFF
--- a/pkg/cmd/kafka/openshift-cluster/list/list.go
+++ b/pkg/cmd/kafka/openshift-cluster/list/list.go
@@ -103,7 +103,7 @@ func kfmListToClusterRowList(opts *options) []clusterRow {
 		crl = append(crl, clusterRow{
 			Name:          ocmCluster.Name(),
 			ID:            kfmcluster.Id,
-			Status:        *kfmcluster.Status,
+			Status:        kafkautil.MapClusterStatus(kfmcluster.GetStatus()),
 			CloudProvider: ocmCluster.CloudProvider().ID(),
 			Region:        ocmCluster.Region().ID(),
 		})

--- a/pkg/shared/kafkautil/dedicated_utils.go
+++ b/pkg/shared/kafkautil/dedicated_utils.go
@@ -8,6 +8,43 @@ import (
 	"net/http"
 )
 
+const (
+	statusClusterAccepted         = "cluster_accepted"
+	statusClusterProvisioning     = "cluster_provisioning"
+	statusClusterProvisioned      = "cluster_provisioned"
+	statusWaitingForKasFleetshard = "waiting_for_kas_fleetshard_operator"
+	statusReady                   = "ready"
+	statusFailed                  = "failed"
+	statusDeprovisioning          = "deprovisioning"
+	statusCleanup                 = "cleanup"
+
+	customStatusAccepted      = "Cluster Accepted"
+	customStatusRegistering   = "Registering"
+	customStatusUnregistering = "Unregistering"
+	customStatusReady         = "Ready"
+	customStatusFailed        = "Failed"
+)
+
+func MapClusterStatus(clusterStatus string) string {
+	switch clusterStatus {
+	case statusClusterAccepted:
+		return customStatusAccepted
+	case statusClusterProvisioning:
+	case statusClusterProvisioned:
+	case statusWaitingForKasFleetshard:
+		return customStatusRegistering
+	case statusCleanup:
+	case statusDeprovisioning:
+		return customStatusUnregistering
+	case statusReady:
+		return customStatusReady
+	case statusFailed:
+		return customStatusFailed
+	}
+
+	return clusterStatus
+}
+
 func CreateClusterSearchStringFromKafkaList(kfmClusterList *kafkamgmtclient.EnterpriseClusterList) string {
 	searchString := ""
 	for idx, kfmcluster := range kfmClusterList.Items {


### PR DESCRIPTION
Adds custom status output for the status of the cluster

Before:
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/45426048/231155245-dcef762c-8c06-4158-9b62-7117df5173e8.png">

After:
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/45426048/231155291-a0711b7b-a0c7-4918-940f-b0186b3c4412.png">


### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do `rhoas kafka oc list` to see the new output

### Type of change
- [x] New feature (non-breaking change which adds functionality)

